### PR TITLE
Sync 'Skip' psychic ability (has source + dest targets)

### DIFF
--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -244,6 +244,15 @@ namespace Multiplayer.Client
                 }, true
             },
             {
+                (ByteWriter data, CompAbilityEffect_WithDest compAbilityEffect) => {
+                    WriteSync(data, compAbilityEffect.parent);
+                },
+                (ByteReader data) => {
+                    var ability = ReadSync<Ability>(data);
+                    return ability.CompOfType<CompAbilityEffect_WithDest>();
+                }
+            },
+            {
                 (ByteWriter data, Verb_CastAbility verb) => {
                     if (verb.DirectOwner is Pawn pawn) {
                         WriteSync(data, VerbOwnerType.Pawn);

--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -510,7 +510,8 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(Command_LoadToTransporter), nameof(Command_LoadToTransporter.ProcessInput));
 
             SyncMethod.Register(typeof(Quest), nameof(Quest.Accept));
-            SyncMethod.Register(typeof(Verb_CastAbility), nameof(Verb_CastAbility.OrderForceTarget));
+            SyncMethod.Register(typeof(Verb_CastAbility), nameof(Verb_CastAbility.OrderForceTarget)); // single target Psychic abilities
+            SyncMethod.Register(typeof(CompAbilityEffect_WithDest), nameof(CompAbilityEffect_WithDest.OrderForceTarget)); // Psychic abilities with a source + destination, such as Skip (warp enemy to target place)
             SyncMethod.Register(typeof(RoyalTitlePermitWorker_CallAid), nameof(RoyalTitlePermitWorker_CallAid.CallAid)).CancelIfAnyArgNull();
 
             // 1


### PR DESCRIPTION
Most psychic abilities have a single target.
Apparently "Skip" has two (select a pawn to teleport, and a destination), this syncs the second one.