### PR TITLE
Changed which methods are synced for abilities/psycasts

### DIFF
--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -549,8 +549,8 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(Pawn_RoyaltyTracker), nameof(Pawn_RoyaltyTracker.RefundPermits));
             SyncMethod.Register(typeof(Pawn_RoyaltyTracker), nameof(Pawn_RoyaltyTracker.SetTitle));
 
-            SyncMethod.Register(typeof(Command_Ability), nameof(Command_Ability.ProcessInput)); // self cast psychic abilities
-            SyncMethod.Register(typeof(CompAbilityEffect_StartSpeech), nameof(CompAbilityEffect_StartSpeech.Apply), new SyncType[] {typeof(LocalTargetInfo), typeof(LocalTargetInfo)}); // Royal Pawn: Give Speech button
+            SyncMethod.Register(typeof(Ability), nameof(Ability.QueueCastingJob), new SyncType[] { typeof(LocalTargetInfo), typeof(LocalTargetInfo) });
+            SyncMethod.Register(typeof(Ability), nameof(Ability.QueueCastingJob), new SyncType[] { typeof(GlobalTargetInfo) });
 
             // 1
             SyncMethod.Register(typeof(TradeRequestComp), nameof(TradeRequestComp.Fulfill)).CancelIfAnyArgNull().SetVersion(1);


### PR DESCRIPTION
This fixes farskip. Additionally, one client picking a targetable ability/psycast will no longer cause all clients to start targeting.

This does NOT fix neuroquake ability, and it'll require more work.

One thing we should consider is if we should sync `Ability.QueueCastingJob` for all subclasses of the class Ability. This does not have any effect on the game itself, but it will affect other mods. The only mod I can think of right now it would affect is Corruption - Psykers, and all it would is sync creation of some motes. Any input on this would be appreciated.