### PR TITLE
Move Designators to SyncSerialization

### DIFF
--- a/Source/Client/Comp/MapAsyncTime.cs
+++ b/Source/Client/Comp/MapAsyncTime.cs
@@ -877,19 +877,10 @@ namespace Multiplayer.Client
         private void HandleDesignator(ScheduledCommand command, ByteReader data)
         {
             DesignatorMode mode = Sync.ReadSync<DesignatorMode>(data);
-            ushort desId = Sync.ReadSync<ushort>(data);
-            Type desType = Sync.designatorTypes[desId];
-
-            Designator designator = Sync.ReadSyncObject(data, desType) as Designator;
-            if (designator == null)
-            {
-                designator = (Designator)Activator.CreateInstance(desType);
-            }
+            Designator designator = Sync.ReadSync<Designator>(data);
 
             try
             {
-                if (!SetDesignatorState(designator, data)) return;
-
                 if (mode == DesignatorMode.SingleCell)
                 {
                     IntVec3 cell = Sync.ReadSync<IntVec3>(data);
@@ -916,44 +907,6 @@ namespace Multiplayer.Client
             {
                 DesignatorInstallPatch.thingToInstall = null;
             }
-        }
-
-        private bool SetDesignatorState(Designator designator, ByteReader data)
-        {
-            if (designator is Designator_AreaAllowed)
-            {
-                Area area = Sync.ReadSync<Area>(data);
-                if (area == null) return false;
-                Designator_AreaAllowed.selectedArea = area;
-            }
-
-            if (designator is Designator_Place place)
-            {
-                place.placingRot = Sync.ReadSync<Rot4>(data);
-            }
-
-            if (designator is Designator_Build build && build.PlacingDef.MadeFromStuff)
-            {
-                ThingDef stuffDef = Sync.ReadSync<ThingDef>(data);
-                if (stuffDef == null) return false;
-                build.stuffDef = stuffDef;
-            }
-
-            if (designator is Designator_Install)
-            {
-                Thing thing = Sync.ReadSync<Thing>(data);
-                if (thing == null) return false;
-                DesignatorInstallPatch.thingToInstall = thing;
-            }
-
-            if (designator is Designator_Zone)
-            {
-                Zone zone = Sync.ReadSync<Zone>(data);
-                if (zone != null)
-                    Find.Selector.selected.Add(zone);
-            }
-
-            return true;
         }
 
         private bool nothingHappeningCached;

--- a/Source/Client/Comp/MapAsyncTime.cs
+++ b/Source/Client/Comp/MapAsyncTime.cs
@@ -881,6 +881,8 @@ namespace Multiplayer.Client
 
             try
             {
+                if (!SetDesignatorState(designator, data)) return;
+
                 if (mode == DesignatorMode.SingleCell)
                 {
                     IntVec3 cell = Sync.ReadSync<IntVec3>(data);
@@ -907,6 +909,32 @@ namespace Multiplayer.Client
             {
                 DesignatorInstallPatch.thingToInstall = null;
             }
+        }
+
+        private bool SetDesignatorState(Designator designator, ByteReader data)
+        {
+            if (designator is Designator_AreaAllowed)
+            {
+                Area area = Sync.ReadSync<Area>(data);
+                if (area == null) return false;
+                Designator_AreaAllowed.selectedArea = area;
+            }
+
+            if (designator is Designator_Install)
+            {
+                Thing thing = Sync.ReadSync<Thing>(data);
+                if (thing == null) return false;
+                DesignatorInstallPatch.thingToInstall = thing;
+            }
+
+            if (designator is Designator_Zone)
+            {
+                Zone zone = Sync.ReadSync<Zone>(data);
+                if (zone != null)
+                    Find.Selector.selected.Add(zone);
+            }
+
+            return true;
         }
 
         private bool nothingHappeningCached;

--- a/Source/Client/Designators.cs
+++ b/Source/Client/Designators.cs
@@ -101,6 +101,18 @@ namespace Multiplayer.Client
         {
             Sync.WriteSync(data, mode);
             Sync.WriteSyncObject(data, designator, designator.GetType());
+
+            // These affect the Global context and shouldn't be SyncWorkers
+            // Read at MapAsyncTimeComp.SetDesignatorState
+
+            if (designator is Designator_AreaAllowed)
+                Sync.WriteSync(data, Designator_AreaAllowed.SelectedArea);
+
+            if (designator is Designator_Install install)
+                Sync.WriteSync(data, install.MiniToInstallOrBuildingToReinstall);
+
+            if (designator is Designator_Zone)
+                Sync.WriteSync(data, Find.Selector.SelectedZone);
         }
     }
 

--- a/Source/Client/Designators.cs
+++ b/Source/Client/Designators.cs
@@ -102,19 +102,6 @@ namespace Multiplayer.Client
             Sync.WriteSync(data, mode);
             Sync.WriteSyncObject(data, designator, designator.GetType());
         }
-
-        internal static Thing ThingToInstall()
-        {
-            Thing singleSelectedThing = Find.Selector.SingleSelectedThing;
-            if (singleSelectedThing is MinifiedThing)
-                return singleSelectedThing;
-
-            Building building = singleSelectedThing as Building;
-            if (building != null && building.def.Minifiable)
-                return singleSelectedThing;
-
-            return null;
-        }
     }
 
     [HarmonyPatch(typeof(Designator_Install))]

--- a/Source/Client/Designators.cs
+++ b/Source/Client/Designators.cs
@@ -99,29 +99,11 @@ namespace Multiplayer.Client
 
         private static void WriteData(ByteWriter data, DesignatorMode mode, Designator designator)
         {
-            Type designatorType = designator.GetType();
-
             Sync.WriteSync(data, mode);
-            Sync.WriteSync(data, (ushort) Array.IndexOf(Sync.designatorTypes, designatorType));
-            Sync.WriteSyncObject(data, designator, designatorType);
-
-            if (designator is Designator_AreaAllowed)
-                Sync.WriteSync(data, Designator_AreaAllowed.SelectedArea);
-
-            if (designator is Designator_Place place)
-                Sync.WriteSync(data, place.placingRot);
-
-            if (designator is Designator_Build build && build.PlacingDef.MadeFromStuff)
-                Sync.WriteSync(data, build.stuffDef);
-
-            if (designator is Designator_Install)
-                Sync.WriteSync(data, ThingToInstall());
-
-            if (designator is Designator_Zone)
-                Sync.WriteSync(data, Find.Selector.SelectedZone);
+            Sync.WriteSyncObject(data, designator, designator.GetType());
         }
 
-        private static Thing ThingToInstall()
+        internal static Thing ThingToInstall()
         {
             Thing singleSelectedThing = Find.Selector.SingleSelectedThing;
             if (singleSelectedThing is MinifiedThing)

--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -545,19 +545,47 @@ namespace Multiplayer.Client
 
             #region Designators
             {
-                // This is here to handle every other Designator that isn't implemented,
-                // by default they only need the type and that's being handled outside.
-                // Returning null is enough.
-                (ByteWriter data, Designator des) => {
-                    // These are handled in DesignatorPatches.WriteData
-                },
-                (ByteReader data) => {
-                    // These are handled in MapAsyncTimeComp.HandleDesignator
-                    return null;
-                }, true // <- isImplicit: true
+                (SyncWorker sync, ref Designator designator)  => {
+
+                }, true, true // <- Implicit, ShouldConstruct
             },
             {
-                // The only special case in vanilla that has arguments, mods can add their own as explicit types.
+                (SyncWorker sync, ref Designator_AreaAllowed area)  => {
+                    if (sync.isWriting) {
+                        sync.Write(Designator_AreaAllowed.SelectedArea);
+                    } else {
+                        Designator_AreaAllowed.selectedArea = sync.Read<Area>();
+                    }
+                }, true, true // <- Implicit, ShouldConstruct
+            },
+            {
+                (SyncWorker sync, ref Designator_Place place)  => {
+                    if (sync.isWriting) {
+                        sync.Write(place.placingRot);
+                    } else {
+                        place.placingRot = sync.Read<Rot4>();
+                    }
+                }, true, true // <- Implicit, ShouldConstruct
+            },
+            {
+                (SyncWorker sync, ref Designator_Zone zone)  => {
+                    if (sync.isWriting) {
+                        sync.Write(Find.Selector.SelectedZone);
+                    } else {
+                        Find.Selector.selected.Add(sync.Read<Zone>());
+                    }
+                }, true, true // <- Implicit, ShouldConstruct
+            },
+            {
+                (SyncWorker sync, ref Designator_Install install)  => {
+                    if (sync.isWriting) {
+                        sync.Write(DesignatorPatches.ThingToInstall());
+                    } else {
+                        DesignatorInstallPatch.thingToInstall = sync.Read<Thing>();
+                    }
+                }, false, true // <- ShouldConstruct
+            },
+            {
                 (ByteWriter data, Designator_Build build) => {
                     WriteSync(data, build.entDef);
                 },

--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -553,42 +553,11 @@ namespace Multiplayer.Client
                 }, true, true // <- Implicit ShouldConstruct
             },
             {
-                // SelectedArea is Global in RW, null is ok
-                (SyncWorker sync, ref Designator_AreaAllowed area) => {
-                    if (sync.isWriting) {
-                        sync.Write(Designator_AreaAllowed.SelectedArea);
-                    } else {
-                        Designator_AreaAllowed.selectedArea = sync.Read<Area>();
-                    }
-                }, true, true // <- Implicit ShouldConstruct
-            },
-            {
                 (SyncWorker sync, ref Designator_Place place) => {
                     if (sync.isWriting) {
                         sync.Write(place.placingRot);
                     } else {
                         place.placingRot = sync.Read<Rot4>();
-                    }
-                }, true, true // <- Implicit ShouldConstruct
-            },
-            {
-                // Find.Selector.SelectedZone is Global in RW, null is ok
-                (SyncWorker sync, ref Designator_Zone zone) => {
-                    if (sync.isWriting) {
-                        sync.Write(Find.Selector.SelectedZone);
-                    } else {
-                        Find.Selector.selected.Add(sync.Read<Zone>());
-                    }
-                }, true, true // <- Implicit ShouldConstruct
-            },
-            {
-                // MiniToInstallOrBuildingToReinstall uses Globals in RW, null is ok
-                // It needs a workaround
-                (SyncWorker sync, ref Designator_Install install) => {
-                    if (sync.isWriting) {
-                        sync.Write(install.MiniToInstallOrBuildingToReinstall);
-                    } else {
-                        DesignatorInstallPatch.thingToInstall = sync.Read<Thing>();
                     }
                 }, true, true // <- Implicit ShouldConstruct
             },

--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -545,12 +545,12 @@ namespace Multiplayer.Client
 
             #region Designators
             {
-                (SyncWorker sync, ref Designator designator)  => {
+                (SyncWorker sync, ref Designator designator) => {
 
                 }, true, true // <- Implicit, ShouldConstruct
             },
             {
-                (SyncWorker sync, ref Designator_AreaAllowed area)  => {
+                (SyncWorker sync, ref Designator_AreaAllowed area) => {
                     if (sync.isWriting) {
                         sync.Write(Designator_AreaAllowed.SelectedArea);
                     } else {
@@ -559,7 +559,7 @@ namespace Multiplayer.Client
                 }, true, true // <- Implicit, ShouldConstruct
             },
             {
-                (SyncWorker sync, ref Designator_Place place)  => {
+                (SyncWorker sync, ref Designator_Place place) => {
                     if (sync.isWriting) {
                         sync.Write(place.placingRot);
                     } else {
@@ -568,7 +568,7 @@ namespace Multiplayer.Client
                 }, true, true // <- Implicit, ShouldConstruct
             },
             {
-                (SyncWorker sync, ref Designator_Zone zone)  => {
+                (SyncWorker sync, ref Designator_Zone zone) => {
                     if (sync.isWriting) {
                         sync.Write(Find.Selector.SelectedZone);
                     } else {
@@ -577,11 +577,20 @@ namespace Multiplayer.Client
                 }, true, true // <- Implicit, ShouldConstruct
             },
             {
-                (SyncWorker sync, ref Designator_Install install)  => {
+                (SyncWorker sync, ref Designator_Install install) => {
                     if (sync.isWriting) {
-                        sync.Write(DesignatorPatches.ThingToInstall());
+                        var singleSelectedThing = Find.Selector.SingleSelectedThing;
+                        if (singleSelectedThing is MinifiedThing || singleSelectedThing is Building building && building.def.Minifiable) {
+                            sync.Write(true);
+                            sync.Write(singleSelectedThing);
+                        } else {
+                            sync.Write(false);
+                        }
                     } else {
-                        DesignatorInstallPatch.thingToInstall = sync.Read<Thing>();
+                        bool hasData = sync.Read<bool>();
+                        if (hasData) {
+                            DesignatorInstallPatch.thingToInstall = sync.Read<Thing>();
+                        }
                     }
                 }, false, true // <- ShouldConstruct
             },

--- a/Source/Client/Sync/SyncSerialization.cs
+++ b/Source/Client/Sync/SyncSerialization.cs
@@ -210,12 +210,11 @@ namespace Multiplayer.Client
                     return def;
                 }
 
-                // Designator is another special case with the same issue
+                // Designators can't be handled by SyncWorkers due to the type change
                 if (typeof(Designator).IsAssignableFrom(type))
                 {
-                    // attention, replaces the type
                     ushort desId = Sync.ReadSync<ushort>(data);
-                    type = Sync.designatorTypes[desId];
+                    type = Sync.designatorTypes[desId]; // Replaces the type!
                 }
 
                 // Where the magic happens
@@ -403,11 +402,10 @@ namespace Multiplayer.Client
                     return;
                 }
 
-                // special case
+                // special case for Designators to change the type
                 if (typeof(Designator).IsAssignableFrom(type))
                 {
                     data.WriteUShort((ushort) Array.IndexOf(Sync.designatorTypes, obj.GetType()));
-                    // attention, no return
                 }
 
                 // Where the magic happens

--- a/Source/Client/Sync/SyncSerialization.cs
+++ b/Source/Client/Sync/SyncSerialization.cs
@@ -210,6 +210,14 @@ namespace Multiplayer.Client
                     return def;
                 }
 
+                // Designator is another special case with the same issue
+                if (typeof(Designator).IsAssignableFrom(type))
+                {
+                    // attention, replaces the type
+                    ushort desId = Sync.ReadSync<ushort>(data);
+                    type = Sync.designatorTypes[desId];
+                }
+
                 // Where the magic happens
                 if (syncWorkers.TryGetValue(type, out var syncWorkerEntry)) 
                 {
@@ -393,6 +401,13 @@ namespace Multiplayer.Client
                     data.WriteUShort(def != null ? def.shortHash : (ushort)0);
 
                     return;
+                }
+
+                // special case
+                if (typeof(Designator).IsAssignableFrom(type))
+                {
+                    data.WriteUShort((ushort) Array.IndexOf(Sync.designatorTypes, obj.GetType()));
+                    // attention, no return
                 }
 
                 // Where the magic happens

--- a/Source/Client/Sync/SyncWorkers.cs
+++ b/Source/Client/Sync/SyncWorkers.cs
@@ -27,6 +27,8 @@ namespace Multiplayer.Client
 
         private List<SyncWorkerEntry> subclasses;
 
+        private SyncWorkerEntry parent;
+
         public int SyncWorkerCount => syncWorkers.Count();
 
         public SyncWorkerEntry(Type type, bool shouldConstruct = false)
@@ -70,6 +72,10 @@ namespace Multiplayer.Client
 
         public bool Invoke(SyncWorker worker, ref object obj)
         {
+            if (parent != null) {
+                parent.Invoke(worker, ref obj);
+            }
+
             for (int i = 0; i < syncWorkers.Count; i++) {
                 if (syncWorkers[i](worker, ref obj))
                     return true;
@@ -122,6 +128,7 @@ namespace Multiplayer.Client
                     return newEntry;
                 } else {
                     newEntry = new SyncWorkerEntry(this);
+
                     this.type = type;
 
                     this.shouldConstruct = shouldConstruct;
@@ -147,6 +154,7 @@ namespace Multiplayer.Client
                 }
 
                 var newEntry = new SyncWorkerEntry(type, shouldConstruct);
+                newEntry.parent = this;
                 subclasses.Add(newEntry);
 
                 return newEntry;

--- a/Source/Client/Sync/SyncWorkers.cs
+++ b/Source/Client/Sync/SyncWorkers.cs
@@ -323,7 +323,7 @@ namespace Multiplayer.Client
                         toRemove.Push(e);
                         continue;
                     }
-                    entry = e.Add(type);
+                    entry = e.Add(type, shouldConstruct);
                 }
             }
 
@@ -340,16 +340,16 @@ namespace Multiplayer.Client
             return entry;
         }
 
-        internal void Add<T>(SyncWorkerDelegate<T> action, bool isImplicit = false)
+        internal void Add<T>(SyncWorkerDelegate<T> action, bool isImplicit = false, bool shouldConstruct = false)
         {
-            var entry = GetOrAddEntry(typeof(T), isImplicit: isImplicit, shouldConstruct: false);
+            var entry = GetOrAddEntry(typeof(T), isImplicit: isImplicit, shouldConstruct: shouldConstruct);
 
             entry.Add(action);
         }
 
-        internal void Add<T>(Action<ByteWriter, T> writer, Func<ByteReader, T> reader, bool isImplicit = false)
+        internal void Add<T>(Action<ByteWriter, T> writer, Func<ByteReader, T> reader, bool isImplicit = false, bool shouldConstruct = false)
         {
-            var entry = GetOrAddEntry(typeof(T), isImplicit: isImplicit, shouldConstruct: false);
+            var entry = GetOrAddEntry(typeof(T), isImplicit: isImplicit, shouldConstruct: shouldConstruct);
 
             AddDelegate(entry, writer, reader);
         }


### PR DESCRIPTION
This PR fixes the issue with right clicking gizmos and possibly any use of Designators outside the click/drag framework.

It also fixes a minor bug with the SyncWorker shouldConstruct propagation.