### PR TITLE
Mod Compatibility: show tooltips, replace "hold shift" with setting (default on)

### DIFF
--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -119,6 +119,9 @@
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
   <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
   <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
+  <MpShowModCompatibility>Show Mod Compatibility</MpShowModCompatibility>
+  <MpShowModCompatibilityDesc>Enables showing of [4] crowd-sourced compatibility scores in Mods manager</MpShowModCompatibilityDesc>
+
   <MpLan>LAN</MpLan>
   <MpDirect>Direct</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Source/Client/ModPatches.cs
+++ b/Source/Client/ModPatches.cs
@@ -114,7 +114,7 @@ namespace Multiplayer.Client
 
         public static void ModManager_ButtonPrefix(object __instance, ModMetaData ____selected, Rect rect, Dictionary<string, string> ____modNameTruncationCache)
         {
-            if (!Input.GetKey(KeyCode.LeftShift)) return;
+            if (!MultiplayerMod.settings.showModCompatibility) return;
 
             var tooltip = "";
             var mod = ____selected;

--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using RestSharp;
 using HarmonyLib;
 using Multiplayer.Common;
 using RimWorld;
@@ -153,23 +151,8 @@ namespace Multiplayer.Client
                 RuntimeHelpers.RunClassConstructor(typeof(Text).TypeHandle);
             }
             else {
-                UpdateModCompatibilityDb();
+                ModManagement.UpdateModCompatibilityDb();
             }
-        }
-
-        private static void UpdateModCompatibilityDb()
-        {
-            Task.Run(() => {
-                var client = new RestClient("https://bot.rimworldmultiplayer.com/mod-compatibility?version=1.1");
-                try {
-                    var rawResponse = client.Get(new RestRequest($"", DataFormat.Json));
-                    modsCompatibility = SimpleJson.DeserializeObject<Dictionary<string, int>>(rawResponse.Content);
-                    Log.Message($"MP: successfully fetched {modsCompatibility.Count} mods compatibility info");
-                }
-                catch (Exception e) {
-                    Log.Warning($"MP: updating mod compatibility list failed {e.Message} {e.StackTrace}");
-                }
-            });
         }
 
         private static void SetUsername()

--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -150,6 +150,7 @@ namespace Multiplayer.Client
             listing.CheckboxLabeled(appendNameToAutosaveLabel, ref settings.appendNameToAutosave);
 
             listing.CheckboxLabeled("MpPauseAutosaveCounter".Translate(), ref settings.pauseAutosaveCounter, "MpPauseAutosaveCounterDesc".Translate());
+            listing.CheckboxLabeled("MpShowModCompatibility".Translate(), ref settings.showModCompatibility, "MpShowModCompatibilityDesc".Translate());
 
             if (Prefs.DevMode)
                 listing.CheckboxLabeled("Show debug info", ref settings.showDevInfo);
@@ -288,6 +289,7 @@ namespace Multiplayer.Client
         public string serverAddress = "127.0.0.1";
         public bool appendNameToAutosave;
         public bool pauseAutosaveCounter = true;
+        public bool showModCompatibility = true;
         public ServerSettings serverSettings;
 
         public override void ExposeData()
@@ -301,11 +303,16 @@ namespace Multiplayer.Client
             Scribe_Values.Look(ref showDevInfo, "showDevInfo");
             Scribe_Values.Look(ref serverAddress, "serverAddress", "127.0.0.1");
             Scribe_Values.Look(ref pauseAutosaveCounter, "pauseAutosaveCounter", true);
+            Scribe_Values.Look(ref showModCompatibility, "showModCompatibility", true);
 
             Scribe_Deep.Look(ref serverSettings, "serverSettings");
 
             if (serverSettings == null)
                 serverSettings = new ServerSettings();
+
+            if (Scribe.mode == LoadSaveMode.Saving && showModCompatibility && Multiplayer.modsCompatibility.Count == 0) {
+                ModManagement.UpdateModCompatibilityDb();
+            }
         }
     }
 }


### PR DESCRIPTION
Most users don't know about "hold shift to show mod compatibility", so lets make it on by default, and add a setting to disable it.

Also, what's `[4]` mean? Now there's tooltips explaining!