### PR TITLE
Sync float menu reload option

### DIFF
--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -857,6 +857,7 @@ namespace Multiplayer.Client
             SyncDelegate.Register(typeof(FloatMenuMakerMap), "<>c__DisplayClass8_6", "<AddHumanlikeOrders>b__5").CancelIfAnyFieldNull().SetContext(mouseKeyContext);   // Capture
             SyncDelegate.Register(typeof(FloatMenuMakerMap), "<>c__DisplayClass8_8", "<AddHumanlikeOrders>b__6").CancelIfAnyFieldNull().SetContext(mouseKeyContext);   // Carry to cryptosleep casket
             SyncDelegate.Register(typeof(FloatMenuMakerMap), "<>c__DisplayClass8_9", "<AddHumanlikeOrders>b__8").CancelIfAnyFieldNull().SetContext(mouseKeyContext);   // Carry to shuttle
+            SyncDelegate.Register(typeof(FloatMenuMakerMap), "<>c__DisplayClass8_13", "<AddHumanlikeOrders>b__14").CancelIfAnyFieldNull().SetContext(mouseKeyContext);  // Reload
 
             SyncDelegate.Register(typeof(HealthCardUtility), "<>c__DisplayClass26_0", "<GenerateSurgeryOption>b__1").CancelIfAnyFieldNull(without: "part");      // Add medical bill
             SyncDelegate.Register(typeof(Command_SetPlantToGrow), "<>c__DisplayClass5_0", "<ProcessInput>b__2");                                                // Set plant to grow


### PR DESCRIPTION
Forcing a pawn to reload stuff like locust armor was not synced (they could still reload them on their own) - fixed in this PR.

It also fixes it for mods that use it, like Vanilla Weapons Expanded - Grenades.