### PR TITLE
Fix #35: sync casting Psychic Abilities 

### DIFF
--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -479,6 +479,7 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(Command_LoadToTransporter), nameof(Command_LoadToTransporter.ProcessInput));
 
             SyncMethod.Register(typeof(Quest), nameof(Quest.Accept));
+            SyncMethod.Register(typeof(Verb_CastAbility), nameof(Verb_CastAbility.OrderForceTarget));
 
             // 1
             SyncMethod.Register(typeof(TradeRequestComp), nameof(TradeRequestComp.Fulfill)).CancelIfAnyArgNull().SetVersion(1);

--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -38,6 +38,7 @@ namespace Multiplayer.Client
         public static ISyncField SyncHostilityResponse = Sync.Field(typeof(Pawn), "playerSettings", "hostilityResponse");
         public static ISyncField SyncInteractionMode = Sync.Field(typeof(Pawn), "guest", "interactionMode");
         public static ISyncField SyncBeCarried = Sync.Field(typeof(Pawn), "health", "beCarriedByCaravanIfSick");
+        public static ISyncField SyncPsychicEntropyLimit = Sync.Field(typeof(Pawn), "psychicEntropy", "limitEntropyAmount");
 
         public static ISyncField SyncGodMode = Sync.Field(null, "Verse.DebugSettings/godMode").SetDebugOnly();
         public static ISyncField SyncResearchProject = Sync.Field(null, "Verse.Find/ResearchManager/currentProj");
@@ -189,6 +190,14 @@ namespace Multiplayer.Client
         static void MedicalDefaults()
         {
             SyncDefaultCare.Watch();
+        }
+
+        [MpPrefix(typeof(PsychicEntropyGizmo), nameof(PsychicEntropyGizmo.GizmoOnGUI))]
+        static void PsychicEntropyLimiterToggle(PsychicEntropyGizmo __instance)
+        {
+            if (__instance?.tracker?.Pawn != null) {
+                SyncPsychicEntropyLimit.Watch(__instance.tracker.Pawn);
+            }
         }
 
         [MpPrefix(typeof(Widgets), "CheckboxLabeled")]

--- a/Source/Client/Sync/SyncSerialization.cs
+++ b/Source/Client/Sync/SyncSerialization.cs
@@ -86,6 +86,11 @@ namespace Multiplayer.Client
             None, Thing, Zone, WorldObject
         }
 
+        enum VerbOwnerType : byte
+        {
+            None, Pawn, Ability
+        }
+
         private static MethodInfo GetDefByIdMethod = AccessTools.Method(typeof(Sync), nameof(Sync.GetDefById));
 
         public static T GetDefById<T>(ushort id) where T : Def => DefDatabase<T>.GetByShortHash(id);


### PR DESCRIPTION
* Syncs `Verb_CastAbility.OrderForceTarget`, called when a pawn uses a Psychic Ability on something. This required writing a SyncDictionary entry for `Verb_CastAbility` - I wrote one that works for verbs owned by Abilities (which seems to be the case when a pawn Psycasts via the GUI) and Pawns (unsure how to trigger), though there's other possible verb.DirectOwners left unimplemented/unsynced.
* Syncs the 'limit psychic entropy' safety toggle, as otherwise it desyncs when you spam a lot of psycasts in a row with it toggled on only one client. 

Whew, those took a lot of fiddling to figure out >.>