### PR TITLE
Fix crash on 2nd load of Multiplayer game

### DIFF
--- a/Source/Client/MultiplayerSession.cs
+++ b/Source/Client/MultiplayerSession.cs
@@ -289,7 +289,7 @@ namespace Multiplayer.Client
             TradeSession.giftMode = false;
 
             DebugTools.curTool = null;
-            PortraitsCache.Clear();
+            // PortraitsCache.Clear(); // seems to cause crashes the second time we load a save as of V1.1
             RealTime.moteList.Clear();
 
             Room.nextRoomID = 1;


### PR DESCRIPTION
As the Discord & #12 have been saying, the 2nd load of a multiplayer game causes a crash.

1. load a game (singleplayer or multiplayer)
2. quit to menu
3. load a multiplayer game
4. 💥 

Looking in the `Local\Temp\Ludeon Studios\RimWorld by Ludeon Studios\Crashes\*\Player.log`, I found a stacktrace ending in
```
0x00007FFCBA72E835 (UnityPlayer) UnityMain
0x00007FFCBA9C5D66 (UnityPlayer) PAL_Thread_YieldExecution
0x00000279846E8F0F (Mono JIT Code) (wrapper managed-to-native) UnityEngine.RenderTexture:DiscardContents (UnityEngine.RenderTexture,bool,bool)
0x00000279846E8E6B (Mono JIT Code) UnityEngine.RenderTexture:DiscardContents ()
0x00000279846E8E03 (Mono JIT Code) RimWorld.PortraitsCache:DestroyRenderTexture (UnityEngine.RenderTexture)
0x00000279F4B6438B (Mono JIT Code) RimWorld.PortraitsCache:Clear ()
0x00000279F4B6374B (Mono JIT Code) Multiplayer.Client.MultiplayerGame:.ctor ()
0x00000279F4B5F8F3 (Mono JIT Code) Multiplayer.Client.GameExposeComponentsPatch:Prefix ()
```

which looks to me like PortraitsCache.Clear() is for some reason segfaulting when trying to free the texture (maybe 1.1 uses a texture somewhere between sessions? Maybe that big Royalty dude in the main menu?). On a whim I commented it out, since hopefully its a small cache, and voila: no crash!