### PR TITLE
Fix Linux-Windows Desyncs - part 2

### DIFF
--- a/Source/Client/Extensions.cs
+++ b/Source/Client/Extensions.cs
@@ -250,7 +250,7 @@ namespace Multiplayer.Client
             var traceToHash = new StringBuilder();
             for (int i = 0; i < trace.FrameCount; i++) {
                 var method = trace.GetFrame(i).GetMethod();
-                traceToHash.AppendLine(methodNameCleaner.Replace(method.ToString(), ""));
+                traceToHash.Append(methodNameCleaner.Replace(method.ToString(), "") + "\n");
             }
 
             return traceToHash.ToString().GetHashCode();


### PR DESCRIPTION
I had it working with plain `string`'s, and apparently broke it without testing when I moved to StringBuilder, as `AppendLine` uses \r\n on Windows and \n on Linux (because of course it does)