### PR TITLE
Better saving defaults

### DIFF
--- a/Source/Client/Patches.cs
+++ b/Source/Client/Patches.cs
@@ -4,6 +4,7 @@ using RimWorld;
 using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -121,7 +122,7 @@ namespace Multiplayer.Client
                     {
                         optList.Insert(0, new ListableOption("Save".Translate(), () => Find.WindowStack.Add(new Dialog_SaveReplay())));
                     }
-                    optList.Insert(0, new ListableOption("MpConvert".Translate(), ConvertToSingleplayer));
+                    optList.Insert(3, new ListableOption("MpConvert".Translate(), ConvertToSingleplayer));
 
                     var quitMenuLabel = "QuitToMainMenu".Translate();
                     var saveAndQuitMenu = "SaveAndQuitToMainMenu".Translate();
@@ -178,6 +179,10 @@ namespace Multiplayer.Client
         {
             LongEventHandler.QueueLongEvent(() =>
             {
+                var saveName = Multiplayer.session.gameName + "-preconvert";
+                new FileInfo(Path.Combine(Multiplayer.ReplaysDir, $"{saveName}.zip")).Delete();
+                Replay.ForSaving(saveName).WriteCurrentData();
+
                 Find.GameInfo.permadeathMode = false;
                 // todo handle the other faction def too
                 Multiplayer.DummyFaction.def = FactionDefOf.Ancients;

--- a/Source/Client/Patches.cs
+++ b/Source/Client/Patches.cs
@@ -116,13 +116,12 @@ namespace Multiplayer.Client
 
                 if (Multiplayer.Client != null)
                 {
+                    optList.RemoveAll(opt => opt.label == "Save".Translate() || opt.label == "LoadGame".Translate());
                     if (!Multiplayer.IsReplay)
                     {
-                        optList.Insert(0, new ListableOption("MpSaveReplay".Translate(), () => Find.WindowStack.Add(new Dialog_SaveReplay())));
+                        optList.Insert(0, new ListableOption("Save".Translate(), () => Find.WindowStack.Add(new Dialog_SaveReplay())));
                     }
                     optList.Insert(0, new ListableOption("MpConvert".Translate(), ConvertToSingleplayer));
-
-                    optList.RemoveAll(opt => opt.label == "Save".Translate() || opt.label == "LoadGame".Translate());
 
                     var quitMenuLabel = "QuitToMainMenu".Translate();
                     var saveAndQuitMenu = "SaveAndQuitToMainMenu".Translate();

--- a/Source/Client/Windows/Windows.cs
+++ b/Source/Client/Windows/Windows.cs
@@ -230,7 +230,7 @@ namespace Multiplayer.Client
     {
         public override Vector2 InitialSize => new Vector2(350f, 205f);
         private bool fileExists;
-        private bool fullSave; // triggers an Autosave
+        private bool fullSave = true; // triggers an Autosave
 
         public Dialog_SaveReplay()
         {


### PR DESCRIPTION
A few "QoL tweaks" suggested by @ZoeyVS:

- Menu -> Save now defaults to 'Full' (slower save, faster/safer load), may as well for explicit saves
- Rename 'Save replay' to 'Save'
- Move 'Convert to Singleplayer' lower in menu order; it now triggers a MP save first. Apparently converting from Singleplayer back to Multiplayer is unstable, so these moves aims to discourage potentially one-way conversions to SP.