### PR TITLE
Fixes display of favorite/ideo color buttons in styling dialog

### DIFF
--- a/Source/Client/Patches/StylingStation.cs
+++ b/Source/Client/Patches/StylingStation.cs
@@ -52,6 +52,10 @@ namespace Multiplayer.Client.Patches
             pawn.pather = new Pawn_PathFollower(pawn);
             pawn.roping = new Pawn_RopeTracker(pawn);
             pawn.mindState = new Pawn_MindState(pawn);
+            pawn.ideo = new Pawn_IdeoTracker(pawn)
+            {
+                ideo = dialog.pawn.ideo.ideo
+            };
 
             window = new Dialog_StylingStation(pawn, dialog.stylingStation);
 


### PR DESCRIPTION
The pawn was missing ideo, thus ideo button wasn't drawn, and favorite color used color picker rect for position.