### PR TITLE
Hookup Async Time + allow enabling on existing saves

### DIFF
--- a/Source/Client/Comp/MapAsyncTime.cs
+++ b/Source/Client/Comp/MapAsyncTime.cs
@@ -147,7 +147,7 @@ namespace Multiplayer.Client
             if (!WorldRendererUtility.WorldRenderedNow && Find.CurrentMap == null) return;
 
             ITickable tickable = Multiplayer.WorldComp;
-            if (!WorldRendererUtility.WorldRenderedNow && Multiplayer.WorldComp.asyncTime)
+            if (!WorldRendererUtility.WorldRenderedNow && MultiplayerWorldComp.asyncTime)
                 tickable = Find.CurrentMap.AsyncTime();
 
             TimeSpeed speed = tickable.TimeSpeed;
@@ -263,7 +263,7 @@ namespace Multiplayer.Client
                 Rect button = new Rect(rect.x - TimeControls.TimeButSize.x / 2f, rect.yMax - TimeControls.TimeButSize.y / 2f, TimeControls.TimeButSize.x, TimeControls.TimeButSize.y);
                 var asyncTime = entry.map.AsyncTime();
 
-                if (Multiplayer.WorldComp.asyncTime)
+                if (MultiplayerWorldComp.asyncTime)
                 {
                     TimeControl.TimeControlButton(button, asyncTime, alpha);
                 }
@@ -287,7 +287,7 @@ namespace Multiplayer.Client
             if (__instance.def != MainButtonDefOf.World) return;
             if (__instance.Disabled) return;
             if (Find.CurrentMap == null) return;
-            if (!Multiplayer.WorldComp.asyncTime) return;
+            if (!MultiplayerWorldComp.asyncTime) return;
 
             Rect button = new Rect(rect.xMax - TimeControls.TimeButSize.x - 5f, rect.y + (rect.height - TimeControls.TimeButSize.y) / 2f, TimeControls.TimeButSize.x, TimeControls.TimeButSize.y);
             __state = button;
@@ -722,7 +722,7 @@ namespace Multiplayer.Client
                     HandleMapFactionData(cmd, data);
                 }
 
-                if (cmdType == CommandType.MapTimeSpeed && Multiplayer.WorldComp.asyncTime)
+                if (cmdType == CommandType.MapTimeSpeed && MultiplayerWorldComp.asyncTime)
                 {
                     TimeSpeed speed = (TimeSpeed)data.ReadByte();
                     TimeSpeed = speed;

--- a/Source/Client/Comp/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/MultiplayerWorldComp.cs
@@ -54,7 +54,7 @@ namespace Multiplayer.Client
         public World world;
         public IdBlock globalIdBlock;
         public ulong randState = 2;
-        public bool asyncTime;
+        public static bool asyncTime;
         public bool debugMode;
         public bool logDesyncTraces;
         public TileTemperaturesComp uiTemperatures;

--- a/Source/Client/Comp/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/MultiplayerWorldComp.cs
@@ -73,7 +73,14 @@ namespace Multiplayer.Client
         public void ExposeData()
         {
             Scribe_Values.Look(ref TickPatch.Timer, "timer");
-            Scribe_Values.Look(ref asyncTime, "asyncTime", true, true); // Enable async time on old saves
+            bool asyncTimeInSave = asyncTime;
+            Scribe_Values.Look(ref asyncTimeInSave, "asyncTime", true, true); // default true to Enable async time on old saves
+            if (Scribe.mode == LoadSaveMode.LoadingVars) {
+                if (asyncTimeInSave) {
+                    // it was previously on, and cannot be turned off, so override the menu setting for this save
+                    asyncTime = asyncTimeInSave;
+                }
+            }
             Scribe_Values.Look(ref debugMode, "debugMode");
             Scribe_Values.Look(ref logDesyncTraces, "logDesyncTraces");
             ScribeUtil.LookULong(ref randState, "randState", 2);

--- a/Source/Client/MainButtons.cs
+++ b/Source/Client/MainButtons.cs
@@ -78,7 +78,7 @@ namespace Multiplayer.Client
                 text.Append($"\n{Sync.bufferedChanges.Sum(kv => kv.Value.Count)}");
                 text.Append($"\n{((uint)async.randState)} {(uint)(async.randState >> 32)}");
                 text.Append($"\n{(uint)Multiplayer.WorldComp.randState} {(uint)(Multiplayer.WorldComp.randState >> 32)}");
-                text.Append($"\n{async.cmds.Count} {Multiplayer.WorldComp.cmds.Count} {async.slower.forceNormalSpeedUntil} {Multiplayer.WorldComp.asyncTime}");
+                text.Append($"\n{async.cmds.Count} {Multiplayer.WorldComp.cmds.Count} {async.slower.forceNormalSpeedUntil} {MultiplayerWorldComp.asyncTime}");
 
                 Rect rect1 = new Rect(80f, 110f, 330f, Text.CalcHeight(text.ToString(), 330f));
                 Widgets.Label(rect1, text.ToString());

--- a/Source/Client/Patches.cs
+++ b/Source/Client/Patches.cs
@@ -1123,7 +1123,7 @@ namespace Multiplayer.Client
             async.storyteller = new Storyteller(Find.Storyteller.def, Find.Storyteller.difficulty);
             async.storyWatcher = new StoryWatcher();
 
-            if (!Multiplayer.WorldComp.asyncTime)
+            if (!MultiplayerWorldComp.asyncTime)
                 async.TimeSpeed = Find.TickManager.CurTimeSpeed;
         }
     }

--- a/Source/Client/Replays.cs
+++ b/Source/Client/Replays.cs
@@ -141,6 +141,7 @@ namespace Multiplayer.Client
                     modIds = LoadedModManager.RunningModsListForReading.Select(m => m.PackageId).ToList(),
                     modNames = LoadedModManager.RunningModsListForReading.Select(m => m.Name).ToList(),
                     modAssemblyHashes = Multiplayer.enabledModAssemblyHashes.Select(h => h.assemblyHash).ToList(),
+                    asyncTime = MultiplayerWorldComp.asyncTime,
                 }
             };
 
@@ -188,6 +189,9 @@ namespace Multiplayer.Client
         public List<string> modIds;
         public List<string> modNames;
         public List<int> modAssemblyHashes;
+
+        /// copied here for easy reading, source of truth is <see cref="MultiplayerWorldComp.asyncTime"/>
+        public bool asyncTime;
     }
 
     public class ReplaySection

--- a/Source/Client/TickPatch.cs
+++ b/Source/Client/TickPatch.cs
@@ -216,7 +216,7 @@ namespace Multiplayer.Client
 
         public static float ActualRateMultiplier(this ITickable tickable, TimeSpeed speed)
         {
-            if (Multiplayer.WorldComp.asyncTime)
+            if (MultiplayerWorldComp.asyncTime)
                 return tickable.TickRateMultiplier(speed);
 
             return Find.Maps.Select(m => (ITickable)m.AsyncTime()).Concat(Multiplayer.WorldComp).Select(t => t.TickRateMultiplier(speed)).Min();

--- a/Source/Client/Windows/HostWindow.cs
+++ b/Source/Client/Windows/HostWindow.cs
@@ -13,6 +13,7 @@ using Verse;
 using Verse.Profile;
 using Verse.Sound;
 using Verse.Steam;
+using Multiplayer.Client;
 
 namespace Multiplayer.Client
 {
@@ -23,7 +24,6 @@ namespace Multiplayer.Client
         private SaveFile file;
         public bool returnToServerBrowser;
         private bool withSimulation;
-        private bool asyncTime;
         private bool debugMode;
         private bool logDesyncTraces;
 
@@ -129,13 +129,13 @@ namespace Multiplayer.Client
                     CheckboxLabeled(entry.Width(checkboxWidth), "The Arbiter:  ", ref settings.arbiter, placeTextNearCheckbox: true);
                     entry = entry.Down(30);
                 }
+            }
 
-                // AsyncTime
-                {
-                    TooltipHandler.TipRegion(entry.Width(checkboxWidth), $"{"MpAsyncTimeDesc".Translate()}\n\n{"MpExperimentalFeature".Translate()}");
-                    CheckboxLabeled(entry.Width(checkboxWidth), "Async time:  ", ref asyncTime, placeTextNearCheckbox: true);
-                    entry = entry.Down(30);
-                }
+            // AsyncTime
+            {
+                TooltipHandler.TipRegion(entry.Width(checkboxWidth), $"{"MpAsyncTimeDesc".Translate()}\n\n{"MpExperimentalFeature".Translate()}");
+                CheckboxLabeled(entry.Width(checkboxWidth), "Async time:  ", ref MultiplayerWorldComp.asyncTime, placeTextNearCheckbox: true);
+                entry = entry.Down(30);
             }
 
             TooltipHandler.TipRegion(entry.Width(checkboxWidth), $"{"MpLogDesyncTracesDesc".Translate()}\n\n{"MpExperimentalFeature".Translate()}");
@@ -296,10 +296,10 @@ namespace Multiplayer.Client
             if (file != null)
             {
                 Replay.LoadReplay(
-                    file.file, 
-                    true, 
-                    ReplayLoaded, 
-                    cancel: GenScene.GoToMainMenu, 
+                    file.file,
+                    true,
+                    ReplayLoaded,
+                    cancel: GenScene.GoToMainMenu,
                     simTextKey: "MpSimulatingServer"
                 );
             }

--- a/Source/Client/Windows/HostWindow.cs
+++ b/Source/Client/Windows/HostWindow.cs
@@ -26,6 +26,7 @@ namespace Multiplayer.Client
         private bool withSimulation;
         private bool debugMode;
         private bool logDesyncTraces;
+        private bool asyncTimeLocked;
 
         private float height;
 
@@ -41,6 +42,11 @@ namespace Multiplayer.Client
             this.withSimulation = withSimulation;
             this.file = file;
             settings.gameName = file?.gameName ?? Multiplayer.session?.gameName ?? $"{Multiplayer.username}'s game";
+
+            MultiplayerWorldComp.asyncTime = file?.asyncTime ?? false;
+            if (file?.asyncTime ?? false) {
+                asyncTimeLocked = true; // once enabled in a save, cannot be disabled
+            }
 
             var localAddr = MpUtil.GetLocalIpAddress() ?? "127.0.0.1";
             settings.lanAddress = localAddr;
@@ -134,7 +140,7 @@ namespace Multiplayer.Client
             // AsyncTime
             {
                 TooltipHandler.TipRegion(entry.Width(checkboxWidth), $"{"MpAsyncTimeDesc".Translate()}\n\n{"MpExperimentalFeature".Translate()}");
-                CheckboxLabeled(entry.Width(checkboxWidth), "Async time:  ", ref MultiplayerWorldComp.asyncTime, placeTextNearCheckbox: true);
+                CheckboxLabeled(entry.Width(checkboxWidth), "Async time:  ", ref MultiplayerWorldComp.asyncTime, placeTextNearCheckbox: true, disabled: asyncTimeLocked);
                 entry = entry.Down(30);
             }
 

--- a/Source/Client/Windows/ServerBrowser.cs
+++ b/Source/Client/Windows/ServerBrowser.cs
@@ -138,6 +138,7 @@ namespace Multiplayer.Client
                         saveFile.modIds = replay.info.modIds.ToArray();
                         saveFile.modNames = replay.info.modNames.ToArray();
                         saveFile.modAssemblyHashes = replay.info.modAssemblyHashes.ToArray();
+                        saveFile.asyncTime = replay.info.asyncTime;
                     }
                     else
                     {
@@ -733,6 +734,7 @@ namespace Multiplayer.Client
         public int[] modAssemblyHashes = new int[0];
 
         public int protocol;
+        public bool asyncTime;
 
         public bool Valid => rwVersion != null;
 


### PR DESCRIPTION
Parexy's #10 hooked up the Async Time setting to actually work, but was kinda a messy PR so hasn't been merged yet.

In testing, I found the checkbox misleadingly useless, as loading a replay would always use the replay's state of AsyncTime. I'm now allowing enabling AsyncTime for existing replays, and disabling the checkbox (so its locked on) if the save says it has AsyncTime enabled.