### PR TITLE
Harmony 2.2 compatibility: remove broken desync trace name tweaks

### DIFF
--- a/Source/Client/Native.cs
+++ b/Source/Client/Native.cs
@@ -78,7 +78,14 @@ namespace Multiplayer.Client
             if (ji == IntPtr.Zero) return null;
 
             var ptrToPrint = mono_jit_info_get_method(ji);
-            // todo: we once had a way to get the original unpatched method names, but Harmony removed it
+            var codeStart = (long)mono_jit_info_get_code_start(ji);
+
+            if (harmonyOriginals)
+            {
+                var original = MpUtil.GetOriginalFromHarmonyReplacement(codeStart);
+                if (original != null)
+                    ptrToPrint = original.MethodHandle.Value;
+            }
 
             var name = mono_debug_print_stack_frame(ptrToPrint, -1, domain);
 

--- a/Source/Client/Native.cs
+++ b/Source/Client/Native.cs
@@ -78,14 +78,7 @@ namespace Multiplayer.Client
             if (ji == IntPtr.Zero) return null;
 
             var ptrToPrint = mono_jit_info_get_method(ji);
-            var codeStart = (long)mono_jit_info_get_code_start(ji);
-
-            if (harmonyOriginals)
-            {
-                var original = MpUtil.GetOriginalFromHarmonyReplacement(codeStart);
-                if (original != null)
-                    ptrToPrint = original.MethodHandle.Value;
-            }
+            // todo: we once had a way to get the original unpatched method names, but Harmony removed it
 
             var name = mono_debug_print_stack_frame(ptrToPrint, -1, domain);
 

--- a/Source/Client/Util/MpUtil.cs
+++ b/Source/Client/Util/MpUtil.cs
@@ -106,15 +106,6 @@ namespace Multiplayer.Client
                     : $"{m.DeclaringType.DeclaringType?.FullDescription()} {m.DeclaringType.FullDescription()} {m.Name}"
                         .Replace("<", "[").Replace(">", "]");
         }
-
-        public static MethodBase GetOriginalFromHarmonyReplacement(long replacementAddr)
-        {
-            return HarmonySharedState.WithState(() =>
-            {
-                return HarmonySharedState.originals
-                    .FirstOrDefault(kv => kv.Key.GetNativeStart().ToInt64() == replacementAddr).Value;
-            });
-        }
     }
 
     public struct Container<T>

--- a/Source/Client/Util/MpUtil.cs
+++ b/Source/Client/Util/MpUtil.cs
@@ -106,6 +106,14 @@ namespace Multiplayer.Client
                     : $"{m.DeclaringType.DeclaringType?.FullDescription()} {m.DeclaringType.FullDescription()} {m.Name}"
                         .Replace("<", "[").Replace(">", "]");
         }
+
+        public static MethodBase GetOriginalFromHarmonyReplacement(long replacementAddr)
+        {
+            // Todo: this is using a non-public API of Harmony, we should refactor to use https://harmony.pardeike.net/api/HarmonyLib.Harmony.html#HarmonyLib_Harmony_GetOriginalMethod_System_Reflection_MethodInfo_
+            // as pardeike suggested in https://github.com/rwmt/Multiplayer/pull/270#issuecomment-1003298289
+            return HarmonySharedState.originals
+                .FirstOrDefault(kv => kv.Key.GetNativeStart().ToInt64() == replacementAddr).Value;
+        }
     }
 
     public struct Container<T>

--- a/Source/Common/Version.cs
+++ b/Source/Common/Version.cs
@@ -2,7 +2,7 @@ namespace Multiplayer.Common
 {
     public static class MpVersion
     {
-        public const string Version = "0.6.0.4";
+        public const string Version = "0.6.0.6";
         public const int Protocol = 25;
 
         public const string ApiAssemblyName = "0MultiplayerAPI";

--- a/Source/Multiplayer.csproj
+++ b/Source/Multiplayer.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Krafs.Publicizer" Version="1.0.1" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.3.0" />
-    <PackageReference Include="Lib.Harmony" Version="2.1.1" ExcludeAssets="runtime" />
+    <PackageReference Include="Lib.Harmony" Version="2.2.0" ExcludeAssets="runtime" />
     <PackageReference Include="LiteNetLib" Version="0.9.5" />
     <PackageReference Include="DotNetZip.Reduced" Version="1.9.1.8" />
     <PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.*" />


### PR DESCRIPTION
This _seems_ to resolve the only error Harmony 2.2 introduced:
```
System.MissingMethodException: !!0 HarmonyLib.HarmonySharedState.WithState<!0>(System.Func`1<!!0>)
```

Its the only usage of `HarmonySharedState` in the mod, and that class isn't documented in https://harmony.pardeike.net/api/index.html , so I'm guessing its not intended to be part of the public interface, and thus why there was no warning that pardeike was "breaking backwards compatibility" by modifying it (since undocumented interfaces aren't protected by BC).