### PR TITLE
Make 'Run Arbiter' a host setting

### DIFF
--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -97,7 +97,8 @@
   <MpAutosaveDays>days</MpAutosaveDays>
   <MpLanDesc1>Broadcast the game to your local network.</MpLanDesc1>
   <MpLanDesc2>Resolved LAN address: {0}</MpLanDesc2>
-  <MpArbiterDesc>A game instance which runs in the background and helps with desync solving.</MpArbiterDesc>
+  <MpRunArbiter>Run Arbiter</MpRunArbiter>
+  <MpArbiterDesc>A background game instance which helps with desync detection/solving. Running without Arbiter is unsupported.</MpArbiterDesc>
   <MpAsyncTimeDesc>Separate time controls for each map and the planet.</MpAsyncTimeDesc>
   <MpLogDesyncTraces>Log Desync Traces</MpLogDesyncTraces>
   <MpLogDesyncTracesDesc>Log extra stacktraces for troubleshooting desyncs; may impact performance</MpLogDesyncTracesDesc>

--- a/Source/Client/Windows/HostWindow.cs
+++ b/Source/Client/Windows/HostWindow.cs
@@ -127,16 +127,6 @@ namespace Multiplayer.Client
                 entry = entry.Down(30);
             }
 
-            if (MpVersion.IsDebug)
-            {
-                // Arbiter
-                {
-                    TooltipHandler.TipRegion(entry.Width(checkboxWidth), "MpArbiterDesc".Translate());
-                    CheckboxLabeled(entry.Width(checkboxWidth), "The Arbiter:  ", ref settings.arbiter, placeTextNearCheckbox: true);
-                    entry = entry.Down(30);
-                }
-            }
-
             // AsyncTime
             {
                 TooltipHandler.TipRegion(entry.Width(checkboxWidth), $"{"MpAsyncTimeDesc".Translate()}\n\n{"MpExperimentalFeature".Translate()}");
@@ -147,6 +137,13 @@ namespace Multiplayer.Client
             TooltipHandler.TipRegion(entry.Width(checkboxWidth), $"{"MpLogDesyncTracesDesc".Translate()}\n\n{"MpExperimentalFeature".Translate()}");
             CheckboxLabeled(entry.Width(checkboxWidth), $"{"MpLogDesyncTraces".Translate()}:  ", ref logDesyncTraces, placeTextNearCheckbox: true);
             entry = entry.Down(30);
+
+            // Arbiter
+            {
+                TooltipHandler.TipRegion(entry.Width(checkboxWidth), "MpArbiterDesc".Translate());
+                CheckboxLabeled(entry.Width(checkboxWidth), $"{"MpRunArbiter".Translate()}:  ", ref settings.arbiter, placeTextNearCheckbox: true);
+                entry = entry.Down(30);
+            }
 
             if (Prefs.DevMode)
             {


### PR DESCRIPTION
> Cody Spring: With Giddy-Up Battlemounts, shooting a ranged weapon from a mount causes everyone to desync when the arbiter is ON.
> But when the arbiter is OFF, I can have three clients on separate machines in front of me and no desyncs occur, all clients show the same projectiles missing, the same hitting causing the same injuries, it's all synced and good. No clients get a desync, so this is suggesting to me that the Arbiter itself may be having an issue, or having a false-positive or something.



>  Cody Spring: we play without arbiter and still get desyncs like normal
> ZoeyVS: I will add, I've managed 100+ hours of Arbiterless gameplay including client Desyncs without it ever breaking the game
> ZoeyVS: And not noticed anything weird either
> ZoeyVS: Also, the performance gain for disabling arbi is massive late game.