### PR TITLE
Fix SyncDelegates TurretGun errors on init

### DIFF
--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -787,13 +787,13 @@ namespace Multiplayer.Client
 
             SyncMethod.Register(typeof(CompFlickable), "<CompGetGizmosExtra>b__20_1"); // Toggle flick designation
             SyncMethod.Register(typeof(Pawn_PlayerSettings), "<GetGizmos>b__31_1");    // Toggle release animals
-            SyncMethod.Register(typeof(Building_TurretGun), "<GetGizmos>b__57_2");     // Toggle turret hold fire
+            SyncMethod.Register(typeof(Building_TurretGun), "<GetGizmos>b__58_2");     // Toggle turret hold fire
             SyncMethod.Register(typeof(Building_Trap), "<GetGizmos>b__23_1");          // Toggle trap auto-rearm
             SyncMethod.Register(typeof(Building_Door), "<GetGizmos>b__57_1");          // Toggle door hold open
             SyncMethod.Register(typeof(Zone_Growing), "<GetGizmos>b__13_1");           // Toggle zone allow sow
 
             SyncMethod.Register(typeof(PriorityWork), "<GetGizmos>b__17_0");                // Clear prioritized work
-            SyncMethod.Register(typeof(Building_TurretGun), "<GetGizmos>b__57_1");          // Reset forced target
+            SyncMethod.Register(typeof(Building_TurretGun), "<GetGizmos>b__58_1");          // Reset forced target
             SyncMethod.Register(typeof(UnfinishedThing), "<GetGizmos>b__27_0");             // Cancel unfinished thing
             SyncMethod.Register(typeof(CompTempControl), "<CompGetGizmosExtra>b__8_2");     // Reset temperature
 


### PR DESCRIPTION
On init of main menu I see

```
Exception during Sync initialization: System.TypeInitializationException: The type initializer for 'Multiplayer.Client.SyncDelegates' threw an exception. ---> System.Exception: Couldn't find method or property <GetGizmos>b__57_2 in type RimWorld.Building_TurretGun
  at Multiplayer.Client.Sync.RegisterSyncMethod (System.Type type, System.String methodOrPropertyName, Multiplayer.API.SyncType[] argTypes) [0x0007c] in <4299605cc90a4872a2b4e1a05d81a08d>:0 
  at Multiplayer.Client.SyncMethod.Register (System.Type type, System.String methodOrPropertyName, Multiplayer.API.SyncType[] argTypes) [0x00001] in <4299605cc90a4872a2b4e1a05d81a08d>:0 
  at Multiplayer.Client.SyncDelegates..cctor () [0x001bb] in <4299605cc90a4872a2b4e1a05d81a08d>:0 
   --- End of inner exception stack trace ---
  at (wrapper managed-to-native) System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(intptr)
  at System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor (System.RuntimeTypeHandle type) [0x0002a] in <567df3e0919241ba98db88bec4c6696f>:0 
  at Multiplayer.Client.SyncHandlers.Init () [0x0003a] in <4299605cc90a4872a2b4e1a05d81a08d>:0 
  at Multiplayer.Client.Multiplayer..cctor () [0x002e9] in <4299605cc90a4872a2b4e1a05d81a08d>:0 
Verse.Log:Error(String, Boolean)
Multiplayer.Client.Multiplayer:.cctor()
```

Navigating to the decompiled Building_TurretGun definition, I saw a bunch of `<GetGizmos>b__58_X>` methods with no mention of b__57's, so I'm guessing a Rimworld update changed the offset of whatever injecting nonsense we're doing in there. Turret hold fire seems to work?