### PR TITLE
Fix MultiplayerApi version checking error

### DIFF
--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -33,8 +33,6 @@ namespace Multiplayer.Client
             //EarlyMarkNoInline(typeof(Multiplayer).Assembly);
             EarlyPatches();
 
-            CheckInterfaceVersions();
-
             settings = GetSettings<MpSettings>();
 
             LongEventHandler.ExecuteWhenFinished(() => {
@@ -176,34 +174,6 @@ namespace Multiplayer.Client
         }
 
         public override string SettingsCategory() => "Multiplayer";
-
-        static void CheckInterfaceVersions()
-        {
-            var mpApiAssembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name == MpVersion.apiAssemblyName);
-            var curVersion = mpApiAssembly.GetName().Version;
-
-            Log.Message($"Current API version: {curVersion}");
-
-            foreach (var mod in LoadedModManager.RunningMods) {
-                if (mod.assemblies.loadedAssemblies.NullOrEmpty())
-                    continue;
-
-                if (mod.Name == "Multiplayer")
-                    continue;
-
-                Assembly assembly = mod.assemblies.loadedAssemblies.FirstOrDefault(a => a.GetName().Name == MpVersion.apiAssemblyName);
-
-                if (assembly != null) {
-                    var version = assembly.GetName().Version;
-                    Log.Message($"Mod {mod.Name} has API client ({version})");
-
-                    if (curVersion > version)
-                        Log.Warning($"Mod {mod.Name} uses an older API version (mod: {version}, current: {curVersion})");
-                    else if (curVersion < version)
-                        Log.Error($"Mod {mod.Name} uses a newer API version! (mod: {version}, current: {curVersion})\nMake sure the Multiplayer mod is up to date");
-                }
-            }
-        }
     }
 
     static class XmlAssetsInModFolderPatch

--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -179,10 +179,8 @@ namespace Multiplayer.Client
 
         static void CheckInterfaceVersions()
         {
-            var mpAssembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name == "Multiplayer");
-            var curVersion = new System.Version(
-                (mpAssembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false)[0] as AssemblyFileVersionAttribute).Version
-            );
+            var mpApiAssembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name == MpVersion.apiAssemblyName);
+            var curVersion = mpApiAssembly.GetName().Version;
 
             Log.Message($"Current API version: {curVersion}");
 
@@ -196,8 +194,7 @@ namespace Multiplayer.Client
                 Assembly assembly = mod.assemblies.loadedAssemblies.FirstOrDefault(a => a.GetName().Name == MpVersion.apiAssemblyName);
 
                 if (assembly != null) {
-                    var version = new Version(FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion);
-
+                    var version = assembly.GetName().Version;
                     Log.Message($"Mod {mod.Name} has API client ({version})");
 
                     if (curVersion > version)


### PR DESCRIPTION
I tried loading a build of `wip-1.1` with ~20 mods I'd been using with Multiplayer back in 1.0 that claim to have 1.1 compatibility. One of them, Tech Advancing https://steamcommunity.com/sharedfiles/filedetails/?id=735268789 , seems to be using the Multiplayer API via nuget, and loading it with `wip-1.1` causes the Version checking to error:

![2020_03_20_03-06-41](https://user-images.githubusercontent.com/1627867/77153881-debf4f00-6a57-11ea-815e-996974fde75a.png)

Which, due to erroring this early in init, **disables the whole Multiplayer mod** (the button's gone from the main menu).

It looks like `assembly.Location == ""` for this mod - not sure why, but it looks like this was recently changed code anyway https://github.com/rwmt/Multiplayer/commit/141cf1bb41e7338da0f31d05d20ec350e9c543f5#diff-87823ce8f8d966f1a4b08dc925c85e90 , perhaps merely untested? 

**After this PR**, the check passes:

![2020_03_20_03-04-02](https://user-images.githubusercontent.com/1627867/77153732-88521080-6a57-11ea-9556-0a5fdf342cdd.png)

... though I'm not sure how good of a job the `mod.assemblies.loadedAssemblies.FirstOrDefault(a => a.GetName().Name == MpVersion.apiAssemblyName)` approach is, as it didn't detect the MultiplayerAPI in any of my other active mods, including RimHUD which even self-announces that its using MultiplayerAPI 0.1 (loaded via https://github.com/Jaxe-Dev/RimHUD/blob/master/Source/Data/Integration/Mod_Multiplayer.cs - so not with a dll?)

![2020_03_20_03-14-30](https://user-images.githubusercontent.com/1627867/77154447-ef23f980-6a58-11ea-87ca-9fbfaf9cbefc.png)
