### PR TITLE
Fixed filter subcategories erroring as of 1.1.2609

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -7,7 +7,8 @@
   </supportedVersions>
   <author>Zetrith</author>
   <url>https://github.com/rwmt/Multiplayer</url>
-  <description>&lt;color=red&gt;&lt;b&gt;Important: &lt;/b&gt; This mod should be loaded as early as possible to work properly!&lt;/color&gt;\n
+  <description>&lt;color=red&gt;&lt;b&gt;Important: &lt;/b&gt; This mod should be loaded as early as possible to work properly!
+Requires >= Rimworld v1.1.2609&lt;/color&gt;\n
 Multiplayer mod for rimworld.
     
 This is version 0.5-BETA

--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -745,7 +745,7 @@ namespace Multiplayer.Client
         static void ThingFilter_AllowCategory_Helper(ThingFilter filter, ThingCategoryDef categoryDef, bool allow, ThingFilter parentfilter, IEnumerable<ThingDef> forceHiddenDefs, IEnumerable<SpecialThingFilterDef> forceHiddenFilters)
         {
             Listing_TreeThingFilter listing = new Listing_TreeThingFilter(filter, parentfilter, forceHiddenDefs, forceHiddenFilters, null);
-            listing.CalculateHiddenSpecialFilters();
+            listing.CalculateHiddenSpecialFilters(new TreeNode_ThingCategory(categoryDef));
             filter.SetAllow(categoryDef, allow, forceHiddenDefs, listing.hiddenSpecialFilters);
         }
     }


### PR DESCRIPTION
Latest update changed signature of `CalculateHiddenSpecialFilters()` to need an argument

Fixes clicking 'Meals' subcategory in the Acceptable Food filter erroring.