### PR TITLE
Async quest patch

### DIFF
--- a/Source/Client/Comp/MapAsyncTime.cs
+++ b/Source/Client/Comp/MapAsyncTime.cs
@@ -977,13 +977,8 @@ namespace Multiplayer.Client
         public void QuestManagerTickAsyncTime()
         {
             if (!MultiplayerWorldComp.asyncTime || Paused) return;
-            if (MultiplayerAsyncQuest.QuestMapAsyncTimeCompsCache.TryGetValue(this, out var quests))
-            {
-                foreach (var quest in quests)
-                {
-                    quest.QuestTick();
-                }
-            }
+
+            MultiplayerAsyncQuest.TickMapQuests(this);
         }
     }
 

--- a/Source/Client/Comp/MultiplayerAsyncQuest.cs
+++ b/Source/Client/Comp/MultiplayerAsyncQuest.cs
@@ -15,11 +15,11 @@ namespace Multiplayer.Client.Comp
     [HarmonyPatch(typeof(SettlementAbandonUtility), nameof(SettlementAbandonUtility.Abandon))]
     static class RemoveMapCacheOnAbandon
     {
-        static void Prefix(MapParent mapParent)
+        static void Prefix(MapParent settlement)
         {
             if (!MultiplayerWorldComp.asyncTime) return;
 
-            var mapAsyncTimeComp = mapParent.Map.AsyncTime();
+            var mapAsyncTimeComp = settlement.Map.AsyncTime();
             if (mapAsyncTimeComp != null)
             {
                 MultiplayerAsyncQuest.TryRemoveCachedMap(mapAsyncTimeComp);

--- a/Source/Client/Comp/MultiplayerAsyncQuest.cs
+++ b/Source/Client/Comp/MultiplayerAsyncQuest.cs
@@ -73,11 +73,11 @@ namespace Multiplayer.Client.Comp
     [HarmonyPatch]
     static class SetContextForQuest
     {
-        static IEnumerable<MethodInfo> TargetMethod()
+        static IEnumerable<MethodInfo> TargetMethods()
         {
-            yield return AccessTools.Method(typeof(Quest), nameof(Quest.TicksSinceAppeared));
-            yield return AccessTools.Method(typeof(Quest), nameof(Quest.TicksSinceAccepted));
-            yield return AccessTools.Method(typeof(Quest), nameof(Quest.TicksSinceCleanup));
+            yield return AccessTools.Method(typeof(Quest), "get_" + nameof(Quest.TicksSinceAppeared));
+            yield return AccessTools.Method(typeof(Quest), "get_" + nameof(Quest.TicksSinceAccepted));
+            yield return AccessTools.Method(typeof(Quest), "get_" + nameof(Quest.TicksSinceCleanup));
             yield return AccessTools.Method(typeof(Quest), nameof(Quest.SetInitiallyAccepted));
             yield return AccessTools.Method(typeof(Quest), nameof(Quest.CleanupQuestParts));
         }

--- a/Source/Client/Comp/MultiplayerAsyncQuest.cs
+++ b/Source/Client/Comp/MultiplayerAsyncQuest.cs
@@ -164,11 +164,7 @@ namespace Multiplayer.Client.Comp
         /// <param name="quest">Quest to remove</param>
         /// <returns>If quest is found in cache</returns>
         public static bool TryRemoveCachedQuest(Quest quest)
-        {
-            var mapQuestBool = mapQuestsCache.SingleOrDefault(x => x.Value.Contains(quest)).Value?.Remove(quest) ?? false;
-            var worldQuestBool = worldQuestsCache.Remove(quest);
-            return mapQuestBool || worldQuestBool; //is there a way to not short circuit...then we can avoid allocation here
-        }
+            => mapQuestsCache.SingleOrDefault(x => x.Value.Contains(quest)).Value?.Remove(quest) ?? false | worldQuestsCache.Remove(quest);
 
         /// <summary>
         /// Attempts to get the MapAsyncTimeComp cached for that quest

--- a/Source/Client/Comp/MultiplayerAsyncQuest.cs
+++ b/Source/Client/Comp/MultiplayerAsyncQuest.cs
@@ -15,6 +15,8 @@ namespace Multiplayer.Client.Comp
     {
         static void Postfix(ref Quest __result)
         {
+            if (!MultiplayerWorldComp.asyncTime) return;
+
             MultiplayerAsyncQuest.CacheQuest(__result);
         }
     }
@@ -25,6 +27,8 @@ namespace Multiplayer.Client.Comp
     {
         static bool Prefix()
         {
+            if (!MultiplayerWorldComp.asyncTime) return true;
+
             //Only tick world quest during world time
             foreach (var quest in MultiplayerAsyncQuest.WorldQuests)
             {
@@ -41,6 +45,8 @@ namespace Multiplayer.Client.Comp
     {
         static void Postfix()
         {
+            if (!MultiplayerWorldComp.asyncTime) return;
+
             foreach (var quest in Find.QuestManager.QuestsListForReading)
             {
                 MultiplayerAsyncQuest.CacheQuest(quest);
@@ -53,6 +59,8 @@ namespace Multiplayer.Client.Comp
     {
         static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
         {
+            if (!MultiplayerWorldComp.asyncTime) return;
+
             __state = MultiplayerAsyncQuest.GetCachedMapAsyncTimeCompForQuest(__instance);
             __state?.PreContext();
         }
@@ -68,6 +76,8 @@ namespace Multiplayer.Client.Comp
     {
         static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
         {
+            if (!MultiplayerWorldComp.asyncTime) return;
+
             __state = MultiplayerAsyncQuest.GetCachedMapAsyncTimeCompForQuest(__instance);
             __state?.PreContext();
         }
@@ -83,6 +93,8 @@ namespace Multiplayer.Client.Comp
     {
         static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
         {
+            if (!MultiplayerWorldComp.asyncTime) return;
+
             __state = MultiplayerAsyncQuest.GetCachedMapAsyncTimeCompForQuest(__instance);
             __state?.PreContext();
         }
@@ -98,6 +110,8 @@ namespace Multiplayer.Client.Comp
     {
         static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
         {
+            if (!MultiplayerWorldComp.asyncTime) return;
+
             __state = MultiplayerAsyncQuest.GetCachedMapAsyncTimeCompForQuest(__instance);
             __state?.PreContext();
         }
@@ -113,6 +127,8 @@ namespace Multiplayer.Client.Comp
     {
         static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
         {
+            if (!MultiplayerWorldComp.asyncTime) return;
+
             __state = MultiplayerAsyncQuest.GetCachedMapAsyncTimeCompForQuest(__instance);
             __state?.PreContext();
         }

--- a/Source/Client/Comp/MultiplayerAsyncQuest.cs
+++ b/Source/Client/Comp/MultiplayerAsyncQuest.cs
@@ -143,8 +143,9 @@ namespace Multiplayer.Client.Comp
             if (mapQuestsCache.TryGetValue(mapAsyncTimeComp, out var quests))
             {
                 worldQuestsCache.AddRange(quests);
-                return true;
+                return mapQuestsCache.Remove(mapAsyncTimeComp);
             }
+
             return false;
         }
 

--- a/Source/Client/Comp/MultiplayerAsyncQuest.cs
+++ b/Source/Client/Comp/MultiplayerAsyncQuest.cs
@@ -1,0 +1,187 @@
+using HarmonyLib;
+using RimWorld;
+using RimWorld.Planet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace Multiplayer.Client.Comp
+{
+#if false
+    [HarmonyPatch(typeof(Quest), nameof(Quest.TicksSinceAppeared), MethodType.Getter)]
+    static class SetTicksSinceAppearedForQuestsBasedOnMap
+    {
+        static bool Prefix(Quest __instance, ref int __result)
+        {
+            __result = MultiplayerAsyncQuest.SetAsyncTimeIfNotExistWorldTime(__instance, __instance.appearanceTick);
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(Quest), nameof(Quest.TicksSinceAccepted), MethodType.Getter)]
+    static class SetTicksSinceAcceptedForQuestsBasedOnMap
+    {
+        static bool Prefix(Quest __instance, ref int __result)
+        {
+            if (__instance.acceptanceTick >= 0)
+            {
+                __result = MultiplayerAsyncQuest.SetAsyncTimeIfNotExistWorldTime(__instance, __instance.acceptanceTick);
+            }
+            else
+            {
+                __result = -1;
+            }
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(Quest), nameof(Quest.TicksSinceCleanup), MethodType.Getter)]
+    static class SetTicksSinceCleanupForQuestsBasedOnMap
+    {
+        static bool Prefix(Quest __instance, ref int __result)
+        {
+            if (!__instance.cleanedUp)
+            {
+                __result = -1;
+                return true;
+            }
+
+            __result = MultiplayerAsyncQuest.SetAsyncTimeIfNotExistWorldTime(__instance, __instance.cleanupTick);
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(Quest), nameof(Quest.SetInitiallyAccepted))]
+    static class SetInitiallyAcceptedForQuestsBasedOnMap
+    {
+        static bool Prefix(Quest __instance)
+        {
+            __instance.acceptanceTick = MultiplayerAsyncQuest.SetAsyncTimeIfNotExistWorldTime(__instance);
+            __instance.ticksUntilAcceptanceExpiry = -1;
+            __instance.initiallyAccepted = true;
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(Quest), nameof(Quest.CleanupQuestParts))]
+    static class SetCleanupQuestPartsForQuestsBasedOnMap
+    {
+        static bool Prefix(Quest __instance)
+        {
+            if (__instance.cleanedUp)
+            {
+                return true;
+            }
+            __instance.cleanupTick = MultiplayerAsyncQuest.SetAsyncTimeIfNotExistWorldTime(__instance);
+            for (int i = 0; i < __instance.parts.Count; i++)
+            {
+                try
+                {
+                    __instance.parts[i].Cleanup();
+                }
+                catch (Exception arg)
+                {
+                    Log.Error("Error in QuestPart cleanup: " + arg, false);
+                }
+            }
+            __instance.cleanedUp = true;
+            return true;
+        }
+    }
+#endif
+    [HarmonyPatch(typeof(Quest), nameof(Quest.Accept))]
+    public static class SetTicksForQuestsBasedOnMap
+    {
+        public static List<Type> mapParentQuestPartTypes = new List<Type>()
+        {
+            typeof(QuestPart_DropPods),
+            typeof(QuestPart_SpawnThing),
+            typeof(QuestPart_PawnsArrive),
+            typeof(QuestPart_Incident),
+            typeof(QuestPart_RandomRaid),
+            typeof(QuestPart_ThreatsGenerator),
+            typeof(QuestPart_Infestation),
+            typeof(QuestPart_GameCondition),
+            typeof(QuestPart_JoinPlayer),
+            typeof(QuestPart_TrackWhenExitMentalState),
+            typeof(QuestPart_RequirementsToAcceptBedroom),
+            typeof(QuestPart_MechCluster),
+            typeof(QuestPart_DropMonumentMarkerCopy),
+            typeof(QuestPart_PawnsAvailable)
+        };
+
+        public static Dictionary<Quest, MapAsyncTimeComp> QuestAsyncTime = new Dictionary<Quest, MapAsyncTimeComp>();
+
+        static bool Prefix(Quest __instance, Pawn by)
+        {
+            if (__instance.State != QuestState.NotYetAccepted)
+            {
+                return true;
+            }
+
+            //Have to cache this since its a lookup
+            MapAsyncTimeComp mapAsyncTimeComp = null;
+
+            //Only attempt this if asyncTime is enabled
+            if (MultiplayerWorldComp.asyncTime)
+            {
+                //Really terrible way to determine if a any quest parts have a map which also has an async time
+                if (__instance.parts != null)
+                {
+                    foreach (var part in __instance.parts.Where(x => mapParentQuestPartTypes.Contains(x.GetType())))
+                    {
+                        var mapParent = part.GetType().GetField("mapParent").GetValue(part) as MapParent;
+                        if (mapParent != null)
+                        {
+                            mapAsyncTimeComp = GetAsyncTimeFromMapParent(mapParent);
+                            if (mapAsyncTimeComp != null) break;
+                        }
+                    }
+                }
+            }
+
+            //Doesn't have a targetted map so using world time
+            if (mapAsyncTimeComp == null)
+            {
+                Log.Message($"Could Not Find AsyncTimeMap!", true);
+                __instance.acceptanceTick = Find.TickManager.TicksGame;
+            }
+            //Does have a targetted map so using that maps AsyncTime
+            else
+            {
+                QuestAsyncTime[__instance] = mapAsyncTimeComp;
+                __instance.acceptanceTick = mapAsyncTimeComp.mapTicks;
+            }
+
+            __instance.accepterPawn = by;
+            __instance.dismissed = false;
+            __instance.Initiate();
+            return true;
+        }
+
+        public static MapAsyncTimeComp GetAsyncTimeFromMapParent(MapParent mapParent)
+        {
+            if (!mapParent.Map.IsPlayerHome) return null;
+            var mapAsyncTimeComp = mapParent.Map.AsyncTime();
+            if (mapAsyncTimeComp != null) Log.Message($"Found AsyncTimeMap - Name: {mapParent.Label}", true);
+            return mapAsyncTimeComp;
+        }
+    }
+
+    public static class MultiplayerAsyncQuest
+    {
+        public static int SetAsyncTimeIfNotExistWorldTime(Quest quest, int tick = 0)
+        {
+            if (MultiplayerWorldComp.asyncTime && SetTicksForQuestsBasedOnMap.QuestAsyncTime.TryGetValue(quest, out var mapAsyncTimeComp))
+            {
+                return mapAsyncTimeComp.mapTicks - tick;
+            }
+            //Uses world time if it can't find async time for this quest
+            else
+            {
+                return Find.TickManager.TicksGame - tick;
+            }
+        }
+    }
+}

--- a/Source/Client/Comp/MultiplayerAsyncQuest.cs
+++ b/Source/Client/Comp/MultiplayerAsyncQuest.cs
@@ -6,10 +6,12 @@ using RimWorld.QuestGen;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Verse;
 
 namespace Multiplayer.Client.Comp
 {
+
     [HarmonyPatch(typeof(SettlementAbandonUtility), nameof(SettlementAbandonUtility.Abandon))]
     static class RemoveMapCacheOnAbandon
     {
@@ -68,77 +70,18 @@ namespace Multiplayer.Client.Comp
         }
     }
 
-    [HarmonyPatch(typeof(Quest), nameof(Quest.TicksSinceAppeared), MethodType.Getter)]
-    static class SetContextForQuestTicksSinceAppeared
+    [HarmonyPatch]
+    static class SetContextForQuest
     {
-        static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
+        static IEnumerable<MethodInfo> TargetMethod()
         {
-            if (!MultiplayerWorldComp.asyncTime) return;
-
-            __state = MultiplayerAsyncQuest.TryGetCachedQuestMap(__instance);
-            __state?.PreContext();
+            yield return AccessTools.Method(typeof(Quest), nameof(Quest.TicksSinceAppeared));
+            yield return AccessTools.Method(typeof(Quest), nameof(Quest.TicksSinceAccepted));
+            yield return AccessTools.Method(typeof(Quest), nameof(Quest.TicksSinceCleanup));
+            yield return AccessTools.Method(typeof(Quest), nameof(Quest.SetInitiallyAccepted));
+            yield return AccessTools.Method(typeof(Quest), nameof(Quest.CleanupQuestParts));
         }
 
-        static void Postfix(MapAsyncTimeComp __state)
-        {
-            __state?.PostContext();
-        }
-    }
-
-    [HarmonyPatch(typeof(Quest), nameof(Quest.TicksSinceAccepted), MethodType.Getter)]
-    static class SetContextForQuestTicksSinceAccepted
-    {
-        static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
-        {
-            if (!MultiplayerWorldComp.asyncTime) return;
-
-            __state = MultiplayerAsyncQuest.TryGetCachedQuestMap(__instance);
-            __state?.PreContext();
-        }
-
-        static void Postfix(MapAsyncTimeComp __state)
-        {
-            __state?.PostContext();
-        }
-    }
-
-    [HarmonyPatch(typeof(Quest), nameof(Quest.TicksSinceCleanup), MethodType.Getter)]
-    static class SetContextForQuestTicksSinceCleanup
-    {
-        static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
-        {
-            if (!MultiplayerWorldComp.asyncTime) return;
-
-            __state = MultiplayerAsyncQuest.TryGetCachedQuestMap(__instance);
-            __state?.PreContext();
-        }
-
-        static void Postfix(MapAsyncTimeComp __state)
-        {
-            __state?.PostContext();
-        }
-    }
-
-    [HarmonyPatch(typeof(Quest), nameof(Quest.SetInitiallyAccepted))]
-    static class SetContextForQuestSetInitiallyAccepted
-    {
-        static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
-        {
-            if (!MultiplayerWorldComp.asyncTime) return;
-
-            __state = MultiplayerAsyncQuest.TryGetCachedQuestMap(__instance);
-            __state?.PreContext();
-        }
-
-        static void Postfix(MapAsyncTimeComp __state)
-        {
-            __state?.PostContext();
-        }
-    }
-
-    [HarmonyPatch(typeof(Quest), nameof(Quest.CleanupQuestParts))]
-    static class SetContextForQuestCleanupQuestParts
-    {
         static void Prefix(Quest __instance, ref MapAsyncTimeComp __state)
         {
             if (!MultiplayerWorldComp.asyncTime) return;


### PR DESCRIPTION
Automatically determines which Map's async time to use if a quest targets a map
Uses that AsyncTime to tick for all aspects of that quest
If no map is targeted then use the world time as a fall back
Does not change Quest generation, it is still based on world time