### PR TITLE
Fix NullReferenceException in PawnPortraitMapTime.Prefix

### DIFF
--- a/Source/Client/SetMapTime.cs
+++ b/Source/Client/SetMapTime.cs
@@ -67,7 +67,7 @@ namespace Multiplayer.Client
 
         static void Prefix(Pawn pawn, ref TimeSnapshot? __state)
         {
-            if (Multiplayer.Client == null || Current.ProgramState != ProgramState.Playing) return;
+            if (Multiplayer.Client == null || pawn.MapHeld == null || Current.ProgramState != ProgramState.Playing) return;
             __state = TimeSnapshot.GetAndSetFromMap(pawn.MapHeld);
         }
 


### PR DESCRIPTION
I faced with error while playing

```
Root level exception in Update(): System.NullReferenceException: Object reference not set to an instance of an object
  at Multiplayer.Client.TimeSnapshot.GetAndSetFromMap (Verse.Map map) [0x0001d] in <79df2601b7c644ccb196bd72b8a623ba>:0 
  at Multiplayer.Client.PawnPortraitMapTime.Prefix (Verse.Pawn pawn, System.Nullable`1[Multiplayer.Client.TimeSnapshot]& __state) [0x00017] in <79df2601b7c644ccb196bd72b8a623ba>:0 
  at (wrapper dynamic-method) RimWorld.PortraitsCache.DMD<DMD<IsAnimated_Patch2>?-213784064::IsAnimated_Patch2>(Verse.Pawn)
  at RimWorld.PortraitsCache.SetAnimatedPortraitsDirty () [0x0003e] in <0ee2c524c4be441e9b7f8bfcb20aca6f>:0 
  at RimWorld.PortraitsCache.PortraitsCacheUpdate () [0x00005] in <0ee2c524c4be441e9b7f8bfcb20aca6f>:0 
  at (wrapper dynamic-method) Verse.Root.DMD<DMD<Update_Patch1>?767768192::Update_Patch1>(Verse.Root)
Verse.Log:Error(String, Boolean)
Verse.Root:DMD<DMD<Update_Patch1>?767768192::Update_Patch1>(Root)
Verse.Root_Play:Update()
```