### PR TITLE
Fix styling station dialog

### DIFF
--- a/Source/Client/Patches/StylingStation.cs
+++ b/Source/Client/Patches/StylingStation.cs
@@ -66,6 +66,10 @@ namespace Multiplayer.Client.Patches
             {
                 ideo = dialogPawn.ideo.ideo
             };
+            pawn.ageTracker = new Pawn_AgeTracker(pawn)
+            {
+                cachedLifeStageIndex = dialogPawn.ageTracker.cachedLifeStageIndex
+            };
 
             return new Dialog_StylingStation(pawn, stylingStation);
         }


### PR DESCRIPTION
Seems like pawn rendering now check for the pawn's life stage, and as the tracker was null it was causing exceptions. We also need to set the life stage index, as otherwise the pawns will be drawn as children in the dialog.