### PR TITLE
Replaced MethodInfo with FastInvokeHandler where possible

### DIFF
--- a/Source/Client/Patches/Letters.cs
+++ b/Source/Client/Patches/Letters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -30,7 +30,7 @@ namespace Multiplayer.Client.Patches
     [HarmonyPatch(typeof(ChoiceLetter), nameof(ChoiceLetter.OpenLetter))]
     static class CloseDialogsForExpiredLetters
     {
-        public static Dictionary<Type, MethodInfo> rejectMethods = new();
+        public static Dictionary<Type, FastInvokeHandler> rejectMethods = new();
 
         static bool Prefix(ChoiceLetter __instance)
         {
@@ -40,7 +40,7 @@ namespace Multiplayer.Client.Patches
                 && __instance.disappearAtTick == Find.TickManager.TicksGame + 1
                 && rejectMethods.TryGetValue(__instance.GetType(), out var method))
             {
-                method.Invoke(__instance, new object[0]);
+                method.Invoke(__instance);
                 return false;
             }
 

--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -182,17 +182,17 @@ namespace Multiplayer.Client
             SyncMethod.LambdaInGetter(typeof(ChoiceLetter_AcceptJoiner), nameof(ChoiceLetter_AcceptJoiner.Choices), 0); // Accept joiner
             CloseDialogsForExpiredLetters.rejectMethods[typeof(ChoiceLetter_AcceptJoiner)] =
                 SyncMethod.LambdaInGetter(typeof(ChoiceLetter_AcceptJoiner), nameof(ChoiceLetter_AcceptJoiner.Choices), 1)
-                    .method; // Reject joiner
+                    .methodDelegate; // Reject joiner
 
             SyncMethod.LambdaInGetter(typeof(ChoiceLetter_AcceptVisitors), nameof(ChoiceLetter_AcceptVisitors.Option_Accept), 0); // Accept visitors join offer
             CloseDialogsForExpiredLetters.rejectMethods[typeof(ChoiceLetter_AcceptVisitors)] =
                 SyncMethod.LambdaInGetter(typeof(ChoiceLetter_AcceptVisitors), nameof(ChoiceLetter_AcceptVisitors.Option_RejectWithCharityConfirmation), 1)
-                    .method; // Reject visitors join offer
+                    .methodDelegate; // Reject visitors join offer
 
             SyncMethod.LambdaInGetter(typeof(ChoiceLetter_RansomDemand), nameof(ChoiceLetter_RansomDemand.Choices), 0); // Accept ransom demand
             CloseDialogsForExpiredLetters.rejectMethods[typeof(ChoiceLetter_RansomDemand)] =
                 SyncMethod.LambdaInGetter(typeof(ChoiceLetter), nameof(ChoiceLetter.Option_Reject), 0)
-                    .method; // Generic reject (currently only used by ransom demand)
+                    .methodDelegate; // Generic reject (currently only used by ransom demand)
         }
 
         [MpPrefix(typeof(FormCaravanComp), nameof(FormCaravanComp.GetGizmos), lambdaOrdinal: 0)]

--- a/Source/Client/Syncing/Handler/SyncMethod.cs
+++ b/Source/Client/Syncing/Handler/SyncMethod.cs
@@ -41,6 +41,7 @@ namespace Multiplayer.Client
     {
         public readonly Type targetType;
         public readonly MethodInfo method;
+        public readonly FastInvokeHandler methodDelegate;
 
         protected readonly string instancePath;
 
@@ -65,6 +66,7 @@ namespace Multiplayer.Client
             this.targetType = targetType;
             this.instancePath = instancePath;
 
+            methodDelegate = MethodInvoker.GetHandler(method);
             argTypes = CheckArgs(method, inTypes);
             argNames = method.GetParameters().Names();
             argTransformers = new SyncTransformer[argTypes.Length];
@@ -195,7 +197,7 @@ namespace Multiplayer.Client
             beforeCall?.Invoke(target, args);
 
             MpLog.Debug($"Invoked {method} on {target} with {args.Length} params {args.ToStringSafeEnumerable()}");
-            method.Invoke(target, args);
+            methodDelegate.Invoke(target, args);
 
             afterCall?.Invoke(target, args);
         }

--- a/Source/Common/Networking/Connection.cs
+++ b/Source/Common/Networking/Connection.cs
@@ -142,7 +142,7 @@ namespace Multiplayer.Common
 
             if (fragState == FRAG_NONE)
             {
-                handler.Method.Invoke(stateObj, new object[] { reader });
+                handler.Method.Invoke(stateObj, reader);
             }
             else if (!handler.Fragment)
             {
@@ -160,7 +160,7 @@ namespace Multiplayer.Common
 
                 if (fragState == FRAG_END)
                 {
-                    handler.Method.Invoke(stateObj, new object[] { new ByteReader(fragmented.ToArray()) });
+                    handler.Method.Invoke(stateObj, new ByteReader(fragmented.ToArray()));
                     fragmented = null;
                 }
             }

--- a/Source/Common/Networking/MpConnectionState.cs
+++ b/Source/Common/Networking/MpConnectionState.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Reflection;
+using HarmonyLib;
 
 namespace Multiplayer.Common
 {
@@ -38,7 +39,7 @@ namespace Multiplayer.Common
                     continue;
 
                 bool fragment = method.GetAttribute<IsFragmentedAttribute>() != null;
-                packetHandlers[(int)state, (int)attr.packet] = new PacketHandlerInfo(method, fragment);
+                packetHandlers[(int)state, (int)attr.packet] = new PacketHandlerInfo(MethodInvoker.GetHandler(method), fragment);
             }
         }
     }

--- a/Source/Common/Networking/PacketHandlerAttribute.cs
+++ b/Source/Common/Networking/PacketHandlerAttribute.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using HarmonyLib;
 using JetBrains.Annotations;
 
 namespace Multiplayer.Common
@@ -23,5 +24,5 @@ namespace Multiplayer.Common
     {
     }
 
-    public record PacketHandlerInfo(MethodInfo Method, bool Fragment);
+    public record PacketHandlerInfo(FastInvokeHandler Method, bool Fragment);
 }


### PR DESCRIPTION
From my testing, calling FastInvokeHandler.Invoke is around 4-5 times faster than calling MethodInfo.Invoke - which is still far slower than calling the method directly, but ends up being faster than the alternative.

I realize that such a change could be seen as controversial and fully understand it could be rejected. However, I personally believe it could be beneficial if accepted.