### PR TITLE
Mod Compatibility: show notes in tooltip; lookup by name fallback

### DIFF
--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -135,5 +135,6 @@
   
   <MpAggressiveTicking>Aggressive ticking</MpAggressiveTicking>
   <MpAggressiveTickingDesc>Always try to automatically catch up with the server at the cost of FPS.</MpAggressiveTickingDesc>
+  <MpMultiplayerCompatibility>MP Compatibility</MpMultiplayerCompatibility>
   
 </LanguageData>

--- a/Source/Client/ModCompatibilityManager.cs
+++ b/Source/Client/ModCompatibilityManager.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using RestSharp;
+using Steamworks;
+using Verse;
+
+namespace Multiplayer.Client
+{
+    public static class ModCompatibilityManager
+    {
+        private static bool startedLazyFetch;
+
+        private static Dictionary<long, ModCompatibility> workshopLookup = new Dictionary<long, ModCompatibility>();
+        private static Dictionary<string, ModCompatibility> nameLookup = new Dictionary<string, ModCompatibility>();
+
+        private static void UpdateModCompatibilityDb() {
+            startedLazyFetch = true;
+
+            Task.Run(() => {
+                var client = new RestClient("https://bot.rimworldmultiplayer.com/mod-compatibility?version=1.1&format=metadata");
+                try {
+                    var rawResponse = client.Get(new RestRequest($"", DataFormat.Json));
+                    var modCompatibilities = SimpleJson.DeserializeObject<List<ModCompatibility>>(rawResponse.Content);
+                    Log.Message($"MP: successfully fetched {modCompatibilities.Count} mods compatibility info");
+
+                    workshopLookup = modCompatibilities
+                        .GroupBy(mod => mod.workshopId)
+                        .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
+                    workshopLookup.Remove(0);
+                    nameLookup = modCompatibilities
+                        .GroupBy(mod => mod.name.ToLower())
+                        .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
+                }
+                catch (Exception e) {
+                    Log.Warning($"MP: updating mod compatibility list failed {e.Message} {e.StackTrace}");
+                }
+            });
+        }
+
+        public static ModCompatibility LookupByWorkshopId(PublishedFileId_t workshopId) {
+            return LookupByWorkshopId(workshopId.m_PublishedFileId);
+        }
+
+        public static ModCompatibility LookupByWorkshopId(ulong workshopId) {
+            if (!startedLazyFetch) {
+                UpdateModCompatibilityDb();
+            }
+
+            return workshopLookup.TryGetValue((long) workshopId);
+        }
+
+        public static ModCompatibility LookupByName(string name) {
+            if (!startedLazyFetch) {
+                UpdateModCompatibilityDb();
+            }
+
+            return nameLookup.TryGetValue(name.ToLower());
+        }
+    }
+
+    public class ModCompatibility
+    {
+        public int status;
+        public string name;
+        public long workshopId;
+        public string notes = "";
+    }
+}

--- a/Source/Client/ModManagement.cs
+++ b/Source/Client/ModManagement.cs
@@ -5,8 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
-using RestSharp;
 using Steamworks;
 using Verse;
 using Verse.Steam;
@@ -15,25 +13,6 @@ namespace Multiplayer.Client
 {
     public static class ModManagement
     {
-        public static void UpdateModCompatibilityDb()
-        {
-            if (!MultiplayerMod.settings.showModCompatibility) {
-                return;
-            }
-
-            Task.Run(() => {
-                var client = new RestClient("https://bot.rimworldmultiplayer.com/mod-compatibility?version=1.1");
-                try {
-                    var rawResponse = client.Get(new RestRequest($"", DataFormat.Json));
-                    Multiplayer.modsCompatibility = SimpleJson.DeserializeObject<Dictionary<string, int>>(rawResponse.Content);
-                    Log.Message($"MP: successfully fetched {Multiplayer.modsCompatibility.Count} mods compatibility info");
-                }
-                catch (Exception e) {
-                    Log.Warning($"MP: updating mod compatibility list failed {e.Message} {e.StackTrace}");
-                }
-            });
-        }
-
         public static List<ulong> GetEnabledWorkshopMods() {
             var enabledModIds = LoadedModManager.RunningModsListForReading.Select(m => m.PackageId).ToArray();
             var allWorkshopItems =

--- a/Source/Client/ModPatches.cs
+++ b/Source/Client/ModPatches.cs
@@ -128,8 +128,10 @@ namespace Multiplayer.Client
                 tooltip = "4 = Everything works (XML-only mod)";
             }
 
-            if (Multiplayer.modsCompatibility.ContainsKey(mod.publishedFileIdInt.ToString())) {
-                var compat = Multiplayer.modsCompatibility[mod.publishedFileIdInt.ToString()];
+            ModCompatibility modCompatibility = ModCompatibilityManager.LookupByWorkshopId(mod.GetPublishedFileId())
+                                                ?? ModCompatibilityManager.LookupByName(mod.Name); // fallback to inaccurate Name for local/non-steam installs
+            if (modCompatibility != null) {
+                var compat = modCompatibility.status;
                 if (compat == 1) {
                     currentModCompat = $"<color=red>{compat}</color>";
                     tooltip = "1 = Does not work";
@@ -147,12 +149,16 @@ namespace Multiplayer.Client
                     currentModCompat = $"<color=grey>{compat}</color>";
                     tooltip = "0 = Unknown; please report findings to #mod-report in our Discord";
                 }
+
+                if (modCompatibility.notes != "") {
+                    tooltip += $"\n\n{modCompatibility.notes}";
+                }
             }
 
             if (tooltip != "") {
                 var tooltipRect = new Rect(rect);
                 tooltipRect.xMax = tooltipRect.xMin + 50f;
-                TooltipHandler.TipRegion(tooltipRect, new TipSignal($"Multiplayer Compatibility: {tooltip}", mod.GetHashCode() * 3312));
+                TooltipHandler.TipRegion(tooltipRect, new TipSignal($"{"MpMultiplayerCompatibility".Translate()}: {tooltip}", mod.GetHashCode() * 3312));
             }
         }
 

--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -66,7 +66,6 @@ namespace Multiplayer.Client
         public static HashSet<string> xmlMods = new HashSet<string>();
         public static List<ModHashes> enabledModAssemblyHashes = new List<ModHashes>();
         public static Dictionary<string, DefInfo> localDefInfos;
-        public static Dictionary<string, int> modsCompatibility = new Dictionary<string, int>();  // workshopID: compatNumber [0-4]
 
         static Multiplayer()
         {
@@ -149,9 +148,6 @@ namespace Multiplayer.Client
 
             if (MultiplayerMod.arbiterInstance) {
                 RuntimeHelpers.RunClassConstructor(typeof(Text).TypeHandle);
-            }
-            else {
-                ModManagement.UpdateModCompatibilityDb();
             }
         }
 

--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -309,10 +309,6 @@ namespace Multiplayer.Client
 
             if (serverSettings == null)
                 serverSettings = new ServerSettings();
-
-            if (Scribe.mode == LoadSaveMode.Saving && showModCompatibility && Multiplayer.modsCompatibility.Count == 0) {
-                ModManagement.UpdateModCompatibilityDb();
-            }
         }
     }
 }


### PR DESCRIPTION
As suggested/requested by TBob/ZoeyVS:

* Show the Notes from the Mod Compat spreadsheet in the tooltip, as they often contain advice ("everything works as long as you disable X")
* Fallback to a mod name lookup when workshopId not found, such as for non-steam users and local mods.
* ~If a mod is marked "1*", interpret to mean "4 if the MP Compat mod is enabled, otherwise its a 1."~
* Move `UpdateModCompatibilityDb()` from mod init into a lazy loader pattern, so its only fetched once the Mods menu is actually opened. It should load quite quickly (~100ms), and IMO the flicker makes it feel more "live updating" :)

Needs rwmt/AdvisorBot#3 (which is currently live)