### PR TITLE
Added UnityEngine.Color to SyncDictionary

### DIFF
--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -1215,6 +1215,17 @@ namespace Multiplayer.Client
             },
 
             #endregion
+
+            #region Color
+            {
+                (SyncWorker worker, ref Color color) => {
+                    worker.Bind(ref color.r);
+                    worker.Bind(ref color.g);
+                    worker.Bind(ref color.b);
+                    worker.Bind(ref color.a);
+                }
+            },
+            #endregion
         };
     }
 }


### PR DESCRIPTION
Additional note: syncing of UnityEngine.Color is required by MP Compat patch I'm working on.