### PR TITLE
Fix Vertigo Pulse ability desyncing

### DIFF
--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -83,7 +83,7 @@ namespace Multiplayer.Client
             { (SyncWorker sync, ref object obj)  => { } },
             {
                 (ByteWriter data, object obj) => {
-            
+
                 },
                 (ByteReader data) => {
                     return null;
@@ -238,7 +238,9 @@ namespace Multiplayer.Client
                     var pawn = ReadSync<Pawn>(data);
                     var uniqueVerbOwnerID = data.ReadString();
 
-                    return pawn.abilities.abilities.Find(ab => ab.UniqueVerbOwnerID() == uniqueVerbOwnerID);
+                    var ability = pawn.abilities.abilities.Find(ab => ab.UniqueVerbOwnerID() == uniqueVerbOwnerID);
+                    var unused = ability.EffectComps; // this getter lazy-initializes ability.effectComps: required for using Vertigo Pulse
+                    return ability;
                 }, true
             },
             {
@@ -926,7 +928,7 @@ namespace Multiplayer.Client
                         throw new SerializationException($"Unknown ISelectable type: {obj.GetType()}");
                     }
                 },
-                (ByteReader data) => {                
+                (ByteReader data) => {
                     ISelectableImpl impl = ReadSync<ISelectableImpl>(data);
 
                     if (impl == ISelectableImpl.None)


### PR DESCRIPTION
`ability.effectComps` must be initialized (which its getter, EffectComps, will do) prior to casting, or the foreach() over `this.ability.effectComps` will throw a null error. If only Rimworld's internals used their own getters...

For reference, the getter looks like
```
    public List<CompAbilityEffect> EffectComps
    {
      get
      {
        if (this.effectComps == null)
          this.effectComps = this.CompsOfType<CompAbilityEffect>().ToList<CompAbilityEffect>();
        return this.effectComps;
      }
    }
```