### PR TITLE
Implemented force pause API

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncTimeComp.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Reflection;
+using Multiplayer.API;
 using UnityEngine;
 using Verse;
 using Verse.AI;
@@ -28,6 +29,7 @@ namespace Multiplayer.Client
     {
         public static Map tickingMap;
         public static Map executingCmdMap;
+        public static List<PauseEnforcerDelegate> pauseEnforcers = new();
 
         public float TickRateMultiplier(TimeSpeed speed)
         {
@@ -38,11 +40,12 @@ namespace Multiplayer.Client
                 comp.ritualSession != null ||
                 comp.mapDialogs.Any() ||
                 Multiplayer.WorldComp.AnyTradeSessionsOnMap(map) ||
-                Multiplayer.WorldComp.splitSession != null;
+                Multiplayer.WorldComp.splitSession != null ||
+                pauseEnforcers.Any(x => x(map));
 
             if (enforcePause)
                 return 0f;
-
+            
             if (mapTicks < slower.forceNormalSpeedUntil)
                 return speed == TimeSpeed.Paused ? 0 : 1;
 

--- a/Source/Client/AsyncTime/AsyncTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncTimeComp.cs
@@ -29,7 +29,7 @@ namespace Multiplayer.Client
     {
         public static Map tickingMap;
         public static Map executingCmdMap;
-        public static List<PauseEnforcerDelegate> pauseEnforcers = new();
+        public static List<PauseLockDelegate> pauseLocks = new();
 
         public float TickRateMultiplier(TimeSpeed speed)
         {
@@ -41,7 +41,7 @@ namespace Multiplayer.Client
                 comp.mapDialogs.Any() ||
                 Multiplayer.WorldComp.AnyTradeSessionsOnMap(map) ||
                 Multiplayer.WorldComp.splitSession != null ||
-                pauseEnforcers.Any(x => x(map));
+                pauseLocks.Any(x => x(map));
 
             if (enforcePause)
                 return 0f;

--- a/Source/Client/Comp/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/MultiplayerWorldComp.cs
@@ -34,8 +34,9 @@ namespace Multiplayer.Client
         {
             if (Multiplayer.GameComp.asyncTime)
             {
-                var enforcePause = Multiplayer.WorldComp.splitSession != null;
-
+                var enforcePause = Multiplayer.WorldComp.splitSession != null ||
+                    AsyncTimeComp.pauseEnforcers.Any(x => x(null));
+                
                 if (enforcePause)
                     return 0f;
             }

--- a/Source/Client/Comp/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/MultiplayerWorldComp.cs
@@ -35,7 +35,7 @@ namespace Multiplayer.Client
             if (Multiplayer.GameComp.asyncTime)
             {
                 var enforcePause = Multiplayer.WorldComp.splitSession != null ||
-                    AsyncTimeComp.pauseEnforcers.Any(x => x(null));
+                    AsyncTimeComp.pauseLocks.Any(x => x(null));
                 
                 if (enforcePause)
                     return 0f;

--- a/Source/Client/Syncing/Sync.cs
+++ b/Source/Client/Syncing/Sync.cs
@@ -156,8 +156,8 @@ namespace Multiplayer.Client
                             RegisterSyncWorker(method, isImplicit: swa.isImplicit, shouldConstruct: swa.shouldConstruct);
                         else if (method.TryGetAttribute(out SyncDialogNodeTreeAttribute sdnta))
                             RegisterSyncDialogNodeTree(method);
-                        else if (method.TryGetAttribute(out PauseEnforcerAttribute pea))
-                            RegisterPauseEnforcer(method);
+                        else if (method.TryGetAttribute(out PauseLockAttribute pea))
+                            RegisterPauseLock(method);
                     }
                     catch (Exception e)
                     {
@@ -386,14 +386,14 @@ namespace Multiplayer.Client
             SyncUtil.PatchMethodForDialogNodeTreeSync(method);
         }
 
-        public static void RegisterPauseEnforcer(MethodInfo method)
+        public static void RegisterPauseLock(MethodInfo method)
         {
-            var enforcer = AccessTools.MethodDelegate<PauseEnforcerDelegate>(method);
+            var pauseLock = AccessTools.MethodDelegate<PauseLockAttribute>(method);
 
-            if (enforcer == null)
-                throw new Exception($"Couldn't generate pause enforcer delegate from {method.DeclaringType?.FullName}:{method.Name}");
+            if (pauseLock == null)
+                throw new Exception($"Couldn't generate pause lock delegate from {method.DeclaringType?.FullName}:{method.Name}");
 
-            AsyncTimeComp.pauseEnforcers.Add(enforcer);
+            AsyncTimeComp.pauseLocks.Add(pauseLock);
         }
 
         public static void ValidateAll()

--- a/Source/Client/Syncing/Sync.cs
+++ b/Source/Client/Syncing/Sync.cs
@@ -156,6 +156,8 @@ namespace Multiplayer.Client
                             RegisterSyncWorker(method, isImplicit: swa.isImplicit, shouldConstruct: swa.shouldConstruct);
                         else if (method.TryGetAttribute(out SyncDialogNodeTreeAttribute sdnta))
                             RegisterSyncDialogNodeTree(method);
+                        else if (method.TryGetAttribute(out PauseEnforcerAttribute pea))
+                            RegisterPauseEnforcer(method);
                     }
                     catch (Exception e)
                     {
@@ -382,6 +384,16 @@ namespace Multiplayer.Client
         public static void RegisterSyncDialogNodeTree(MethodInfo method)
         {
             SyncUtil.PatchMethodForDialogNodeTreeSync(method);
+        }
+
+        public static void RegisterPauseEnforcer(MethodInfo method)
+        {
+            var enforcer = AccessTools.MethodDelegate<PauseEnforcerDelegate>(method);
+
+            if (enforcer == null)
+                throw new Exception($"Couldn't generate pause enforcer delegate from {method.DeclaringType?.FullName}:{method.Name}");
+
+            AsyncTimeComp.pauseEnforcers.Add(enforcer);
         }
 
         public static void ValidateAll()

--- a/Source/Common/MultiplayerAPIBridge.cs
+++ b/Source/Common/MultiplayerAPIBridge.cs
@@ -110,9 +110,9 @@ namespace Multiplayer.Common
             Sync.RegisterSyncDialogNodeTree(method);
         }
 
-        public void RegisterPauseEnforcer(PauseEnforcerDelegate pauseEnforcer)
+        public void RegisterPauseLock(PauseLockDelegate pauseLock)
         {
-            AsyncTimeComp.pauseEnforcers.Add(pauseEnforcer);
+            AsyncTimeComp.pauseLocks.Add(pauseLock);
         }
     }
 }

--- a/Source/Common/MultiplayerAPIBridge.cs
+++ b/Source/Common/MultiplayerAPIBridge.cs
@@ -109,5 +109,10 @@ namespace Multiplayer.Common
         {
             Sync.RegisterSyncDialogNodeTree(method);
         }
+
+        public void RegisterPauseEnforcer(PauseEnforcerDelegate pauseEnforcer)
+        {
+            AsyncTimeComp.pauseEnforcers.Add(pauseEnforcer);
+        }
     }
 }


### PR DESCRIPTION
Requires changes in the API: rwmt/MultiplayerAPI#4

My main motivation behind creating this is that in some of the mods I've patched for MP they open up dialogs or windows - but it does not pause the game in MP like it normally would in SP. This allows to handle this outside of Multiplayer.

I've prepared the PR, but I'm not 100% decided on some details.

First: the name "pause enforcer". I've used it as I could not think of anything better, and would be fully okay with changing it.
Second: location of the list holding all the delegates. Originally I was contemplating between putting them as I did in `AsyncTimeComp`, or inside of `MultiplayerWorldComp`. I'm open to moving it anywhere else if someone were to suggest a better location.