### PR TITLE
Force PauseOnLoad to false, misalignment causes desyncs on load

### DIFF
--- a/Source/Client/ClientNetworking.cs
+++ b/Source/Client/ClientNetworking.cs
@@ -97,7 +97,7 @@ namespace Multiplayer.Client
             }
             else
             {
-                var timeSpeed = Prefs.data.pauseOnLoad ? TimeSpeed.Paused : TimeSpeed.Normal;
+                var timeSpeed = TimeSpeed.Paused;
 
                 Multiplayer.WorldComp.TimeSpeed = timeSpeed;
                 foreach (var map in Find.Maps)

--- a/Source/Client/MultiplayerSession.cs
+++ b/Source/Client/MultiplayerSession.cs
@@ -301,6 +301,8 @@ namespace Multiplayer.Client
 
             SetThingMakerSeed(1);
 
+            Prefs.PauseOnLoad = false; // causes immediate desyncs on load if misaligned between host and clients
+
             foreach (var field in typeof(DebugSettings).GetFields(BindingFlags.Public | BindingFlags.Static))
                 if (!field.IsLiteral && field.FieldType == typeof(bool))
                     field.SetValue(null, default(bool));

--- a/Source/Client/TickPatch.cs
+++ b/Source/Client/TickPatch.cs
@@ -237,17 +237,4 @@ namespace Multiplayer.Client
 
         void ExecuteCmd(ScheduledCommand cmd);
     }
-
-    [HarmonyPatch(typeof(Prefs))]
-    [HarmonyPatch(nameof(Prefs.PauseOnLoad), MethodType.Getter)]
-    public static class CancelSingleTick
-    {
-        // Cancel ticking after loading as its handled seperately
-        static void Postfix(ref bool __result)
-        {
-            if (Multiplayer.Client != null)
-                __result = false;
-        }
-    }
-
 }


### PR DESCRIPTION
Several players in the Discord reported "immediate desync on connect" with no mods on a basic map, in at least 2 cases this was confirmed to be solved by making sure both host and client had the same state for the vanilla setting PauseOnLoad.

There were already patches in place that tried to make the setting return false in multiplayer (`return true` in a Prefix() for a getter = skip the getter = default to false I'm assuming?), but oddly these did not prevent the desync. Viewing a full decompile, I'm baffled as to how the game is circumventing the getter: the patches look valid and are emitting Log.Message("test")'s, just not where it counts?

I'm now both forcing the setter to always set false, and triggering that setter on MultiplayerSession boot, which seems to quell the desync.