### PR TITLE
Add 'Full Save' option to Main Menu -> Save

### DIFF
--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -48,6 +48,8 @@
   
   <MpHostServer>Host a server</MpHostServer>
   <MpSaveReplay>Save replay</MpSaveReplay>
+  <MpFullSave>Full Save</MpFullSave>
+  <MpFullSaveDesc>Full saves load faster, but save slower, and are only available to the Host</MpFullSaveDesc>
   
   <MpConvert>Convert to singleplayer</MpConvert>
   <MpConverting>Converting</MpConverting>

--- a/Source/Client/Comp/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/MultiplayerWorldComp.cs
@@ -275,7 +275,7 @@ namespace Multiplayer.Client
 
                 if (cmdType == CommandType.Autosave)
                 {
-                    LongEventHandler.QueueLongEvent(DoAutosave, "MpSaving", false, null);
+                    LongEventHandler.QueueLongEvent(() => DoAutosave(data.ReadString()), "MpSaving", false, null);
                 }
             }
             catch (Exception e)
@@ -295,9 +295,9 @@ namespace Multiplayer.Client
             }
         }
 
-        private static void DoAutosave()
+        private static void DoAutosave(string saveName="")
         {
-            var autosaveFile = AutosaveFile();
+            var autosaveFile = saveName != "" ? saveName : AutosaveFile();
             var written = false;
 
             if (Multiplayer.LocalServer != null && !TickPatch.Skipping && !Multiplayer.IsReplay)

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -206,7 +206,7 @@ namespace Multiplayer.Common
             SendToAll(Packets.Server_PlayerList, writer.ToArray());
         }
 
-        public bool DoAutosave()
+        public bool DoAutosave(string saveName = "")
         {
             if (tmpMapCmds != null)
                 return false;
@@ -214,7 +214,9 @@ namespace Multiplayer.Common
             if (settings.pauseOnAutosave)
                 SendCommand(CommandType.WorldTimeSpeed, ScheduledCommand.NoFaction, ScheduledCommand.Global, new byte[] { (byte)Verse.TimeSpeed.Paused });
 
-            SendCommand(CommandType.Autosave, ScheduledCommand.NoFaction, ScheduledCommand.Global, new byte[0]);
+            ByteWriter writer = new ByteWriter();
+            writer.WriteString(saveName);
+            SendCommand(CommandType.Autosave, ScheduledCommand.NoFaction, ScheduledCommand.Global, writer.ToArray());
             tmpMapCmds = new Dictionary<int, List<byte[]>>();
 
             SendChat("Autosaving...");


### PR DESCRIPTION
![2020_05_03_17-15-39](https://user-images.githubusercontent.com/1627867/80929565-cf733700-8d61-11ea-9fa4-a60b84b9371a.png)

Triggers an Autosave (named) in a more convenient/obvious manner than "Chat -> /autosave -> enter"

Should I also rename "Save replay" to just "Save"? The default are still replays but I'm not sure that's a meaningful word to most players.