### PR TITLE
Fixed White Window Bug.

### DIFF
--- a/Source/Client/ClientNetworking.cs
+++ b/Source/Client/ClientNetworking.cs
@@ -222,8 +222,19 @@ namespace Multiplayer.Client
 
             Multiplayer.LocalServer.SetupArbiterConnection();
 
-            string args = $"-batchmode -nographics -arbiter -logfile arbiter_log.txt -connect=127.0.0.1:{Multiplayer.LocalServer.ArbiterPort}";
+            string args = $"";
 
+            //I am not sure why i have to do it this way but any other way of appending or or other modification leads to it not working.
+            if (Application.platform  == RuntimePlatform.WindowsPlayer)
+            {
+                //Verse.Log.Message("Applying Fix.");
+                args = $"-batchmode -nographics -force-gfx-direct -arbiter -logfile arbiter_log.txt -connect=127.0.0.1:{Multiplayer.LocalServer.ArbiterPort}";
+            }
+            else
+            {
+                //Verse.Log.Message("Not Applying Fix.");
+                args = $"-batchmode -nographics -arbiter -logfile arbiter_log.txt -connect=127.0.0.1:{Multiplayer.LocalServer.ArbiterPort}";
+            }
             if (GenCommandLine.TryGetCommandLineArg("savedatafolder", out string saveDataFolder))
                 args += $" -savedatafolder=\"{saveDataFolder}\"";
 


### PR DESCRIPTION
This fix works on:
```
Direct3D:
    Version:  Direct3D 9.0c [nvldumdx.dll 26.21.14.4219]
    Renderer: NVIDIA GeForce GTX 1080
    Vendor:   NVIDIA
    VRAM:     8079 MB (via DXGI)
    Caps:     Shader=30 DepthRT=1 NativeDepth=1 NativeShadow=1 DF16=0 INTZ=1 NULL=1 RESZ=0 SlowINTZ=0 ATOC=1 BC4=1 BC5=1
```

Edit:
As also commented in the code section, this structure isn't in the least bit elegant but any other way of adding the argument weirdly enough led to it not working properly.

Edit2:
The argument I added is for some reason not in the unity manual (at least i couldn't find it.). I found it on this thread: https://forum.unity.com/threads/editor-opens-on-blank-screen.539360/