### PR TITLE
Refactors MpPatch patches to use HarmonyPatch

### DIFF
--- a/Source/Client/ArbiterPatches.cs
+++ b/Source/Client/ArbiterPatches.cs
@@ -12,9 +12,14 @@ using Verse;
 
 namespace Multiplayer.Client
 {
-    [MpPatch(typeof(GUI), "get_" + nameof(GUI.skin))]
+    [HarmonyPatch]
     static class GUISkinArbiter_Patch
     {
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(GUI), nameof(GUI.skin));
+        }
+
         static bool Prefix(ref GUISkin __result)
         {
             if (!MultiplayerMod.arbiterInstance) return true;
@@ -23,12 +28,17 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(SubcameraDriver), nameof(SubcameraDriver.UpdatePositions))]
-    [MpPatch(typeof(PortraitsCache), nameof(PortraitsCache.Get))]
+    [HarmonyPatch]
     static class RenderTextureCreatePatch
     {
         static MethodInfo IsCreated = AccessTools.Method(typeof(RenderTexture), "IsCreated");
         static FieldInfo ArbiterField = AccessTools.Field(typeof(MultiplayerMod), nameof(MultiplayerMod.arbiterInstance));
+
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(SubcameraDriver), nameof(SubcameraDriver.UpdatePositions));
+            yield return AccessTools.Method(typeof(PortraitsCache), nameof(PortraitsCache.Get));
+        }
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
         {
@@ -45,17 +55,22 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(WaterInfo), nameof(WaterInfo.SetTextures))]
-    [MpPatch(typeof(SubcameraDriver), nameof(SubcameraDriver.UpdatePositions))]
-    [MpPatch(typeof(Prefs), nameof(Prefs.Save))]
-    [MpPatch(typeof(FloatMenuOption), nameof(FloatMenuOption.SetSizeMode))]
-    [MpPatch(typeof(Section), nameof(Section.RegenerateAllLayers))]
-    [MpPatch(typeof(Section), nameof(Section.RegenerateLayers))]
-    [MpPatch(typeof(SectionLayer), nameof(SectionLayer.DrawLayer))]
-    [MpPatch(typeof(Map), nameof(Map.MapUpdate))]
-    [MpPatch(typeof(GUIStyle), nameof(GUIStyle.CalcSize))]
+    [HarmonyPatch]
     static class CancelForArbiter
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(WaterInfo), nameof(WaterInfo.SetTextures));
+            yield return AccessTools.Method(typeof(SubcameraDriver), nameof(SubcameraDriver.UpdatePositions));
+            yield return AccessTools.Method(typeof(Prefs), nameof(Prefs.Save));
+            yield return AccessTools.Method(typeof(FloatMenuOption), nameof(FloatMenuOption.SetSizeMode));
+            yield return AccessTools.Method(typeof(Section), nameof(Section.RegenerateAllLayers));
+            yield return AccessTools.Method(typeof(Section), nameof(Section.RegenerateLayers));
+            yield return AccessTools.Method(typeof(SectionLayer), nameof(SectionLayer.DrawLayer));
+            yield return AccessTools.Method(typeof(Map), nameof(Map.MapUpdate));
+            yield return AccessTools.Method(typeof(GUIStyle), nameof(GUIStyle.CalcSize));
+        }
+
         static bool Prefix() => !MultiplayerMod.arbiterInstance;
     }
 

--- a/Source/Client/ArbiterPatches.cs
+++ b/Source/Client/ArbiterPatches.cs
@@ -17,7 +17,7 @@ namespace Multiplayer.Client
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.Method(typeof(GUI), nameof(GUI.skin));
+            return AccessTools.Method(typeof(GUI), "get_" + nameof(GUI.skin));
         }
 
         static bool Prefix(ref GUISkin __result)

--- a/Source/Client/Comp/MapAsyncTime.cs
+++ b/Source/Client/Comp/MapAsyncTime.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Reflection;
 using UnityEngine;
 using Verse;
 using Verse.AI;
@@ -18,10 +19,15 @@ using zip::Ionic.Zip;
 
 namespace Multiplayer.Client
 {
-    [MpPatch(typeof(Map), nameof(Map.MapPreTick))]
-    [MpPatch(typeof(Map), nameof(Map.MapPostTick))]
+    [HarmonyPatch]
     static class CancelMapManagersTick
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Map), nameof(Map.MapPreTick));
+            yield return AccessTools.Method(typeof(Map), nameof(Map.MapPostTick));
+        }
+
         static bool Prefix() => Multiplayer.Client == null || MapAsyncTimeComp.tickingMap != null;
     }
 
@@ -40,12 +46,17 @@ namespace Multiplayer.Client
         static void Postfix() => updating = false;
     }
 
-    [MpPatch(typeof(PowerNetManager), nameof(PowerNetManager.UpdatePowerNetsAndConnections_First))]
-    [MpPatch(typeof(GlowGrid), nameof(GlowGrid.GlowGridUpdate_First))]
-    [MpPatch(typeof(RegionGrid), nameof(RegionGrid.UpdateClean))]
-    [MpPatch(typeof(RegionAndRoomUpdater), nameof(RegionAndRoomUpdater.TryRebuildDirtyRegionsAndRooms))]
+    [HarmonyPatch]
     static class CancelMapManagersUpdate
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(PowerNetManager), nameof(PowerNetManager.UpdatePowerNetsAndConnections_First));
+            yield return AccessTools.Method(typeof(GlowGrid), nameof(GlowGrid.GlowGridUpdate_First));
+            yield return AccessTools.Method(typeof(RegionGrid), nameof(RegionGrid.UpdateClean));
+            yield return AccessTools.Method(typeof(RegionAndRoomUpdater), nameof(RegionAndRoomUpdater.TryRebuildDirtyRegionsAndRooms));
+        }
+        
         static bool Prefix() => Multiplayer.Client == null || !MapUpdateMarker.updating;
     }
 
@@ -361,10 +372,15 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(Storyteller), nameof(Storyteller.StorytellerTick))]
-    [MpPatch(typeof(StoryWatcher), nameof(StoryWatcher.StoryWatcherTick))]
+    [HarmonyPatch]
     public class StorytellerTickPatch
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Storyteller), nameof(Storyteller.StorytellerTick));
+            yield return AccessTools.Method(typeof(StoryWatcher), nameof(StoryWatcher.StoryWatcherTick));
+        }
+
         static bool Prefix() => Multiplayer.Client == null || Multiplayer.Ticking;
     }
 

--- a/Source/Client/MainButtons.cs
+++ b/Source/Client/MainButtons.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 using UnityEngine;
 using Verse;
 
@@ -305,11 +306,16 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(MouseoverReadout), nameof(MouseoverReadout.MouseoverReadoutOnGUI))]
-    [MpPatch(typeof(GlobalControls), nameof(GlobalControls.GlobalControlsOnGUI))]
-    [MpPatch(typeof(WorldGlobalControls), nameof(WorldGlobalControls.WorldGlobalControlsOnGUI))]
+    [HarmonyPatch]
     static class MakeSpaceForReplayTimeline
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(MouseoverReadout), nameof(MouseoverReadout.MouseoverReadoutOnGUI));
+            yield return AccessTools.Method(typeof(GlobalControls), nameof(GlobalControls.GlobalControlsOnGUI));
+            yield return AccessTools.Method(typeof(WorldGlobalControls), nameof(WorldGlobalControls.WorldGlobalControlsOnGUI));
+        }
+
         static void Prefix()
         {
             if (Multiplayer.IsReplay)

--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -121,15 +121,6 @@ namespace Multiplayer.Client
 
             try
             {
-                harmony.DoAllMpPatches();
-            }
-            catch (Exception e)
-            {
-                Log.Error($"Exception during MpPatching: {e}");
-            }
-
-            try
-            {
                 SyncHandlers.Init();
 
                 var asm = Assembly.GetExecutingAssembly();

--- a/Source/Client/Patches.cs
+++ b/Source/Client/Patches.cs
@@ -32,10 +32,15 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(MainMenuDrawer), nameof(MainMenuDrawer.DoMainMenuControls))]
+    [HarmonyPatch]
     public static class MainMenuMarker
     {
         public static bool drawing;
+
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(MainMenuDrawer), nameof(MainMenuDrawer.DoMainMenuControls));
+        }
 
         static void Prefix() => drawing = true;
         static void Postfix() => drawing = false;
@@ -71,16 +76,26 @@ namespace Multiplayer.Client
         static void Postfix() => ticking = false;
     }
 
-    [MpPatch(typeof(MainMenuDrawer), nameof(MainMenuDrawer.DoMainMenuControls))]
+    [HarmonyPatch]
     public static class MainMenu_AddHeight
     {
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(MainMenuDrawer), nameof(MainMenuDrawer.DoMainMenuControls));
+        }
+
         static void Prefix(ref Rect rect) => rect.height += 45f;
     }
 
-    [MpPatch(typeof(OptionListingUtility), nameof(OptionListingUtility.DrawOptionListing))]
+    [HarmonyPatch]
     [HotSwappable]
     public static class MainMenuPatch
     {
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(OptionListingUtility), nameof(OptionListingUtility.DrawOptionListing));
+        }
+
         static void Prefix(Rect rect, List<ListableOption> optList)
         {
             if (!MainMenuMarker.drawing) return;
@@ -190,11 +205,15 @@ namespace Multiplayer.Client
             }, "Play", "MpConverting", true, null);
         }
     }
-
-    [MpPatch(typeof(GenScene), nameof(GenScene.GoToMainMenu))]
-    [MpPatch(typeof(Root), nameof(Root.Shutdown))]
+    [HarmonyPatch]
     static class Shutdown_Quit_Patch
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(GenScene), nameof(GenScene.GoToMainMenu));
+            yield return AccessTools.Method(typeof(Root), nameof(Root.Shutdown));
+        }
+
         static void Prefix()
         {
             OnMainThread.StopMultiplayer();
@@ -760,11 +779,16 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(OutfitDatabase), nameof(OutfitDatabase.GenerateStartingOutfits))]
-    [MpPatch(typeof(DrugPolicyDatabase), nameof(DrugPolicyDatabase.GenerateStartingDrugPolicies))]
-    [MpPatch(typeof(FoodRestrictionDatabase), nameof(FoodRestrictionDatabase.GenerateStartingFoodRestrictions))]
+    [HarmonyPatch]
     static class CancelReinitializationDuringLoading
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(OutfitDatabase), nameof(OutfitDatabase.GenerateStartingOutfits));
+            yield return AccessTools.Method(typeof(DrugPolicyDatabase), nameof(DrugPolicyDatabase.GenerateStartingDrugPolicies));
+            yield return AccessTools.Method(typeof(FoodRestrictionDatabase), nameof(FoodRestrictionDatabase.GenerateStartingFoodRestrictions));
+        }
+
         static bool Prefix() => Scribe.mode != LoadSaveMode.LoadingVars;
     }
 
@@ -870,12 +894,16 @@ namespace Multiplayer.Client
         static void Postfix() => loading = false;
     }
 
-    [MpPatch(typeof(SoundStarter), nameof(SoundStarter.PlayOneShot))]
-    [MpPatch(typeof(Command_SetPlantToGrow), nameof(Command_SetPlantToGrow.WarnAsAppropriate))]
-    [MpPatch(typeof(TutorUtility), nameof(TutorUtility.DoModalDialogIfNotKnown))]
-    [MpPatch(typeof(CameraJumper), nameof(CameraJumper.TryHideWorld))]
+    [HarmonyPatch]
     static class CancelFeedbackNotTargetedAtMe
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(SoundStarter), nameof(SoundStarter.PlayOneShot));
+            yield return AccessTools.Method(typeof(Command_SetPlantToGrow), nameof(Command_SetPlantToGrow.WarnAsAppropriate));
+            yield return AccessTools.Method(typeof(TutorUtility), nameof(TutorUtility.DoModalDialogIfNotKnown));
+            yield return AccessTools.Method(typeof(CameraJumper), nameof(CameraJumper.TryHideWorld));
+        }
         public static bool Cancel =>
             Multiplayer.Client != null &&
             Multiplayer.ExecutingCmds &&
@@ -896,10 +924,15 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(MoteMaker), nameof(MoteMaker.MakeStaticMote), new[] {typeof(IntVec3), typeof(Map), typeof(ThingDef), typeof(float)})]
-    [MpPatch(typeof(MoteMaker), nameof(MoteMaker.MakeStaticMote), new[] {typeof(Vector3), typeof(Map), typeof(ThingDef), typeof(float)})]
+    [HarmonyPatch]
     static class CancelMotesNotTargetedAtMe
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(MoteMaker), nameof(MoteMaker.MakeStaticMote), new[] {typeof(IntVec3), typeof(Map), typeof(ThingDef), typeof(float)});
+            yield return AccessTools.Method(typeof(MoteMaker), nameof(MoteMaker.MakeStaticMote), new[] {typeof(Vector3), typeof(Map), typeof(ThingDef), typeof(float)});
+        }
+
         static bool Prefix(ThingDef moteDef)
         {
             if (moteDef == ThingDefOf.Mote_FeedbackGoto)
@@ -919,11 +952,16 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(Messages), nameof(Messages.Message), new[] {typeof(string), typeof(MessageTypeDef), typeof(bool)})]
-    [MpPatch(typeof(Messages), nameof(Messages.Message), new[] {typeof(string), typeof(LookTargets), typeof(MessageTypeDef), typeof(bool)})]
+    [HarmonyPatch]
     static class MessagesMarker
     {
         public static bool? historical;
+
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Messages), nameof(Messages.Message), new[] {typeof(string), typeof(MessageTypeDef), typeof(bool)});
+            yield return AccessTools.Method(typeof(Messages), nameof(Messages.Message), new[] {typeof(string), typeof(LookTargets), typeof(MessageTypeDef), typeof(bool)});
+        }
 
         static void Prefix(bool historical) => MessagesMarker.historical = historical;
         static void Postfix() => historical = null;
@@ -1126,11 +1164,15 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(IncidentWorker_CaravanMeeting), nameof(IncidentWorker_CaravanMeeting.CanFireNowSub))]
-    [MpPatch(typeof(IncidentWorker_CaravanDemand), nameof(IncidentWorker_CaravanDemand.CanFireNowSub))]
-    [MpPatch(typeof(IncidentWorker_RansomDemand), nameof(IncidentWorker_RansomDemand.CanFireNowSub))]
+    [HarmonyPatch]
     static class CancelIncidents
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(IncidentWorker_CaravanMeeting), nameof(IncidentWorker_CaravanMeeting.CanFireNowSub));
+            yield return AccessTools.Method(typeof(IncidentWorker_CaravanDemand), nameof(IncidentWorker_CaravanDemand.CanFireNowSub));
+            yield return AccessTools.Method(typeof(IncidentWorker_RansomDemand), nameof(IncidentWorker_RansomDemand.CanFireNowSub));
+        }
         static void Postfix(ref bool __result)
         {
             if (Multiplayer.Client != null)
@@ -1168,11 +1210,15 @@ namespace Multiplayer.Client
         static bool Prefix() => Multiplayer.Client == null;
     }
 
-    [MpPatch(typeof(CameraJumper), nameof(CameraJumper.TrySelect))]
-    [MpPatch(typeof(CameraJumper), nameof(CameraJumper.TryJumpAndSelect))]
-    [MpPatch(typeof(CameraJumper), nameof(CameraJumper.TryJump), new[] {typeof(GlobalTargetInfo)})]
+    [HarmonyPatch]
     static class NoCameraJumpingDuringSkipping
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(CameraJumper), nameof(CameraJumper.TrySelect));
+            yield return AccessTools.Method(typeof(CameraJumper), nameof(CameraJumper.TryJumpAndSelect));
+            yield return AccessTools.Method(typeof(CameraJumper), nameof(CameraJumper.TryJump), new[] {typeof(GlobalTargetInfo)});
+        }
         static bool Prefix() => !TickPatch.Skipping;
     }
 
@@ -1550,11 +1596,16 @@ namespace Multiplayer.Client
         static bool Prefix(Pawn_PlayerSettings __instance, Area value) => __instance.AreaRestriction != value;
     }
 
-    [MpPatch(typeof(GlobalTargetInfo), nameof(GlobalTargetInfo.GetHashCode))]
-    [MpPatch(typeof(TargetInfo), nameof(TargetInfo.GetHashCode))]
+    [HarmonyPatch]
     static class PatchTargetInfoHashCodes
     {
         static MethodInfo Combine = AccessTools.Method(typeof(Gen), nameof(Gen.HashCombine)).MakeGenericMethod(typeof(Map));
+
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(GlobalTargetInfo), nameof(GlobalTargetInfo.GetHashCode));
+            yield return AccessTools.Method(typeof(TargetInfo), nameof(TargetInfo.GetHashCode));
+        }
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
         {

--- a/Source/Client/Persistent/Trading.cs
+++ b/Source/Client/Persistent/Trading.cs
@@ -456,12 +456,16 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(HaulDestinationManager), nameof(HaulDestinationManager.AddHaulDestination))]
-    [MpPatch(typeof(HaulDestinationManager), nameof(HaulDestinationManager.RemoveHaulDestination))]
-    [MpPatch(typeof(HaulDestinationManager), nameof(HaulDestinationManager.SetCellFor))]
-    [MpPatch(typeof(HaulDestinationManager), nameof(HaulDestinationManager.ClearCellFor))]
+    [HarmonyPatch]
     static class HaulDestinationChanged
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(HaulDestinationManager), nameof(HaulDestinationManager.AddHaulDestination));
+            yield return AccessTools.Method(typeof(HaulDestinationManager), nameof(HaulDestinationManager.RemoveHaulDestination));
+            yield return AccessTools.Method(typeof(HaulDestinationManager), nameof(HaulDestinationManager.SetCellFor));
+            yield return AccessTools.Method(typeof(HaulDestinationManager), nameof(HaulDestinationManager.ClearCellFor));
+        }
         static void Postfix(HaulDestinationManager __instance)
         {
             if (Multiplayer.Client != null)
@@ -479,10 +483,14 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(ListerThings), nameof(ListerThings.Add))]
-    [MpPatch(typeof(ListerThings), nameof(ListerThings.Remove))]
+    [HarmonyPatch]
     static class ListerThingsChangedItem
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(ListerThings), nameof(ListerThings.Add));
+            yield return AccessTools.Method(typeof(ListerThings), nameof(ListerThings.Remove));
+        }
         static void Postfix(ListerThings __instance, Thing t)
         {
             if (Multiplayer.Client == null) return;
@@ -491,10 +499,14 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(Pawn_HealthTracker), nameof(Pawn_HealthTracker.MakeDowned))]
-    [MpPatch(typeof(Pawn_HealthTracker), nameof(Pawn_HealthTracker.MakeUndowned))]
+    [HarmonyPatch]
     static class PawnDownedStateChanged
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Pawn_HealthTracker), nameof(Pawn_HealthTracker.MakeDowned));
+            yield return AccessTools.Method(typeof(Pawn_HealthTracker), nameof(Pawn_HealthTracker.MakeUndowned));
+        }
         static void Postfix(Pawn_HealthTracker __instance)
         {
             if (Multiplayer.Client != null)
@@ -535,11 +547,15 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(ThingOwner), nameof(ThingOwner.NotifyAdded))]
-    [MpPatch(typeof(ThingOwner), nameof(ThingOwner.NotifyAddedAndMergedWith))]
-    [MpPatch(typeof(ThingOwner), nameof(ThingOwner.NotifyRemoved))]
+    [HarmonyPatch]
     static class ThingOwner_ChangedPatch
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(ThingOwner), nameof(ThingOwner.NotifyAdded));
+            yield return AccessTools.Method(typeof(ThingOwner), nameof(ThingOwner.NotifyAddedAndMergedWith));
+            yield return AccessTools.Method(typeof(ThingOwner), nameof(ThingOwner.NotifyRemoved));
+        }
         static void Postfix(ThingOwner __instance)
         {
             if (Multiplayer.Client == null) return;
@@ -569,10 +585,14 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(Lord), nameof(Lord.AddPawn))]
-    [MpPatch(typeof(Lord), nameof(Lord.Notify_PawnLost))]
+    [HarmonyPatch]
     static class Lord_TradeChanged
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Lord), nameof(Lord.AddPawn));
+            yield return AccessTools.Method(typeof(Lord), nameof(Lord.Notify_PawnLost));
+        }
         static void Postfix(Lord __instance)
         {
             if (Multiplayer.Client == null) return;
@@ -591,10 +611,14 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(MentalStateHandler), nameof(MentalStateHandler.TryStartMentalState))]
-    [MpPatch(typeof(MentalStateHandler), nameof(MentalStateHandler.ClearMentalStateDirect))]
+    [HarmonyPatch]
     static class MentalStateChanged
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(MentalStateHandler), nameof(MentalStateHandler.TryStartMentalState));
+            yield return AccessTools.Method(typeof(MentalStateHandler), nameof(MentalStateHandler.ClearMentalStateDirect));
+        }
         static void Postfix(MentalStateHandler __instance)
         {
             if (Multiplayer.Client == null) return;

--- a/Source/Client/Persistent/TradingUI.cs
+++ b/Source/Client/Persistent/TradingUI.cs
@@ -247,10 +247,19 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(JobDriver_TradeWithPawn), "<>c__DisplayClass3_0", "<MakeNewToils>b__1")]
+    [HarmonyPatch]
     static class ShowTradingWindow
     {
         public static int tradeJobStartedByMe = -1;
+
+        static MethodBase TargetMethod()
+        {
+            List<Type> nestedPrivateTypes = new List<Type>(typeof(JobDriver_TradeWithPawn).GetNestedTypes(BindingFlags.NonPublic));
+
+            Type cType = nestedPrivateTypes.Find(t => t.Name.Equals("<>c__DisplayClass3_0"));
+
+            return AccessTools.Method(cType, "<MakeNewToils>b__1");
+        }
 
         static void Prefix(Toil ___trade)
         {
@@ -400,10 +409,14 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(Dialog_Trade), "<DoWindowContents>b__60_0")]
-    [MpPatch(typeof(Dialog_Trade), "<DoWindowContents>b__60_1")]
+    [HarmonyPatch]
     static class FixTradeSorters
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Dialog_Trade), "<DoWindowContents>b__60_0");
+            yield return AccessTools.Method(typeof(Dialog_Trade), "<DoWindowContents>b__60_1");
+        }
         static void Prefix(ref bool __state)
         {
             TradingWindow trading = Find.WindowStack.WindowOfType<TradingWindow>();

--- a/Source/Client/Seeds.cs
+++ b/Source/Client/Seeds.cs
@@ -194,12 +194,17 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(GrammarResolver), nameof(GrammarResolver.Resolve))]
-    [MpPatch(typeof(PawnBioAndNameGenerator), nameof(PawnBioAndNameGenerator.GeneratePawnName))]
-    [MpPatch(typeof(NameGenerator), nameof(NameGenerator.GenerateName), new[] { typeof(RulePackDef), typeof(Predicate<string>), typeof(bool), typeof(string), typeof(string) })]
+    [HarmonyPatch]
     static class SeedGrammar
     {
-        [HarmonyPriority(MpPriority.MpFirst)]
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(GrammarResolver), nameof(GrammarResolver.Resolve));
+            yield return AccessTools.Method(typeof(PawnBioAndNameGenerator), nameof(PawnBioAndNameGenerator.GeneratePawnName));
+            yield return AccessTools.Method(typeof(NameGenerator), nameof(NameGenerator.GenerateName), new[] { typeof(RulePackDef), typeof(Predicate<string>), typeof(bool), typeof(string), typeof(string) });
+        }
+
+        [HarmonyPriority(Priority.First + 1)]
         static void Prefix(ref bool __state)
         {
             Rand.Element(0, 0); // advance the rng
@@ -207,7 +212,7 @@ namespace Multiplayer.Client
             __state = true;
         }
 
-        [HarmonyPriority(MpPriority.MpLast)]
+        [HarmonyPriority(Priority.Last - 1)]
         static void Postfix(bool __state)
         {
             if (__state)
@@ -215,18 +220,23 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(PawnGraphicSet), nameof(PawnGraphicSet.ResolveAllGraphics))]
-    [MpPatch(typeof(PawnGraphicSet), nameof(PawnGraphicSet.ResolveApparelGraphics))]
+    [HarmonyPatch]
     static class SeedPawnGraphics
     {
-        [HarmonyPriority(MpPriority.MpFirst)]
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(PawnGraphicSet), nameof(PawnGraphicSet.ResolveAllGraphics));
+            yield return AccessTools.Method(typeof(PawnGraphicSet), nameof(PawnGraphicSet.ResolveApparelGraphics));
+        }
+
+        [HarmonyPriority(Priority.First + 1)]
         static void Prefix(PawnGraphicSet __instance, ref bool __state)
         {
             Rand.PushState(__instance.pawn.thingIDNumber);
             __state = true;
         }
 
-        [HarmonyPriority(MpPriority.MpLast)]
+        [HarmonyPriority(Priority.Last - 1)]
         static void Postfix(bool __state)
         {
             if (__state)

--- a/Source/Client/SetMapTime.cs
+++ b/Source/Client/SetMapTime.cs
@@ -5,22 +5,28 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 using Verse;
 using Verse.Sound;
 
 namespace Multiplayer.Client
 {
     // Set the map time for GUI methods depending on it
-    [MpPatch(typeof(MapInterface), nameof(MapInterface.MapInterfaceOnGUI_BeforeMainTabs))]
-    [MpPatch(typeof(MapInterface), nameof(MapInterface.MapInterfaceOnGUI_AfterMainTabs))]
-    [MpPatch(typeof(MapInterface), nameof(MapInterface.HandleMapClicks))]
-    [MpPatch(typeof(MapInterface), nameof(MapInterface.HandleLowPriorityInput))]
-    [MpPatch(typeof(MapInterface), nameof(MapInterface.MapInterfaceUpdate))]
-    [MpPatch(typeof(SoundRoot), nameof(SoundRoot.Update))]
-    [MpPatch(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.ChoicesAtFor))]
+    [HarmonyPatch]
     static class SetMapTimeForUI
     {
-        [HarmonyPriority(MpPriority.MpFirst)]
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(MapInterface), nameof(MapInterface.MapInterfaceOnGUI_BeforeMainTabs));
+            yield return AccessTools.Method(typeof(MapInterface), nameof(MapInterface.MapInterfaceOnGUI_AfterMainTabs));
+            yield return AccessTools.Method(typeof(MapInterface), nameof(MapInterface.HandleMapClicks));
+            yield return AccessTools.Method(typeof(MapInterface), nameof(MapInterface.HandleLowPriorityInput));
+            yield return AccessTools.Method(typeof(MapInterface), nameof(MapInterface.MapInterfaceUpdate));
+            yield return AccessTools.Method(typeof(SoundRoot), nameof(SoundRoot.Update));
+            yield return AccessTools.Method(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.ChoicesAtFor));
+        }
+
+        [HarmonyPriority(Priority.First + 1)]
         static void Prefix(ref TimeSnapshot? __state)
         {
             if (Multiplayer.Client == null || WorldRendererUtility.WorldRenderedNow || Find.CurrentMap == null) return;
@@ -31,24 +37,34 @@ namespace Multiplayer.Client
         static void Postfix(TimeSnapshot? __state) => __state?.Set();
     }
 
-    [MpPatch(typeof(Map), nameof(Map.MapUpdate))]
-    [MpPatch(typeof(Map), nameof(Map.FinalizeLoading))]
+    [HarmonyPatch]
     static class MapUpdateTimePatch
     {
-        [HarmonyPriority(MpPriority.MpFirst)]
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Map), nameof(Map.MapUpdate));
+            yield return AccessTools.Method(typeof(Map), nameof(Map.FinalizeLoading));
+        }
+
+        [HarmonyPriority(Priority.First + 1)]
         static void Prefix(Map __instance, ref TimeSnapshot? __state)
         {
             if (Multiplayer.Client == null) return;
             __state = TimeSnapshot.GetAndSetFromMap(__instance);
         }
 
-        [HarmonyPriority(MpPriority.MpLast)]
+        [HarmonyPriority(Priority.Last - 1)]
         static void Postfix(TimeSnapshot? __state) => __state?.Set();
     }
 
-    [MpPatch(typeof(PortraitsCache), nameof(PortraitsCache.IsAnimated))]
+    [HarmonyPatch]
     static class PawnPortraitMapTime
     {
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(PortraitsCache), nameof(PortraitsCache.IsAnimated));
+        }
+
         static void Prefix(Pawn pawn, ref TimeSnapshot? __state)
         {
             if (Multiplayer.Client == null || Current.ProgramState != ProgramState.Playing) return;
@@ -94,10 +110,15 @@ namespace Multiplayer.Client
         static void Postfix(TimeSnapshot? __state) => __state?.Set();
     }
 
-    [MpPatch(typeof(Sustainer), nameof(Sustainer.SustainerUpdate))]
-    [MpPatch(typeof(Sustainer), "<.ctor>b__15_0")]
+    [HarmonyPatch]
     static class SustainerUpdateMapTime
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Sustainer), nameof(Sustainer.SustainerUpdate));
+            yield return AccessTools.Method(typeof(Sustainer), "<.ctor>b__15_0");
+        }
+
         static void Prefix(Sustainer __instance, ref TimeSnapshot? __state)
         {
             if (Multiplayer.Client == null) return;

--- a/Source/Client/SettingsPatches.cs
+++ b/Source/Client/SettingsPatches.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 using UnityEngine;
 using Verse;
 
@@ -28,10 +29,15 @@ namespace Multiplayer.Client
         static bool Setter_Prefix() => Multiplayer.Client == null;
     }
 
-    [MpPatch(typeof(Prefs), "get_" + nameof(Prefs.VolumeGame))]
-    [MpPatch(typeof(Prefs), nameof(Prefs.Save))]
+    [HarmonyPatch]
     static class CancelDuringSkipping
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Prefs), "get_" + nameof(Prefs.VolumeGame));
+            yield return AccessTools.Method(typeof(Prefs), nameof(Prefs.Save));
+        }
+
         static bool Prefix() => !TickPatch.Skipping;
     }
 
@@ -55,21 +61,29 @@ namespace Multiplayer.Client
         }
     }
 
-    [MpPatch(typeof(Prefs), "get_" + nameof(Prefs.PauseOnLoad))]
-    [MpPatch(typeof(Prefs), "get_" + nameof(Prefs.PauseOnError))]
-    [MpPatch(typeof(Prefs), "get_" + nameof(Prefs.AutomaticPauseMode))]
+    [HarmonyPatch]
     static class PrefGettersInMultiplayer
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Prefs), "get_" + nameof(Prefs.PauseOnLoad));
+            yield return AccessTools.Method(typeof(Prefs), "get_" + nameof(Prefs.PauseOnError));
+            yield return AccessTools.Method(typeof(Prefs), "get_" + nameof(Prefs.AutomaticPauseMode));
+        }
         static bool Prefix() => Multiplayer.Client == null;
     }
 
-    [MpPatch(typeof(Prefs), "set_" + nameof(Prefs.PauseOnLoad))]
-    [MpPatch(typeof(Prefs), "set_" + nameof(Prefs.PauseOnError))]
-    [MpPatch(typeof(Prefs), "set_" + nameof(Prefs.AutomaticPauseMode))]
-    [MpPatch(typeof(Prefs), "set_" + nameof(Prefs.MaxNumberOfPlayerSettlements))]
-    [MpPatch(typeof(Prefs), "set_" + nameof(Prefs.RunInBackground))]
+    [HarmonyPatch]
     static class PrefSettersInMultiplayer
     {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Prefs), "set_" + nameof(Prefs.PauseOnLoad));
+            yield return AccessTools.Method(typeof(Prefs), "set_" + nameof(Prefs.PauseOnError));
+            yield return AccessTools.Method(typeof(Prefs), "set_" + nameof(Prefs.AutomaticPauseMode));
+            yield return AccessTools.Method(typeof(Prefs), "set_" + nameof(Prefs.MaxNumberOfPlayerSettlements));
+            yield return AccessTools.Method(typeof(Prefs), "set_" + nameof(Prefs.RunInBackground));
+        }
         static bool Prefix() => Multiplayer.Client == null;
     }
 


### PR DESCRIPTION
Per discussion in Discord, this eliminates the usage of `MpPatch` per @notfood findings that the previous approach in this project for patching multiple targets is no longer supported. There may be another patch required to remove all errors in debug log:

![image](https://user-images.githubusercontent.com/1621747/75622465-6e5a9780-5b55-11ea-8e69-fc4c6fb7f139.png)
