### PR TITLE
Clamp World's TimeSpeed between min + max map speeds

### DIFF
--- a/Source/Client/ClientNetworking.cs
+++ b/Source/Client/ClientNetworking.cs
@@ -108,6 +108,7 @@ namespace Multiplayer.Client
                 Multiplayer.WorldComp.TimeSpeed = timeSpeed;
                 foreach (var map in Find.Maps)
                     map.AsyncTime().TimeSpeed = timeSpeed;
+                Multiplayer.WorldComp.UpdateTimeSpeed();
 
                 Multiplayer.WorldComp.debugMode = debugMode;
                 Multiplayer.WorldComp.logDesyncTraces = logDesyncTraces;
@@ -198,6 +199,7 @@ namespace Multiplayer.Client
                 async.mapTicks = Find.TickManager.TicksGame;
                 async.TimeSpeed = Find.TickManager.CurTimeSpeed;
             }
+            Multiplayer.WorldComp.UpdateTimeSpeed();
         }
 
         private static void SetupLocalClient()

--- a/Source/Client/Comp/MapAsyncTime.cs
+++ b/Source/Client/Comp/MapAsyncTime.cs
@@ -708,6 +708,7 @@ namespace Multiplayer.Client
 
             CommandType cmdType = cmd.type;
 
+            var updateWorldTime = false;
             keepTheMap = false;
             var prevMap = Current.Game.CurrentMap;
             Current.Game.currentMapIndex = (sbyte)map.Index;
@@ -749,6 +750,7 @@ namespace Multiplayer.Client
                 {
                     TimeSpeed speed = (TimeSpeed)data.ReadByte();
                     TimeSpeed = speed;
+                    updateWorldTime = true;
 
                     MpLog.Log("Set map time speed " + speed);
                 }
@@ -806,6 +808,9 @@ namespace Multiplayer.Client
 
                 if (!keepTheMap)
                     TrySetCurrentMap(prevMap);
+                if (updateWorldTime) {
+                    Multiplayer.WorldComp.UpdateTimeSpeed();
+                }
 
                 keepTheMap = false;
 

--- a/Source/Client/Comp/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/MultiplayerWorldComp.cs
@@ -19,6 +19,7 @@ namespace Multiplayer.Client
     {
         public static bool tickingWorld;
         public static bool executingCmdWorld;
+        private TimeSpeed desiredTimeSpeed = TimeSpeed.Paused;
 
         public float RealTimeToTickThrough { get; set; }
 
@@ -44,7 +45,33 @@ namespace Multiplayer.Client
         public TimeSpeed TimeSpeed
         {
             get => Find.TickManager.CurTimeSpeed;
-            set => Find.TickManager.CurTimeSpeed = value;
+            set {
+                desiredTimeSpeed = value;
+                UpdateTimeSpeed();
+            }
+        }
+
+        /**
+         * Clamps the World's TimeSpeed to be between (slowest map) and (fastest map)
+         * Caution: doesn't work if called inside a MapAsyncTime.PreContext()
+         */
+        public void UpdateTimeSpeed()
+        {
+            if (!MultiplayerWorldComp.asyncTime) {
+                Find.TickManager.CurTimeSpeed = desiredTimeSpeed;
+                return;
+            }
+
+            var mapSpeeds = Find.Maps.Select(m => m.AsyncTime().TimeSpeed)
+                .Where(timeSpeed => timeSpeed != TimeSpeed.Paused)
+                .ToList();
+            if (mapSpeeds.NullOrEmpty()) {
+                // all maps are paused = pause the world
+                Find.TickManager.CurTimeSpeed = TimeSpeed.Paused;
+            }
+            else {
+                Find.TickManager.CurTimeSpeed = (TimeSpeed)Math.Min(Math.Max((byte)desiredTimeSpeed, (byte)mapSpeeds.Min()), (byte)mapSpeeds.Max());
+            }
         }
 
         public Queue<ScheduledCommand> Cmds { get => cmds; }


### PR DESCRIPTION
Ensures World cannot be paused while maps are unpaused, so the world time doesn't fall behind, ensuring questgen/etc will carry on.

Might help #76. Compliments #77 (which moves quests to map-time if they relate to a map, _once generated_)
Should fix quests not generating in Async time, and may solve other related time oddities (from other behaviors being tied to a paused world time). 