### PR TITLE
Add Ingame Mod Compatibility Checker

### DIFF
--- a/Source/Client/ModPatches.cs
+++ b/Source/Client/ModPatches.cs
@@ -114,12 +114,16 @@ namespace Multiplayer.Client
             var mod = ____selected;
             currentModName = __instance == null ? mod.Name : (string)__instance.GetPropertyOrField("TrimmedName");
             truncatedStrings = ____modNameTruncationCache;
-            if (Multiplayer.xmlMods.Contains(mod.RootDir.FullName)) {
-                currentModCompat = "XML";
+            if (mod.IsCoreMod || mod.Name == "Harmony") {
+                currentModCompat = "<color=green>4</color>";
+            } else if (mod.Official) { // eg. Royalty
+                currentModCompat = "<color=yellow>3</color>";
+            } else if (Multiplayer.xmlMods.Contains(mod.RootDir.FullName)) {
+                currentModCompat = "<color=green>5</color>";
             }
 
-            if (Multiplayer.modsCompatibility.ContainsKey((int) mod.publishedFileIdInt.m_PublishedFileId)) {
-                var compat = Multiplayer.modsCompatibility[(int) mod.publishedFileIdInt.m_PublishedFileId];
+            if (Multiplayer.modsCompatibility.ContainsKey(mod.publishedFileIdInt.ToString())) {
+                var compat = Multiplayer.modsCompatibility[mod.publishedFileIdInt.ToString()];
                 if (compat == 1) {
                     currentModCompat = $"<color=red>{compat}</color>";
                 } else if (compat == 2) {

--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -160,7 +160,7 @@ namespace Multiplayer.Client
         private static void UpdateModCompatibilityDb()
         {
             Task.Run(() => {
-                var client = new RestClient("http://neb.nebtown.info:51412/mod-compatibility?version=1.1");
+                var client = new RestClient("https://bot.rimworldmultiplayer.com/mod-compatibility?version=1.1");
                 try {
                     var rawResponse = client.Get(new RestRequest($"", DataFormat.Json));
                     modsCompatibility = SimpleJson.DeserializeObject<Dictionary<string, int>>(rawResponse.Content);

--- a/Source/Multiplayer.csproj
+++ b/Source/Multiplayer.csproj
@@ -15,6 +15,7 @@
     
     <!-- Nuget dependencies -->
     <PackageReference Include="Publicise.MSBuild.Task" Version="1.*" />
+    <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.2.0" />
     <PackageReference Include="Lib.Harmony" Version="2.0.0.8" />
     <PackageReference Include="LiteNetLib" Version="0.8.3.1" />


### PR DESCRIPTION
This extends the existing "hold shift when looking at Mod list to reveal which are XML mods" behaviour by comparing against the Compatibility Spreadsheet, showing the numbers directly in-game!


I initially had this fetching directly from Google Sheets, but I'll likely run into rate limits that way, so I've extended the Discord bot responsible for replying to mod compatibility checks (which already has a local cache of the spreadsheet, and a /reload command to refresh it) to rehost the sheet in an efficient format. https://github.com/rwmt/DiscordBot-Advisor/pull/1 (though I'll host it until that PR is merged + deployed)

This is compatible with both Fluffy's Mod Manager and the vanilla one.

![2020_04_09_02-24-34](https://user-images.githubusercontent.com/1627867/78879831-4fc7a600-7a09-11ea-8804-1fc0eb2aa3c5.png)