### PR TITLE
Fixes the issue with Drafted Pawns being unable to be ordered.

### DIFF
--- a/Source/Client/Sync/Sync.cs
+++ b/Source/Client/Sync/Sync.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Multiplayer.API;
 using Multiplayer.Common;
 using RimWorld;
@@ -832,6 +832,11 @@ namespace Multiplayer.Client
 
             foreach (FieldInfo field in type.GetDeclaredInstanceFields()) {
                 string curPath = path + "/" + field.Name;
+
+                //In the case of GoTo, the Action is being its own field this fixes
+                //todo set this to check for the Action being self-referential
+                if (field.FieldType == typeof(Action))
+                    continue;
 
                 if (getter(curPath))
                     return true;


### PR DESCRIPTION
Prevents recursively defined actions

This may need to be changed to be smarter in the future such that it only checks for Actions that reference themselves. However for now I do not believe there are any such nested delegates that are themselves fields.

Reasoning: Having followed the call stack carefully and checking IL Spy, DisplayClass<>0__9 now contains the action <>0__9 as a field, this action points to the function that the closure was created for. This results in the Action being considered a relevant field which causes the Sync Serialisation issue. By preventing Actions from being allowed as fields. This fixes the issue of being unable to command Drafted pawns. I would appreciate if someone else could test this as well