### PR TITLE
Synced "Execute guilty colonist" action

### DIFF
--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -23,6 +23,7 @@ namespace Multiplayer.Client
         public static ISyncField SyncBeCarried;
         public static ISyncField SyncPsychicEntropyLimit;
         public static ISyncField SyncPsychicEntropyTargetFocus;
+        public static ISyncField SyncGuiltAwaitingExecution;
 
         public static ISyncField SyncGodMode;
         public static ISyncField SyncUseWorkPriorities;
@@ -91,6 +92,7 @@ namespace Multiplayer.Client
             SyncBeCarried = Sync.Field(typeof(Pawn), "health", "beCarriedByCaravanIfSick");
             SyncPsychicEntropyLimit = Sync.Field(typeof(Pawn), "psychicEntropy", "limitEntropyAmount");
             SyncPsychicEntropyTargetFocus = Sync.Field(typeof(Pawn), "psychicEntropy", "targetPsyfocus").SetBufferChanges();
+            SyncGuiltAwaitingExecution = Sync.Field(typeof(Pawn), nameof(Pawn.guilt), nameof(Pawn_GuiltTracker.awaitingExecution));
 
             SyncUseWorkPriorities = Sync.Field(null, "Verse.Current/Game/playSettings", "useWorkPriorities").PostApply(UseWorkPriorities_PostApply);
             SyncAutoHomeArea = Sync.Field(null, "Verse.Current/Game/playSettings", "autoHomeArea");
@@ -508,6 +510,12 @@ namespace Multiplayer.Client
         {
             SyncNeuralSuperchargerMode.Watch(__instance.comp);
 		}
+
+        [MpPrefix(typeof(CharacterCardUtility), nameof(CharacterCardUtility.DrawCharacterCard))]
+        static void WatchAwaitingExecution(Pawn pawn)
+        {
+            SyncGuiltAwaitingExecution.Watch(pawn);
+        }
     }
 
 }


### PR DESCRIPTION
Considering that I was not aware that this interaction even exists, I assume it may be the same for some other people. In that case, here's an image showing which button it refers to:

![unknown](https://user-images.githubusercontent.com/36712560/184499198-b37165b2-1d66-4546-97b5-5ee2538f338c.png)