### PR TITLE
Auto download host's mods on join

### DIFF
--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -16,7 +16,9 @@
   <MpWrongDefs>Mod definition mismatch</MpWrongDefs>
   <MpWrongDefsInfo>Make sure your installed mods, their versions and order match the host's.</MpWrongDefsInfo>
   <MpModList>Mod list</MpModList>
+  <MpSyncModList>Autosync Mod List</MpSyncModList>
   <MpSeeModList>See mod list</MpSeeModList>
+  <MPDownloadingWorkshopMods>Downloading Workshop Mods</MPDownloadingWorkshopMods>
   
   <MpServerClosed>Server closed</MpServerClosed>
   <MpServerFull>Server is full</MpServerFull>

--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -18,7 +18,7 @@
   <MpModList>Mod list</MpModList>
   <MpSyncModList>Autosync Mod List</MpSyncModList>
   <MpSeeModList>See mod list</MpSeeModList>
-  <MPDownloadingWorkshopMods>Downloading Workshop Mods</MPDownloadingWorkshopMods>
+  <MpDownloadingWorkshopMods>Downloading Workshop Mods</MpDownloadingWorkshopMods>
   
   <MpServerClosed>Server closed</MpServerClosed>
   <MpServerFull>Server is full</MpServerFull>

--- a/Source/Client/ClientConnection.cs
+++ b/Source/Client/ClientConnection.cs
@@ -33,6 +33,8 @@ namespace Multiplayer.Client
         {
             Multiplayer.session.mods.remoteRwVersion = data.ReadString();
             Multiplayer.session.mods.remoteModNames = data.ReadPrefixedStrings();
+            Multiplayer.session.mods.remoteModIds = data.ReadPrefixedStrings();
+            Multiplayer.session.mods.remoteWorkshopModIds = data.ReadPrefixedULongs();
 
             var defs = Multiplayer.localDefInfos;
             Multiplayer.session.mods.defInfo = defs;

--- a/Source/Client/ClientConnection.cs
+++ b/Source/Client/ClientConnection.cs
@@ -39,6 +39,10 @@ namespace Multiplayer.Client
             var defs = Multiplayer.localDefInfos;
             Multiplayer.session.mods.defInfo = defs;
 
+            var endPoint = Multiplayer.session.netClient.FirstPeer.EndPoint;
+            Multiplayer.session.mods.remoteAddress = endPoint.Address.ToString();
+            Multiplayer.session.mods.remotePort = endPoint.Port;
+
             var response = new ByteWriter();
             response.WriteInt32(defs.Count);
 
@@ -376,7 +380,7 @@ namespace Multiplayer.Client
         public void HandlePause(ByteReader data)
         {
             bool pause = data.ReadBool();
-            // This packet doesn't get processed in time during a synchronous long event 
+            // This packet doesn't get processed in time during a synchronous long event
         }
 
         [PacketHandler(Packets.Server_Debug)]

--- a/Source/Client/ClientNetworking.cs
+++ b/Source/Client/ClientNetworking.cs
@@ -62,7 +62,11 @@ namespace Multiplayer.Client
 
             localServer.rwVersion = session.mods.remoteRwVersion = VersionControl.CurrentVersionString;
             localServer.modNames = session.mods.remoteModNames = LoadedModManager.RunningModsListForReading.Select(m => m.Name).ToArray();
+            localServer.modIds = session.mods.remoteModIds = LoadedModManager.RunningModsListForReading.Select(m => m.PackageId).ToArray();
+            localServer.workshopModIds = session.mods.remoteWorkshopModIds = ModManagement.GetEnabledWorkshopMods().ToArray();
             localServer.defInfos = session.mods.defInfo = Multiplayer.localDefInfos;
+            Log.Message($"MP Host modIds: {string.Join(", ", localServer.modIds)}");
+            Log.Message($"MP Host workshopIds: {string.Join(", ", localServer.workshopModIds)}");
 
             if (settings.steam)
                 localServer.NetTick += SteamIntegration.ServerSteamNetTick;

--- a/Source/Client/ModManagement.cs
+++ b/Source/Client/ModManagement.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Steamworks;
+using Verse;
+using Verse.Steam;
+
+namespace Multiplayer.Client
+{
+    public static class ModManagement
+    {
+        public static List<ulong> GetEnabledWorkshopMods() {
+            var enabledModIds = LoadedModManager.RunningModsListForReading.Select(m => m.PackageId).ToArray();
+            var allWorkshopItems =
+                WorkshopItems.AllSubscribedItems.Where<WorkshopItem>(
+                    (Func<WorkshopItem, bool>) (it => it is WorkshopItem_Mod)
+                );
+            var workshopModIds = new List<ulong>();
+            foreach (WorkshopItem workshopItem in allWorkshopItems) {
+                ModMetaData mod = new ModMetaData(workshopItem);
+
+                if (enabledModIds.Contains(mod.PackageIdNonUnique)) {
+                    workshopModIds.Add(workshopItem.PublishedFileId.m_PublishedFileId);
+                }
+            }
+
+            return workshopModIds;
+        }
+
+        public static void DownloadWorkshopMods(ulong[] workshopModIds) {
+            try {
+                var downloadInProgress = new List<PublishedFileId_t>();
+                foreach (var workshopModId in workshopModIds) {
+                    var publishedFileId = new PublishedFileId_t(workshopModId);
+                    var itemState = (EItemState) SteamUGC.GetItemState(publishedFileId);
+                    if (!itemState.HasFlag(EItemState.k_EItemStateInstalled | EItemState.k_EItemStateSubscribed)) {
+                        Log.Message($"Starting workshop download {publishedFileId}");
+                        SteamUGC.SubscribeItem(publishedFileId);
+                        downloadInProgress.Add(publishedFileId);
+                    }
+                }
+
+                // wait for all workshop downloads to complete
+                while (downloadInProgress.Count > 0) {
+                    var publishedFileId = downloadInProgress.First();
+                    var itemState = (EItemState) SteamUGC.GetItemState(publishedFileId);
+                    if (itemState.HasFlag(EItemState.k_EItemStateInstalled | EItemState.k_EItemStateSubscribed)) {
+                        downloadInProgress.RemoveAt(0);
+                    }
+                    else {
+                        Log.Message($"Waiting for workshop download {publishedFileId} status {itemState}");
+                        Thread.Sleep(200);
+                    }
+                }
+            }
+            catch (InvalidOperationException e) {
+                Log.Error($"MP Workshop mod sync error: {e.Message}");
+            }
+        }
+
+        /// Calls the private <see cref="WorkshopItems.RebuildItemsList"/>) to manually detect newly downloaded Workshop mods
+        public static void RebuildModsList() {
+            // ReSharper disable once PossibleNullReferenceException
+            typeof(WorkshopItems)
+                .GetMethod("RebuildItemsList", BindingFlags.Static | BindingFlags.NonPublic)
+                .Invoke(obj: null, parameters: new object[] { });
+        }
+    }
+}

--- a/Source/Client/MultiplayerSession.cs
+++ b/Source/Client/MultiplayerSession.cs
@@ -181,6 +181,8 @@ namespace Multiplayer.Client
     {
         public string remoteRwVersion;
         public string[] remoteModNames;
+        public string[] remoteModIds;
+        public ulong[] remoteWorkshopModIds;
         public Dictionary<string, DefInfo> defInfo;
     }
 

--- a/Source/Client/MultiplayerSession.cs
+++ b/Source/Client/MultiplayerSession.cs
@@ -184,6 +184,8 @@ namespace Multiplayer.Client
         public string[] remoteModIds;
         public ulong[] remoteWorkshopModIds;
         public Dictionary<string, DefInfo> defInfo;
+        public string remoteAddress;
+        public int remotePort;
     }
 
     public class PlayerInfo

--- a/Source/Client/Windows/DisconnectedWindow.cs
+++ b/Source/Client/Windows/DisconnectedWindow.cs
@@ -112,12 +112,12 @@ namespace Multiplayer.Client
                         ModManagement.RebuildModsList();
                         ModsConfig.SetActiveToList(mods.remoteModIds.ToList());
                         ModsConfig.Save();
-                        ModsConfig.RestartFromChangedMods();
+                        ModManagement.PromptRestartAndReconnect(mods.remoteAddress, mods.remotePort);
                     }
                     catch (Exception e) {
                         Log.Error($"MP mod sync error: {e.GetType()} {e.Message}");
                     }
-                }, "MPDownloadingWorkshopMods", true, null);
+                }, "MpDownloadingWorkshopMods", true, null);
             }
 
             btnRect.x += btnRect.width + gap;

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -61,6 +61,8 @@ namespace Multiplayer.Common
 
         public string rwVersion;
         public string[] modNames;
+        public string[] modIds;
+        public ulong[] workshopModIds;
         public Dictionary<string, DefInfo> defInfos;
 
         public int NetPort => netManager.LocalPort;

--- a/Source/Common/Networking.cs
+++ b/Source/Common/Networking.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Verse;
 
 namespace Multiplayer.Common
 {
@@ -388,6 +389,10 @@ namespace Multiplayer.Common
             {
                 WriteLong(@long);
             }
+            else if (obj is ulong @ulong)
+            {
+                WriteULong(@ulong);
+            }
             else if (obj is byte @byte)
             {
                 WriteByte(@byte);
@@ -423,6 +428,9 @@ namespace Multiplayer.Common
                 Write(list.Count);
                 foreach (object o in list)
                     Write(o);
+            }
+            else {
+                Log.Error($"MP ByteWriter.Write: Unknown type {obj.GetType().ToString()}");
             }
         }
 
@@ -537,6 +545,16 @@ namespace Multiplayer.Common
             uint[] result = new uint[len];
             for (int i = 0; i < len; i++)
                 result[i] = ReadUInt32();
+            return result;
+        }
+
+        public ulong[] ReadPrefixedULongs()
+        {
+            int len = ReadInt32();
+            ulong[] result = new ulong[len];
+            for (int i = 0; i < len; i++) {
+                result[i] = ReadULong();
+            }
             return result;
         }
 

--- a/Source/Common/ServerConnection.cs
+++ b/Source/Common/ServerConnection.cs
@@ -23,7 +23,7 @@ namespace Multiplayer.Common
                 return;
             }
 
-            connection.Send(Packets.Server_ModList, Server.rwVersion, Server.modNames);
+            connection.Send(Packets.Server_ModList, Server.rwVersion, Server.modNames, Server.modIds, Server.workshopModIds);
         }
 
         [PacketHandler(Packets.Client_Defs)]


### PR DESCRIPTION
Adds a new button to the 'Mod definition mismatch' window that appears when a guest joins a host with differing mods enabled: "Autosync Mod List". It will:
* Subscribe to any Workshop mods the host currently has active, waiting for their downloads/installs to complete
* Set the list of active mods to match the host's, including order. This is functionally equivalent to automating the copying of `ModsConfig.xml`

Caveats:
* it doesn't download non-workshop versions of mods. If they're installed out-of-band, this will still correctly activate them in `ModsConfig.xml`, so that's something!
* it'll display a console error if Workshop cannot be reached, such as for non-Steam installs, and proceed to try setting up ModsConfig. Missing mods are just ignored/not-set.

I expect this to _personally_ save me 60+ minutes of handholding my friends through the manual sync process :D