### PR TITLE
Fixed 'trace hash mismatch' desync on join, between Linux + Windows

### DIFF
--- a/Source/Client/Extensions.cs
+++ b/Source/Client/Extensions.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml;
 using UnityEngine;
 using Verse;
@@ -22,6 +23,8 @@ namespace Multiplayer.Client
 {
     public static class Extensions
     {
+        private static Regex methodNameCleaner = new Regex(@"(\?[0-9\-]+)");
+
         public static IEnumerable<T> NotNull<T>(this IEnumerable<T> e)
         {
             return e.Where(t => t != null);
@@ -244,20 +247,13 @@ namespace Multiplayer.Client
 
         public static int Hash(this StackTrace trace)
         {
-            int hash = 0;
-            for (int i = 0; i < trace.GetFrames().Length; i++)
-                hash = Gen.HashCombineInt(hash, trace.GetFrames()[i].GetMethod().MetadataToken);
+            var traceToHash = new StringBuilder();
+            for (int i = 0; i < trace.FrameCount; i++) {
+                var method = trace.GetFrame(i).GetMethod();
+                traceToHash.AppendLine(methodNameCleaner.Replace(method.ToString(), ""));
+            }
 
-            return hash;
-        }
-
-        public static int Hash(this MethodBase[] methods)
-        {
-            int hash = 0;
-            for (int i = 0; i < methods.Length; i++)
-                hash = Gen.HashCombineInt(hash, methods[i].MetadataToken);
-
-            return hash;
+            return traceToHash.ToString().GetHashCode();
         }
 
         public static byte[] GetBytes(this ZipEntry entry)


### PR DESCRIPTION
`traceFrame.GetMethod().MetadataToken` is an assembly-specific hash which differ between builds (such as Linux vs Windows), ensuring that no trace hashes will ever align, and immediate desyncs on load.

I'm now hashing the Method.ToString() (looks like `DMD<DMD<TickManagerUpdate_Patch2>?489914240::TickManagerUpdate_Patch2> (Verse.TickManager )`) with the assembly-specific hashes (`?489914240`) stripped out, which should be functionally equivalent for our purposes.