### PR TITLE
#142 Synced Designators Don't Interrupt Current Action

### DIFF
--- a/Source/Client/Comp/MapAsyncTime.cs
+++ b/Source/Client/Comp/MapAsyncTime.cs
@@ -886,10 +886,11 @@ namespace Multiplayer.Client
         {
             DesignatorMode mode = Sync.ReadSync<DesignatorMode>(data);
             Designator designator = Sync.ReadSync<Designator>(data);
+            Area previousSelectedArea = null;
 
             try
             {
-                if (!SetDesignatorState(designator, data)) return;
+                if (!SetDesignatorState(designator, data, out previousSelectedArea)) return;
 
                 if (mode == DesignatorMode.SingleCell)
                 {
@@ -916,15 +917,23 @@ namespace Multiplayer.Client
             finally
             {
                 DesignatorInstallPatch.thingToInstall = null;
+
+                if (previousSelectedArea != null)
+                {
+                    Designator_AreaAllowed.selectedArea = previousSelectedArea;
+                }
             }
         }
 
-        private bool SetDesignatorState(Designator designator, ByteReader data)
+        private bool SetDesignatorState(Designator designator, ByteReader data, out Area previousSelectedArea)
         {
+            previousSelectedArea = null;
+
             if (designator is Designator_AreaAllowed)
             {
                 Area area = Sync.ReadSync<Area>(data);
                 if (area == null) return false;
+                previousSelectedArea = Designator_AreaAllowed.selectedArea;
                 Designator_AreaAllowed.selectedArea = area;
             }
 


### PR DESCRIPTION
Addresses [#142](https://github.com/rwmt/Multiplayer/issues/142).

Fixes 2 issues and potentially other similar issues I'm not aware of.

**Issues fixed:**
1. Last person to edit an "allowed area" would force that area on all other players.  This caused an interruption if you were editing an area then someone else started to edit a different "allowed area".
2. Designating a thing to be reinstalled would cause all other players to lose their currently active "designators".  For example if you were in the process of marking out an area to be mined at the same time a different player reinstalled a thing on any map, your mining tool would disappear and revert to a simple cursor. 

**Testing tip:**
1. With 2 Rimworld windows open begin to drag a designator (e.g. the mining designator).  
2. With the drag started and the mouse still pressed, press and hold "Alt+Tab"
3. Release Tab only.
4. Release Mouse button only.
5. Release Alt.
6. The designator should be stuck in a dragging state allowing you to move to a different Rimworld window to continue testing. 
7. Just know that when you mouse press and release again in the original dragging Rimworld window, the designated area will not match what was rendered because your mouse focus was broke in this way. 