### PR TITLE
#72: Added song synchronization between host and clients

### DIFF
--- a/Source/Client/Comp/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/MultiplayerWorldComp.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Multiplayer.Common;
 using RimWorld;
 using RimWorld.Planet;
@@ -277,6 +277,15 @@ namespace Multiplayer.Client
                 {
                     LongEventHandler.QueueLongEvent(DoAutosave, "MpSaving", false, null);
                 }
+
+                if (cmdType == CommandType.SongUpdate)
+                {
+                    // Only clients should handle SongUpdate commands
+                    if (MultiplayerServer.instance == null)
+                    {
+                        HandleSongUpdate(cmd, data);
+                    }
+                }
             }
             catch (Exception e)
             {
@@ -383,6 +392,31 @@ namespace Multiplayer.Client
 
                 MpLog.Log($"New faction {faction.GetUniqueLoadID()}");
             }
+        }
+
+        private void HandleSongUpdate(ScheduledCommand command, ByteReader data)
+        {
+            float time = data.ReadFloat();
+            int maxlen = data.ReadInt32();
+
+            if (maxlen > 64)
+            {
+                Log.Error($"Song Path Len Exceeded Max: {maxlen}");
+                return;
+            }
+
+            string path = data.ReadString(maxlen);
+
+            IEnumerable<SongDef> source = from x in DefDatabase<SongDef>.defsList where x.clipPath.Equals(path) select x;
+            if (source.Count() != 1)
+            {
+                Log.Error($"Song Path Count is: {source.Count()} for song \"{path}\"");
+                return;
+            }
+
+            Log.Message($"Playing received song \"{path}\" at time {time}");
+            Find.MusicManagerPlay.ForceStartSong(source.First(), false);
+            Find.MusicManagerPlay.audioSource.time = time;
         }
 
         public void DirtyColonyTradeForMap(Map map)

--- a/Source/Client/Comp/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/MultiplayerWorldComp.cs
@@ -397,25 +397,18 @@ namespace Multiplayer.Client
         private void HandleSongUpdate(ScheduledCommand command, ByteReader data)
         {
             float time = data.ReadFloat();
-            int maxlen = data.ReadInt32();
+            string path = data.ReadString();
 
-            if (maxlen > 64)
+            SongDef requestedSong = DefDatabase<SongDef>.defsList.Find(song => song.clipPath.Equals(path)); 
+            if (requestedSong == null)
             {
-                Log.Error($"Song Path Len Exceeded Max: {maxlen}");
-                return;
-            }
-
-            string path = data.ReadString(maxlen);
-
-            IEnumerable<SongDef> source = from x in DefDatabase<SongDef>.defsList where x.clipPath.Equals(path) select x;
-            if (source.Count() != 1)
-            {
-                Log.Error($"Song Path Count is: {source.Count()} for song \"{path}\"");
+                Log.Error($"Could not find SongDef for song with path: \"{path}\"");
                 return;
             }
 
             Log.Message($"Playing received song \"{path}\" at time {time}");
-            Find.MusicManagerPlay.ForceStartSong(source.First(), false);
+            Find.MusicManagerPlay.MusicUpdate();
+            Find.MusicManagerPlay.ForceStartSong(requestedSong, false);
             Find.MusicManagerPlay.audioSource.time = time;
         }
 

--- a/Source/Client/Patches.cs
+++ b/Source/Client/Patches.cs
@@ -1627,7 +1627,6 @@ namespace Multiplayer.Client
             // if a song is being played, lets notify the clients of the song
             ByteWriter data = new ByteWriter();
             data.WriteFloat(__instance.audioSource.time);
-            data.WriteInt32(__instance.lastStartedSong.clipPath.Length);
             data.WriteString(__instance.lastStartedSong.clipPath);
 
             MultiplayerServer.instance.SendCommand(CommandType.SongUpdate, ScheduledCommand.NoFaction, ScheduledCommand.Global, data.ToArray());

--- a/Source/Common/Commands.cs
+++ b/Source/Common/Commands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Multiplayer.Common
 {
@@ -11,6 +11,7 @@ namespace Multiplayer.Common
         GlobalIdBlock,
         FactionOnline,
         FactionOffline,
+        SongUpdate,
 
         // Mixed scope
         Sync,


### PR DESCRIPTION
Added synchronization of soundtrack between the host and the clients.
Since the soundtrack is not saved in the replay or the saves, I implemented it using a new command.
In multiplayer, the clients (not the host) do not choose or automatically play any non-forced music and the host sends an update for each song that is starting to play. When the clients receive the update, the forcibly play the songs.