### PR TITLE
Auto sync Mods + Mod Configs on Connect

### DIFF
--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -19,6 +19,7 @@
   <MpSyncModList>Autosync Mod List</MpSyncModList>
   <MpSeeModList>See mod list</MpSeeModList>
   <MpDownloadingWorkshopMods>Downloading Workshop Mods</MpDownloadingWorkshopMods>
+  <MpRestoreLastConfigs>Restore Last Configs</MpRestoreLastConfigs>
   
   <MpServerClosed>Server closed</MpServerClosed>
   <MpServerFull>Server is full</MpServerFull>

--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -15,8 +15,13 @@
   
   <MpWrongDefs>Mod definition mismatch</MpWrongDefs>
   <MpWrongDefsInfo>Make sure your installed mods, their versions and order match the host's.</MpWrongDefsInfo>
+  <MpWrongModConfigs>Mod configs mismatch</MpWrongModConfigs>
+  <MpWrongModConfigsInfo>Your mod configs differ from the host's, sync them for best results.</MpWrongModConfigsInfo>
   <MpModList>Mod list</MpModList>
-  <MpSyncModList>Autosync Mod List</MpSyncModList>
+  <MpSyncModsAndConfigs>Sync Mods &amp; Configs</MpSyncModsAndConfigs>
+  <MpSyncMods>Sync Mods</MpSyncMods>
+  <MpSyncModConfigs>Sync Mod Configs</MpSyncModConfigs>
+  <MpSyncModConfigsDesc>Forces clients to download the same mod configs as the host; reduces desyncs</MpSyncModConfigsDesc>
   <MpSeeModList>See mod list</MpSeeModList>
   <MpDownloadingWorkshopMods>Downloading Workshop Mods</MpDownloadingWorkshopMods>
   <MpRestoreLastConfigs>Restore Last Configs</MpRestoreLastConfigs>
@@ -51,8 +56,6 @@
   <MpShowPlayerCursors>Show player cursors</MpShowPlayerCursors>
   <MpAutoAcceptSteam>Auto-accept Steam</MpAutoAcceptSteam>
   <MpAutoAcceptSteamDesc>Automatically accept any incoming Steam connection requests.</MpAutoAcceptSteamDesc>
-  <MpSyncModConfigs>Sync Mod Configs</MpSyncModConfigs>
-  <MpSyncModConfigsDesc>Forces clients to download the same mod configs as the host; reduces desyncs</MpSyncModConfigsDesc>
   <MpTransparentChat>Transparent chat</MpTransparentChat>
   
   <MpAutosaveSlots>Autosave slots</MpAutosaveSlots>

--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -51,6 +51,8 @@
   <MpShowPlayerCursors>Show player cursors</MpShowPlayerCursors>
   <MpAutoAcceptSteam>Auto-accept Steam</MpAutoAcceptSteam>
   <MpAutoAcceptSteamDesc>Automatically accept any incoming Steam connection requests.</MpAutoAcceptSteamDesc>
+  <MpSyncModConfigs>Sync Mod Configs</MpSyncModConfigs>
+  <MpSyncModConfigsDesc>Forces clients to download the same mod configs as the host; reduces desyncs</MpSyncModConfigsDesc>
   <MpTransparentChat>Transparent chat</MpTransparentChat>
   
   <MpAutosaveSlots>Autosave slots</MpAutosaveSlots>

--- a/Source/Client/ClientConnection.cs
+++ b/Source/Client/ClientConnection.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
+using RestSharp;
 using UnityEngine;
 using Verse;
 using Verse.Profile;
@@ -36,11 +37,8 @@ namespace Multiplayer.Client
             Multiplayer.session.mods.remoteModIds = data.ReadPrefixedStrings();
             Multiplayer.session.mods.remoteWorkshopModIds = data.ReadPrefixedULongs();
 
-            var remoteModConfigFilenames = data.ReadPrefixedStrings();
-            var remoteModConfigContents = data.ReadPrefixedStrings();
-            Multiplayer.session.mods.remoteModConfigs = remoteModConfigFilenames
-                .Zip(remoteModConfigContents, (k, v) => new {k, v})
-                .ToDictionary(x => x.k, x => x.v);
+            var modConfigsCompressed = data.ReadPrefixedBytes();
+            Multiplayer.session.mods.remoteModConfigs = SimpleJson.DeserializeObject<Dictionary<string, string>>(GZipStream.UncompressString(modConfigsCompressed));
 
             var defs = Multiplayer.localDefInfos;
             Multiplayer.session.mods.defInfo = defs;

--- a/Source/Client/ClientConnection.cs
+++ b/Source/Client/ClientConnection.cs
@@ -43,13 +43,6 @@ namespace Multiplayer.Client
             var defs = Multiplayer.localDefInfos;
             Multiplayer.session.mods.defInfo = defs;
 
-            var endPoint = Multiplayer.session?.netClient?.FirstPeer?.EndPoint;
-            if (endPoint?.Address != null) {
-                // todo: why is this sometimes null? It means the "auto reconnect after changing mods" won't work
-                Multiplayer.session.mods.remoteAddress = endPoint.Address.ToString();
-                Multiplayer.session.mods.remotePort = endPoint.Port;
-            }
-
             if (!ModManagement.CheckModConfigsMatch(Multiplayer.session.mods.remoteModConfigs)) {
                 connection.Close();
                 connection.State = ConnectionStateEnum.Disconnected;

--- a/Source/Client/ClientConnection.cs
+++ b/Source/Client/ClientConnection.cs
@@ -44,6 +44,7 @@ namespace Multiplayer.Client
             Multiplayer.session.mods.defInfo = defs;
 
             if (!ModManagement.CheckModConfigsMatch(Multiplayer.session.mods.remoteModConfigs)) {
+                Log.Message("MP: Mod Configs Mismatch, disconnecting");
                 connection.Close();
                 connection.State = ConnectionStateEnum.Disconnected;
                 Multiplayer.session.disconnectReason = MpDisconnectReason.Defs;

--- a/Source/Client/ClientConnection.cs
+++ b/Source/Client/ClientConnection.cs
@@ -30,6 +30,7 @@ namespace Multiplayer.Client
         }
 
         [PacketHandler(Packets.Server_ModList)]
+        [IsFragmented]
         public void HandleModList(ByteReader data)
         {
             Multiplayer.session.mods.remoteRwVersion = data.ReadString();

--- a/Source/Client/ClientNetworking.cs
+++ b/Source/Client/ClientNetworking.cs
@@ -22,6 +22,8 @@ namespace Multiplayer.Client
         public static void TryConnect(string address, int port)
         {
             Multiplayer.session = new MultiplayerSession();
+            Multiplayer.session.mods.remoteAddress = address;
+            Multiplayer.session.mods.remotePort = port;
             NetManager netClient = new NetManager(new MpClientNetListener());
 
             netClient.Start();

--- a/Source/Client/ModManagement.cs
+++ b/Source/Client/ModManagement.cs
@@ -200,7 +200,10 @@ namespace Multiplayer.Client
                    && file.Name != "ModsConfig.xml" // already synced at earlier step
                    && file.Name != "Prefs.xml" // base game stuff: volume, resolution, etc
                    && file.Name != "LastSeenNews.xml"
+                   && file.Name != "ColourPicker.xml"
                    && !file.Name.EndsWith("MultiplayerMod.xml") // contains username
+                   && !file.Name.EndsWith("ModManager.xml")
+                   && !file.Name.EndsWith("ModSwitch.xml")
                    && !file.DirectoryName.Contains("RimHUD");
         }
 

--- a/Source/Client/ModManagement.cs
+++ b/Source/Client/ModManagement.cs
@@ -214,6 +214,8 @@ namespace Multiplayer.Client
                    && !file.Name.EndsWith("MultiplayerMod.xml") // contains username
                    && !file.Name.EndsWith("ModManager.xml")
                    && !file.Name.EndsWith("ModSwitch.xml")
+                   && file.Name.IndexOf("backup", StringComparison.OrdinalIgnoreCase) == -1
+                   && file.DirectoryName.IndexOf("backup", StringComparison.OrdinalIgnoreCase) == -1
                    && !file.DirectoryName.Contains("RimHUD");
         }
 

--- a/Source/Client/ModManagement.cs
+++ b/Source/Client/ModManagement.cs
@@ -99,6 +99,7 @@ namespace Multiplayer.Client
             }
 
             var localConfigsBackupDir = GenFilePaths.FolderUnderSaveData($"LocalConfigsBackup-{DateTime.Now:yyyy-MM-ddTHH-mm-ss}");
+            (new DirectoryInfo(Path.Combine(localConfigsBackupDir, "Config"))).Create();
 
             foreach (var modConfigData in hostModConfigFiles) {
                 var relativeFilePath = modConfigData.Key.Replace('/', Path.DirectorySeparatorChar);

--- a/Source/Client/ModManagement.cs
+++ b/Source/Client/ModManagement.cs
@@ -91,9 +91,12 @@ namespace Multiplayer.Client
                 .Invoke(obj: null, parameters: new object[] { });
         }
 
-        public static void ApplyHostModConfigFiles()
+        public static void ApplyHostModConfigFiles(Dictionary<string, string> hostModConfigFiles)
         {
-            var hostModConfigFiles = Multiplayer.session.mods.remoteModConfigs;
+            if (hostModConfigFiles == null) {
+                Log.Warning("MP: hostModConfigFiles is null");
+                return;
+            }
             if (CheckModConfigsMatch(hostModConfigFiles)) {
                 return;
             }

--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -143,6 +143,7 @@ namespace Multiplayer.Client
             listing.CheckboxLabeled("MpAutoAcceptSteam".Translate(), ref settings.autoAcceptSteam, "MpAutoAcceptSteamDesc".Translate());
             listing.CheckboxLabeled("MpTransparentChat".Translate(), ref settings.transparentChat);
             listing.CheckboxLabeled("MpAggressiveTicking".Translate(), ref settings.aggressiveTicking, "MpAggressiveTickingDesc".Translate());
+            listing.CheckboxLabeled("MpSyncModConfigs".Translate(), ref settings.syncModConfigs, "MpSyncModConfigsDesc".Translate());
 
             var appendNameToAutosaveLabel = $"{"MpAppendNameToAutosave".Translate()}:  ";
             var appendNameToAutosaveLabelWidth = Text.CalcSize(appendNameToAutosaveLabel).x;
@@ -285,6 +286,7 @@ namespace Multiplayer.Client
         public bool transparentChat;
         public int autosaveSlots = 5;
         public bool aggressiveTicking = true;
+        public bool syncModConfigs = true;
         public bool showDevInfo;
         public string serverAddress = "127.0.0.1";
         public bool appendNameToAutosave;
@@ -300,6 +302,7 @@ namespace Multiplayer.Client
             Scribe_Values.Look(ref transparentChat, "transparentChat");
             Scribe_Values.Look(ref autosaveSlots, "autosaveSlots", 5);
             Scribe_Values.Look(ref aggressiveTicking, "aggressiveTicking", true);
+            Scribe_Values.Look(ref syncModConfigs, "syncModConfigs", true);
             Scribe_Values.Look(ref showDevInfo, "showDevInfo");
             Scribe_Values.Look(ref serverAddress, "serverAddress", "127.0.0.1");
             Scribe_Values.Look(ref pauseAutosaveCounter, "pauseAutosaveCounter", true);

--- a/Source/Client/MultiplayerSession.cs
+++ b/Source/Client/MultiplayerSession.cs
@@ -183,6 +183,7 @@ namespace Multiplayer.Client
         public string[] remoteModNames;
         public string[] remoteModIds;
         public ulong[] remoteWorkshopModIds;
+        public Dictionary<string, string> remoteModConfigs;
         public Dictionary<string, DefInfo> defInfo;
         public string remoteAddress;
         public int remotePort;

--- a/Source/Client/MultiplayerSession.cs
+++ b/Source/Client/MultiplayerSession.cs
@@ -165,10 +165,12 @@ namespace Multiplayer.Client
         {
             Find.WindowStack.windows.Clear();
 
-            if (disconnectReason != MpDisconnectReason.Defs)
-                Find.WindowStack.Add(new DisconnectedWindow(disconnectReasonKey, disconnectInfo) { returnToServerBrowser = Multiplayer.Client.State != ConnectionStateEnum.ClientPlaying });
-            else
+            if (disconnectReason == MpDisconnectReason.Defs) {
                 Find.WindowStack.Add(new DefMismatchWindow(mods));
+            }
+            else {
+                Find.WindowStack.Add(new DisconnectedWindow(disconnectReasonKey, disconnectInfo) {returnToServerBrowser = Multiplayer.Client.State != ConnectionStateEnum.ClientPlaying});
+            }
         }
 
         public void ReapplyPrefs()

--- a/Source/Client/Patches.cs
+++ b/Source/Client/Patches.cs
@@ -86,13 +86,23 @@ namespace Multiplayer.Client
                 int newColony = optList.FindIndex(opt => opt.label == "NewColony".Translate());
                 if (newColony != -1)
                 {
-                    optList.Insert(newColony + 1, new ListableOption("Multiplayer", () =>
+                    optList.Insert(newColony + 1, new ListableOption("MpMultiplayer".Translate(), () =>
                     {
                         if (Prefs.DevMode && Event.current.button == 1)
                             ShowModDebugInfo();
                         else
                             Find.WindowStack.Add(new ServerBrowser());
                     }));
+                }
+
+                int optionsIndex = optList.FindIndex(opt => opt.label == "Options".Translate());
+                if (optionsIndex != -1 && ModManagement.HasRecentConfigBackup()) {
+                    var option = new ListableOption("MpRestoreLastConfigs".Translate(), () => {
+                        ModManagement.RestoreConfigBackup(ModManagement.GetMostRecentConfigBackup());
+                        ModManagement.PromptRestart();
+                    });
+                    option.minHeight = 30f;
+                    optList.Insert(optionsIndex + 1, option);
                 }
             }
 

--- a/Source/Client/Sync/Sync.cs
+++ b/Source/Client/Sync/Sync.cs
@@ -1141,7 +1141,14 @@ namespace Multiplayer.Client
         public static void HandleCmd(ByteReader data)
         {
             int syncId = data.ReadInt32();
-            SyncHandler handler = handlers[syncId];
+            SyncHandler handler;
+            try {
+                handler = handlers[syncId];
+            }
+            catch (ArgumentOutOfRangeException) {
+                Log.Error($"Error: invalid syncId {syncId}/{handlers.Count}, this implies mismatched mods, ensure your versions match! Stacktrace follows.");
+                throw;
+            }
 
             List<object> prevSelected = Find.Selector.selected;
             List<WorldObject> prevWorldSelected = Find.WorldSelector.selected;

--- a/Source/Client/Windows/DisconnectedWindow.cs
+++ b/Source/Client/Windows/DisconnectedWindow.cs
@@ -108,6 +108,7 @@ namespace Multiplayer.Client
 
                 LongEventHandler.QueueLongEvent(() => {
                     ModManagement.DownloadWorkshopMods(mods.remoteWorkshopModIds);
+                    ModManagement.ApplyHostModConfigFiles();
                     try {
                         ModManagement.RebuildModsList();
                         ModsConfig.SetActiveToList(mods.remoteModIds.ToList());

--- a/Source/Client/Windows/DisconnectedWindow.cs
+++ b/Source/Client/Windows/DisconnectedWindow.cs
@@ -108,7 +108,7 @@ namespace Multiplayer.Client
 
                 LongEventHandler.QueueLongEvent(() => {
                     ModManagement.DownloadWorkshopMods(mods.remoteWorkshopModIds);
-                    ModManagement.ApplyHostModConfigFiles();
+                    ModManagement.ApplyHostModConfigFiles(mods.remoteModConfigs);
                     try {
                         ModManagement.RebuildModsList();
                         ModsConfig.SetActiveToList(mods.remoteModIds.ToList());

--- a/Source/Client/Windows/Windows.cs
+++ b/Source/Client/Windows/Windows.cs
@@ -394,7 +394,7 @@ namespace Multiplayer.Client
 
     public class TwoTextAreas_Window : Window
     {
-        public override Vector2 InitialSize => new Vector2(600, 300);
+        public override Vector2 InitialSize => new Vector2(600, 500);
 
         private Vector2 scroll1;
         private Vector2 scroll2;

--- a/Source/Common/Networking.cs
+++ b/Source/Common/Networking.cs
@@ -161,6 +161,10 @@ namespace Multiplayer.Common
                 read += len;
             }
         }
+        public virtual void SendFragmented(Packets id, params object[] msg)
+        {
+            SendFragmented(id, ByteWriter.GetBytes(msg));
+        }
 
         protected abstract void SendRaw(byte[] raw, bool reliable = true);
 

--- a/Source/Common/ServerConnection.cs
+++ b/Source/Common/ServerConnection.cs
@@ -28,7 +28,7 @@ namespace Multiplayer.Common
                 return;
             }
 
-            var modConfigFiles = ModManagement.GetSyncableConfigFiles();
+            var modConfigFiles = MultiplayerMod.settings.syncModConfigs ? ModManagement.GetSyncableConfigFiles() : new Dictionary<string, string>();
             // Compress configs, to keep packet size < 50kb limit. JSON encode first, as the many tiny files are better compressed together
             var modConfigsCompressed = GZipStream.CompressString(SimpleJson.SerializeObject(modConfigFiles));
             if (MpVersion.IsDebug) {

--- a/Source/Common/ServerConnection.cs
+++ b/Source/Common/ServerConnection.cs
@@ -39,7 +39,7 @@ namespace Multiplayer.Common
                 Log.Message($"modConfigsCompressed size: {modConfigsCompressed.Length}");
             }
 
-            connection.Send(Packets.Server_ModList, Server.rwVersion, Server.modNames, Server.modIds, Server.workshopModIds, modConfigsCompressed);
+            connection.SendFragmented(Packets.Server_ModList, Server.rwVersion, Server.modNames, Server.modIds, Server.workshopModIds, modConfigsCompressed);
         }
 
         [PacketHandler(Packets.Client_Defs)]


### PR DESCRIPTION
This extends #41 's Mod Downloading/Syncing, to include syncing Mod config files too! A dated backup of existing configs is created beforehand, and a 'Restore Last Configs' button is added to the Main Menu if a backup exists that's < 2 weeks old, which will reapply the backup configs (and previously enabled mods), allowing for quickly switching between Multiplayer and Singleplayer mod sets.

Configs are only overridden when the user hits 'Autosync Mods List' in the 'Mod mismatch!' connection error window.

After syncing, a restart is required to apply the new mods/configs - the client'll automatically reconnect to the server after initializing by utilizing `-connect` launch parameter.

Which configs to sync? Good question; for now I've a hardcoded blacklist of what not to sync (client specific stuff that won't cause desyncs). If we find the PR's adding to it cumbersome, we could later consider adding something to the MultiplayerApi for extending the blacklist, but I think its ok for now.

Closes #44 