### PR TITLE
Fixed 'toggle prisoner bed' not syncing the correct method

### DIFF
--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -782,7 +782,7 @@ namespace Multiplayer.Client
 
             SyncDelegate.Register(typeof(HealthCardUtility), "<>c__DisplayClass26_0", "<GenerateSurgeryOption>b__1").CancelIfAnyFieldNull(without: "part");      // Add medical bill
             SyncDelegate.Register(typeof(Command_SetPlantToGrow), "<>c__DisplayClass5_0", "<ProcessInput>b__2");                                                // Set plant to grow
-            SyncDelegate.Register(typeof(Building_Bed), "<>c__DisplayClass39_0", "<ToggleForPrisonersByInterface>b__1").RemoveNullsFromLists("bedsToAffect");    // Toggle bed for prisoners
+            SyncDelegate.Register(typeof(Building_Bed), "<>c__DisplayClass39_0", "<ToggleForPrisonersByInterface>b__0").RemoveNullsFromLists("bedsToAffect");    // Toggle bed for prisoners
             SyncDelegate.Register(typeof(ITab_Bills), "<>c__DisplayClass10_0", "<FillTab>b__1").SetContext(SyncContext.MapSelected).CancelIfNoSelectedObjects(); // Add bill
 
             SyncDelegate.Register(typeof(CompLongRangeMineralScanner), "<>c__DisplayClass7_0", "<CompGetGizmosExtra>b__1").SetContext(SyncContext.MapSelected); // Select mineral to scan for


### PR DESCRIPTION
Fixes #32, which said that a desync was detected upon trying to arrest a prisoner, though the actual desync arose from the clients disagreeing on whether there were any prisoner beds.

The relevant code in Building_Bed.cs is:
```
      Action confirmedAct = (Action) (() => // IL calls this `<ToggleForPrisonersByInterface>b__0`
      {
        List<Room> roomList = new List<Room>();
        foreach (Building_Bed thing in bedsToAffect)
        {
          Room room = thing.GetRoom(RegionType.Set_Passable);
          thing.ForPrisoners = newForPrisoners && !room.TouchesMapEdge;
          for (int slotIndex = 0; slotIndex < this.SleepingSlotsCount; ++slotIndex)
            this.GetCurOccupant(slotIndex)?.jobs.EndCurrentJob(JobCondition.InterruptForced, true, true);
          if (!roomList.Contains(room) && !room.TouchesMapEdge)
            roomList.Add(room);
        }
        foreach (Room room in roomList)
          room.Notify_RoomShapeOrContainedBedsChanged();
      });
      if (bedsToAffect.Where<Building_Bed>((Func<Building_Bed, bool>) (b => b.OwnersForReading.Any<Pawn>() && b != this)).Count<Building_Bed>() == 0) // IL calls this `<ToggleForPrisonersByInterface>b__1`
      {
        confirmedAct();
      }
```

Thanks to Ed Harris on the Discord (Desync6) for isolating that it was the beds state!