### PR TITLE
Comms Console: fixed window open loop; Fix trading tooltip

### DIFF
--- a/Source/Client/Comp/MultiplayerMapComp.cs
+++ b/Source/Client/Comp/MultiplayerMapComp.cs
@@ -206,9 +206,10 @@ namespace Multiplayer.Client
 
             if (comp.mapDialogs.Any())
             {
+                var newDialog = comp.mapDialogs.First().Dialog;
                 //If NO mapdialogs (Dialog_NodeTrees) are open, add the first one to the window stack
-                if (!Find.WindowStack.IsOpen(typeof(Dialog_NodeTree))) {
-                    Find.WindowStack.Add(comp.mapDialogs.First().Dialog);
+                if (!Find.WindowStack.IsOpen(typeof(Dialog_NodeTree)) && !Find.WindowStack.IsOpen(newDialog.GetType())) {
+                    Find.WindowStack.Add(newDialog);
                 }
             }
             else if (comp.caravanForming != null)

--- a/Source/Client/Persistent/TradingUI.cs
+++ b/Source/Client/Persistent/TradingUI.cs
@@ -416,6 +416,7 @@ namespace Multiplayer.Client
         {
             yield return AccessTools.Method(typeof(Dialog_Trade), "<DoWindowContents>b__60_0");
             yield return AccessTools.Method(typeof(Dialog_Trade), "<DoWindowContents>b__60_1");
+            yield return AccessTools.Method(typeof(Tradeable), nameof(Tradeable.GetPriceTooltip));
         }
         static void Prefix(ref bool __state)
         {


### PR DESCRIPTION
The Comms Console opens a `Dialog_Negotiation`, which is a subclass of `Dialog_NodeTree`, but wasn't being caught by the current check - causing an infinite opening loop. Fixes #60 