### PR TITLE
Fix infinite dialog creation on Research Completion

### DIFF
--- a/Source/Client/Comp/MultiplayerMapComp.cs
+++ b/Source/Client/Comp/MultiplayerMapComp.cs
@@ -207,8 +207,9 @@ namespace Multiplayer.Client
             if (comp.mapDialogs.Any())
             {
                 //If NO mapdialogs (Dialog_NodeTrees) are open, add the first one to the window stack
-                if (!Find.WindowStack.IsOpen(typeof(Dialog_NodeTree)))
-                    Find.WindowStack.Add(comp.mapDialogs.First().Dialog);Find.WindowStack.Add(comp.mapDialogs.First().Dialog);
+                if (!Find.WindowStack.IsOpen(typeof(Dialog_NodeTree))) {
+                    Find.WindowStack.Add(comp.mapDialogs.First().Dialog);
+                }
             }
             else if (comp.caravanForming != null)
             {


### PR DESCRIPTION
Fixes #33 

Looks like this may have been introduced by a PR merge conflict, as #2 touched the line (but looks correct), yet the merge commit itself has the line doubled f4d8e8261f1733b3a028a6b291a1134ae09f9657
