### PR TITLE
Make WritingSyncWorker and ReadingSyncWorker override Bind<T>(ref T obj, SyncType type)

### DIFF
--- a/Source/Client/Syncing/Worker/ReadingSyncWorker.cs
+++ b/Source/Client/Syncing/Worker/ReadingSyncWorker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Multiplayer.API;
 using Multiplayer.Common;
@@ -18,7 +18,7 @@ namespace Multiplayer.Client
             initialPos = reader.Position;
         }
 
-        public void Bind<T>(ref T obj, SyncType type)
+        public override void Bind<T>(ref T obj, SyncType type)
         {
             obj = (T)SyncSerialization.ReadSyncObject(reader, type);
         }

--- a/Source/Client/Syncing/Worker/WritingSyncWorker.cs
+++ b/Source/Client/Syncing/Worker/WritingSyncWorker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Multiplayer.API;
 using Multiplayer.Common;
@@ -18,7 +18,7 @@ namespace Multiplayer.Client
             initialPos = writer.Position;
         }
 
-        public void Bind<T>(ref T obj, SyncType type)
+        public override void Bind<T>(ref T obj, SyncType type)
         {
             SyncSerialization.WriteSyncObject(writer, obj, type);
         }


### PR DESCRIPTION
They already had it as a method, I simply added the override keyword. This needs the appropriate modification in MultiplayerAPI: rwmt/MultiplayerAPI#3