### PR TITLE
Add workshop_bundler.sh, for making a 1.0/1.1 compatible zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,5 @@ __pycache__/
 /Source/Publicise.exe
 /Source/LICENSE
 /Source/dnlib.dll
+/Multiplayer
+Multiplayer.zip

--- a/About/About.xml
+++ b/About/About.xml
@@ -8,7 +8,7 @@
   <author>Zetrith</author>
   <url>https://github.com/rwmt/Multiplayer</url>
   <description>&lt;color=red&gt;&lt;b&gt;Important: &lt;/b&gt; This mod should be loaded as early as possible to work properly!&lt;/color&gt;\n
-Multiplayer mod for rimworld. Rimworld Multiplayer requires Harmony as of 0.5.
+Multiplayer mod for rimworld.
     
 This is version 0.5-BETA
     

--- a/About/About.xml
+++ b/About/About.xml
@@ -3,7 +3,6 @@
   <packageId>rwmt.Multiplayer</packageId>
   <name>Multiplayer</name>
   <supportedVersions>
-    <li>1.0</li>
     <li>1.1</li>
   </supportedVersions>
   <author>Zetrith</author>

--- a/About/About.xml
+++ b/About/About.xml
@@ -3,6 +3,7 @@
   <packageId>rwmt.Multiplayer</packageId>
   <name>Multiplayer</name>
   <supportedVersions>
+    <li>1.0</li>
     <li>1.1</li>
   </supportedVersions>
   <author>Zetrith</author>

--- a/Source/Common/Version.cs
+++ b/Source/Common/Version.cs
@@ -2,7 +2,7 @@ namespace Multiplayer.Common
 {
     public static class MpVersion
     {
-        public const string Version = "0.5";
+        public const string Version = "0.5.0.10"; // this is copied to About.xml via workshop_bundler.sh
         public const int Protocol = 18;
 
         public const string apiAssemblyName = "0MultiplayerAPI";

--- a/workshop_bundler.sh
+++ b/workshop_bundler.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+mkdir -p Multiplayer
+cp -r About Languages Multiplayer/
+
+rm -rf Multiplayer/1.1
+mkdir -p Multiplayer/1.1
+cp -r Assemblies Defs Multiplayer/1.1/
+
+mkdir -p Multiplayer/1.0
+git --work-tree=Multiplayer/1.0 checkout origin/rw-1.0 -- Assemblies Defs
+git reset Assemblies Defs
+
+rm -f Multiplayer.zip
+zip -r -q Multiplayer.zip Multiplayer
+
+echo "Ok, $PWD/Multiplayer.zip ready for uploading to Workshop"

--- a/workshop_bundler.sh
+++ b/workshop_bundler.sh
@@ -3,6 +3,7 @@
 mkdir -p Multiplayer
 cp -r About Languages Multiplayer/
 sed -i "/<supportedVersions>/ a \ \ \ \ <li>1.0</li>" Multiplayer/About/About.xml
+sed -i "s/This is version .*\$/This is version $(grep -Po '(?<=Version = ")[0-9\.]+' Source/Common/Version.cs)./" Multiplayer/About/About.xml
 
 rm -rf Multiplayer/1.1
 mkdir -p Multiplayer/1.1

--- a/workshop_bundler.sh
+++ b/workshop_bundler.sh
@@ -2,6 +2,7 @@
 
 mkdir -p Multiplayer
 cp -r About Languages Multiplayer/
+sed -i "/<supportedVersions>/ a \ \ \ \ <li>1.0</li>" Multiplayer/About/About.xml
 
 rm -rf Multiplayer/1.1
 mkdir -p Multiplayer/1.1


### PR DESCRIPTION
In lieu of #30, this adds a `workshop_bundler.sh` that copies the appropriate files into a clean directory + zips it.

As I can't actually build 1.0 and don't care enough to figure it out, I've pushed the stable 1.0 assemblies (from the last Workshop release) to a `rw-1.0` branch, so it can be fetched via git at bundle-time.

I initially had this as a `.bat` but Windows doesn't have a zip utility built-in.