### PR TITLE
Fixes drop resources Royal permit error/no cooldown

### DIFF
--- a/Source/Client/Sync/SyncDictionary.cs
+++ b/Source/Client/Sync/SyncDictionary.cs
@@ -834,6 +834,17 @@ namespace Multiplayer.Client
                     }
                 }, true // Implicit
             },
+            {
+                // Parent: RoyalTitlePermitWorker_Targeted
+                (SyncWorker sync, ref RoyalTitlePermitWorker_DropResources dropResources) => {
+                    if (sync.isWriting) {
+                        sync.Write(dropResources.faction);
+                    }
+                    else {
+                        dropResources.faction = sync.Read<Faction>();
+                    }
+                }, true // Implicit
+            },
             #endregion
 
             #region Databases


### PR DESCRIPTION
Added sync worker for RoyalTitlePermitWorker_DropResources, which fixes the error that happened when trying to use it due to the faction not being synced.

The error caused the permit to go on cooldown only for the client that used it, other clients could use it again without any penalties.