### PR TITLE
Fixed issue where some dialogs (research complete, refugee chase) wou…

### DIFF
--- a/Source/Client/Comp/MultiplayerMapComp.cs
+++ b/Source/Client/Comp/MultiplayerMapComp.cs
@@ -206,16 +206,10 @@ namespace Multiplayer.Client
 
             if (comp.mapDialogs.Any())
             {
-                // This makes it so only one of the same type should open
-                // They're blocking windows
-                foreach(var a in comp.mapDialogs) {
-                    if (Find.WindowStack.IsOpen(a.GetType())) {
-                        return;
-                    }
-                }
-
-                Find.WindowStack.Add(comp.mapDialogs.First().Dialog);
-            }
+				//If NO mapdialogs (Dialog_NodeTrees) are open, add the first one to the window stack
+				if (!Find.WindowStack.IsOpen(typeof(Dialog_NodeTree)))
+					Find.WindowStack.Add(comp.mapDialogs.First().Dialog);
+			}
             else if (comp.caravanForming != null)
             {
                 if (!Find.WindowStack.IsOpen(typeof(MpFormingCaravanWindow)))


### PR DESCRIPTION
This fixes an issue I'd experienced where certain mapDialogs would open endlessly, softlocking the game.

By adding the log message "Adding dialog to window stack" just before the line

`Find.WindowStack.Add(comp.mapDialogs.First().Dialog);`

You can see the below log output when a "Researched Finished" dialog appears. The game is softlocked and the dialog opening sound effect *blip* goes *blipblipblipblipblipblipblipblipblip...* endlessly.

![dialog windowstack bug](https://user-images.githubusercontent.com/18107237/71648898-3d7d0280-2d5e-11ea-9006-1c75c2286ec1.png)

Fixed by instead checking if the WindowStack has any open "Dialog_NodeTree" types.

The mapDialog.Dialog property is a "Dialog_NodeTree", so we only need to check if the WindowStack has any open windows of that type. We don't need to check each mapDialog using GetType() - which I believe is the wrong type to compare, and the cause of the original bug (every GetType() would NOT find a matching window type and open the dialog again).