### PR TITLE
Dont start a job to go to the styling station until confirming

### DIFF
--- a/Source/Client/Patches/StylingStation.cs
+++ b/Source/Client/Patches/StylingStation.cs
@@ -1,11 +1,10 @@
 using HarmonyLib;
 using Multiplayer.API;
 using RimWorld;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reflection;
+using Multiplayer.Client.Util;
 using UnityEngine;
 using Verse;
 using Verse.AI;
@@ -20,31 +19,42 @@ namespace Multiplayer.Client.Patches
     [HarmonyPatch(typeof(WindowStack), nameof(WindowStack.Add))]
     static class StylingDialog_ReplaceWindow
     {
+        // We normally open the dialog through OpenDialogWithoutCreatingJob,
+        // but we leave this here in case some mod opens up the styling dialog by their own
         static bool Prefix(ref Window window)
         {
-            if (Multiplayer.Client == null || window is not Dialog_StylingStation dialog)
+            if (Multiplayer.Client == null || window is not Dialog_StylingStation dialog || dialog.pawn is StylingDialog_DummyPawn)
                 return true;
 
+            window = CreateStylingDialog(dialog.pawn, dialog.stylingStation);
+
+            return Multiplayer.ExecutingCmds && TickPatch.currentExecutingCmdIssuedBySelf
+                   || dialog.pawn.CurJob.loadID == SyncMethods.stylingStationJobStartedByMe;
+        }
+
+        public static Dialog_StylingStation CreateStylingDialog(Pawn dialogPawn, Thing stylingStation)
+        {
             // In vanilla, the styling dialog mutates the pawn directly
             // A dummy pawn taking on the mutations is needed for multiplayer
-            var pawn = new StylingDialog_DummyPawn();
+            var pawn = new StylingDialog_DummyPawn
+            {
+                origPawn = dialogPawn,
+                def = dialogPawn.def,
+                gender = dialogPawn.gender,
+                mapIndexOrState = dialogPawn.mapIndexOrState,
+                nameInt = dialogPawn.Name
+            };
 
-            pawn.origPawn = dialog.pawn;
-            pawn.def = dialog.pawn.def;
-            pawn.gender = dialog.pawn.gender;
-            pawn.mapIndexOrState = dialog.pawn.mapIndexOrState;
-            pawn.Name = dialog.pawn.Name;
-
-            pawn.story = MpUtil.ShallowCopy(dialog.pawn.story, new Pawn_StoryTracker(pawn));
+            pawn.story = MpUtil.ShallowCopy(dialogPawn.story, new Pawn_StoryTracker(pawn));
             pawn.story.pawn = pawn;
 
-            pawn.style = MpUtil.ShallowCopy(dialog.pawn.style, new Pawn_StyleTracker(pawn));
+            pawn.style = MpUtil.ShallowCopy(dialogPawn.style, new Pawn_StyleTracker(pawn));
             pawn.style.pawn = pawn;
 
-            pawn.apparel = MpUtil.ShallowCopy(dialog.pawn.apparel, new Pawn_ApparelTracker(pawn));
+            pawn.apparel = MpUtil.ShallowCopy(dialogPawn.apparel, new Pawn_ApparelTracker(pawn));
             pawn.apparel.pawn = pawn;
             pawn.apparel.lockedApparel = pawn.apparel.lockedApparel.ToList();
-            pawn.apparel.wornApparel = MpUtil.ShallowCopy(dialog.pawn.apparel.wornApparel, new ThingOwner<Apparel>());
+            pawn.apparel.wornApparel = MpUtil.ShallowCopy(dialogPawn.apparel.wornApparel, new ThingOwner<Apparel>());
             pawn.apparel.wornApparel.innerList = pawn.apparel.wornApparel.innerList.ToList();
 
             pawn.health = new Pawn_HealthTracker(pawn);
@@ -53,10 +63,7 @@ namespace Multiplayer.Client.Patches
             pawn.roping = new Pawn_RopeTracker(pawn);
             pawn.mindState = new Pawn_MindState(pawn);
 
-            window = new Dialog_StylingStation(pawn, dialog.stylingStation);
-
-            return Multiplayer.ExecutingCmds && TickPatch.currentExecutingCmdIssuedBySelf
-                || dialog.pawn.CurJob.loadID == SyncMethods.stylingStationJobStartedByMe;
+            return new Dialog_StylingStation(pawn, stylingStation);
         }
     }
 
@@ -191,6 +198,32 @@ namespace Multiplayer.Client.Patches
                 }
             }
             dialog.ApplyApparelColors();
+        }
+    }
+
+    [HarmonyPatch]
+    internal static class OpenDialogWithoutCreatingJob
+    {
+        private static AccessTools.FieldRef<object, Building_StylingStation> stylingStationField;
+
+        internal static MethodBase TargetMethod()
+        {
+            var method = MpMethodUtil.GetLambda(typeof(Building_StylingStation),
+                nameof(Building_StylingStation.GetFloatMenuOptions), lambdaOrdinal: 0);
+
+            stylingStationField = AccessTools.FieldRefAccess<Building_StylingStation>(method.DeclaringType, "<>4__this");
+            
+            return method;
+        }
+
+        internal static bool Prefix(object __instance, Pawn ___selPawn)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            Find.WindowStack.Add(StylingDialog_ReplaceWindow.CreateStylingDialog(___selPawn, stylingStationField(__instance)));
+
+            return false;
         }
     }
 


### PR DESCRIPTION
Right now in MP, if you order a pawn to use a styling station they'll walk there, only to open the dialog for the player who ordered it, and walk away while that player is modifying their style.

I've modified the behaviour here to not take the job and instead open the dialog for the player who ordered it - the job to change style will be applied after accepting the dialog, like it was previously.