### PR TITLE
Stop abilities with confirmation dialogs from being synced

### DIFF
--- a/Source/Client/Patches/Abilities.cs
+++ b/Source/Client/Patches/Abilities.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace Multiplayer.Client
+{
+    // Sanguophage bloodfeed ability shows a confirmation if it'll cause a severe blood loss or kill the target, which we don't want to do.
+    // Cancel syncing if the method is showing a confirmation dialog for situations like those.
+    [HarmonyPatch(typeof(Verb_CastAbility), nameof(Verb_CastAbility.OrderForceTarget))]
+    public class CancelTargetableAbilityWithConfirmation
+    {
+        static void Prefix(Verb_CastAbility __instance, LocalTargetInfo target, ref bool __state)
+        {
+            if (Multiplayer.Client == null ||
+                Multiplayer.dontSync ||
+                __instance.ability?.ConfirmationDialog(target, () => { }) == null) // Use an empty action in case some method checks for null
+                return;
+
+            __state = true;
+            Multiplayer.dontSync = true;
+        }
+
+        static void Postfix(bool __state)
+        {
+            if (__state)
+                Multiplayer.dontSync = false;
+        }
+    }
+}


### PR DESCRIPTION
This prevents situations where the ability opens a confirmation dialog without actually casting the ability. As mentioned in the comments in the code, this affects sanguophage bloodfeed ability in cases it displays a warning (severe blood loss or death).