### PR TITLE
Sync 'Call Royal Aid' + 'Assign to Throne'

### DIFF
--- a/Source/Client/Persistent/PersistentDialogs.cs
+++ b/Source/Client/Persistent/PersistentDialogs.cs
@@ -165,7 +165,7 @@ namespace Multiplayer.Client
         /// <param name="dialog">Any window</param>
         public static PersistentDialog FindDialog(Window dialog)
         {
-            return Find.Maps.SelectMany(m => m.MpComp().mapDialogs).FirstOrDefault(d => d.Dialog == dialog);
+            return Find.Maps?.SelectMany(m => m.MpComp().mapDialogs).FirstOrDefault(d => d.Dialog == dialog);
         }
 
         /// <summary>

--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -665,6 +665,18 @@ namespace Multiplayer.Client
             },
             #endregion
 
+            #region RoyalTitlePermitWorker
+            {
+                (ByteWriter data, RoyalTitlePermitWorker worker) => {
+                    WriteSync(data, worker.def);
+                },
+                (ByteReader data) => {
+                    RoyalTitlePermitDef def = ReadSync<RoyalTitlePermitDef>(data);
+                    return def?.Worker;
+                }, true
+            },
+            #endregion
+
             #region Databases
 
             { (SyncWorker data, ref OutfitDatabase db) => db = Current.Game.outfitDatabase },

--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -509,6 +509,7 @@ namespace Multiplayer.Client
 
             SyncMethod.Register(typeof(Quest), nameof(Quest.Accept));
             SyncMethod.Register(typeof(Verb_CastAbility), nameof(Verb_CastAbility.OrderForceTarget));
+            SyncMethod.Register(typeof(RoyalTitlePermitWorker_CallAid), nameof(RoyalTitlePermitWorker_CallAid.CallAid)).CancelIfAnyArgNull();
 
             // 1
             SyncMethod.Register(typeof(TradeRequestComp), nameof(TradeRequestComp.Fulfill)).CancelIfAnyArgNull().SetVersion(1);

--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -468,6 +468,8 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(Building_Bed), nameof(Building_Bed.Medical));
             SyncMethod.Register(typeof(CompAssignableToPawn_Grave), nameof(CompAssignableToPawn_Grave.TryAssignPawn)).CancelIfAnyArgNull();
             SyncMethod.Register(typeof(CompAssignableToPawn_Grave), nameof(CompAssignableToPawn_Grave.TryUnassignPawn)).CancelIfAnyArgNull();
+            SyncMethod.Register(typeof(CompAssignableToPawn_Throne), nameof(CompAssignableToPawn_Throne.TryAssignPawn)).CancelIfAnyArgNull();
+            SyncMethod.Register(typeof(CompAssignableToPawn_Throne), nameof(CompAssignableToPawn_Throne.TryUnassignPawn)).CancelIfAnyArgNull();
             SyncMethod.Register(typeof(PawnColumnWorker_Designator), nameof(PawnColumnWorker_Designator.SetValue)).CancelIfAnyArgNull(); // Virtual but currently not overriden by any subclasses
             SyncMethod.Register(typeof(PawnColumnWorker_FollowDrafted), nameof(PawnColumnWorker_FollowDrafted.SetValue)).CancelIfAnyArgNull();
             SyncMethod.Register(typeof(PawnColumnWorker_FollowFieldwork), nameof(PawnColumnWorker_FollowFieldwork.SetValue)).CancelIfAnyArgNull();


### PR DESCRIPTION
* Fix desync "Call Royal Aid" (button next to Draft on any pawn with rank)
* Fix desync "Assign Pawn to Throne" (just like assigning a bed)
* Fix a, probably harmless but red, null reference exception that seems to happen on main menu load