### PR TITLE
Fix desync: changing BillRepeatMode to Forever or Until X

### DIFF
--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -248,6 +248,8 @@ namespace Multiplayer.Client
         }
 
         [MpPrefix(typeof(BillRepeatModeUtility), "<>c__DisplayClass0_0", "<MakeConfigFloatMenu>b__0")]
+        [MpPrefix(typeof(BillRepeatModeUtility), "<>c__DisplayClass0_0", "<MakeConfigFloatMenu>b__1")]
+        [MpPrefix(typeof(BillRepeatModeUtility), "<>c__DisplayClass0_0", "<MakeConfigFloatMenu>b__2")]
         static void BillRepeatMode(object __instance)
         {
             SyncBillProduction.Watch(__instance.GetPropertyOrField("bill"));


### PR DESCRIPTION
Fixes a shadow-desync: toggling bills (ie. 'Make Simple Meals' in a Cooking Table) from 'Do X Times' to 'Do Until you have X' or 'Do Forever' wasn't synced (though switching back to 'Do X Times' was).

This likely is the cause of Ed Harris's Desync-01 and 07, as if a pawn started work on one client, that wasn't queued up for another client, it would trigger a hard desync "out of the blue".

Prior to the big 'Harmony Pass' 1.1 commit, there used to be 3x calls like this.