### PR TITLE
Prevent creation of TabStorageWrapper when storage is a thing/comp with null map

### DIFF
--- a/Source/Client/Syncing/Game/SyncGame.cs
+++ b/Source/Client/Syncing/Game/SyncGame.cs
@@ -80,8 +80,13 @@ namespace Multiplayer.Client
 
         #region ThingFilter Markers
         [MpPrefix(typeof(ITab_Storage), "FillTab")]
-        static void TabStorageFillTab_Prefix(ITab_Storage __instance) =>
+        static void TabStorageFillTab_Prefix(ITab_Storage __instance)
+        {
+            var selThing = __instance.SelStoreSettingsParent;
+            if (selThing is Thing {Map: null} or ThingComp {parent: {Map: null}})
+                return;
             tabStorage = new(__instance.SelStoreSettingsParent);
+        }
 
         [MpPostfix(typeof(ITab_Storage), "FillTab")]
         static void TabStorageFillTab_Postfix() => tabStorage = null;


### PR DESCRIPTION
I'm unsure how this exactly happens, but it's happening consistently with Save our Ship 2 torpedoes.

I assumed it'd be better to patch it here instead of doing harmony prefixes to prevent it from being created, as it's (in my eyes) much cleaner solution to this issue. And in case it ever would appear in another mod, it'll help with those situations too.

Fixes one of the issues in rwmt/Multiplayer-Compatibility#167