### PR TITLE
1.1: Sync Accept Quest

### DIFF
--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -307,6 +307,19 @@ namespace Multiplayer.Client
             },
             #endregion
 
+            #region Quests
+            {
+                (ByteWriter data, Quest quest) => {
+                    data.WriteInt32(quest.id);
+                },
+                (ByteReader data) => {
+                    int questId = data.ReadInt32();
+                    return Find.QuestManager.QuestsListForReading.FirstOrDefault(possibleQuest => possibleQuest.id == questId);
+                },
+                true
+            },
+            #endregion
+
             #region Ranges
             {
                 (ByteWriter data, FloatRange range) => {

--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -476,6 +476,8 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(InstallBlueprintUtility), nameof(InstallBlueprintUtility.CancelBlueprintsFor)).CancelIfAnyArgNull();
             SyncMethod.Register(typeof(Command_LoadToTransporter), nameof(Command_LoadToTransporter.ProcessInput));
 
+            SyncMethod.Register(typeof(Quest), nameof(Quest.Accept));
+
             // 1
             SyncMethod.Register(typeof(TradeRequestComp), nameof(TradeRequestComp.Fulfill)).CancelIfAnyArgNull().SetVersion(1);
 


### PR DESCRIPTION
This seems to "work", at least, given a save with a Quest available like https://cdn.discordapp.com/attachments/649645755929198604/692684990538055680/desync952PM.zip , hitting Accept no longer causes a desync.

I'm not 100% sure simply writing/reading the quest.id is sufficient, I tried and failed to see a pattern amongst the other SyncDictionary event types.