### PR TITLE
Added Ultrafast speed to TickRatePatch, changed if/else to switch

### DIFF
--- a/Source/Client/AsyncTime/TickRatePatch.cs
+++ b/Source/Client/AsyncTime/TickRatePatch.cs
@@ -10,16 +10,27 @@ namespace Multiplayer.Client
         {
             if (Multiplayer.Client == null) return true;
 
-            if (__instance.CurTimeSpeed == TimeSpeed.Paused)
-                __result = 0;
-            else if (__instance.slower.ForcedNormalSpeed)
-                __result = 1;
-            else if (__instance.CurTimeSpeed == TimeSpeed.Fast)
-                __result = 3;
-            else if (__instance.CurTimeSpeed == TimeSpeed.Superfast)
-                __result = 6;
-            else
-                __result = 1;
+            switch (__instance.CurTimeSpeed, __instance.slower.ForcedNormalSpeed)
+            {
+                case (TimeSpeed.Paused, _):
+                    __result = 0;
+                    break;
+                case (_, true):
+                    __result = 1;
+                    break;
+                case (TimeSpeed.Fast, _):
+                    __result = 3;
+                    break;
+                case (TimeSpeed.Superfast, _):
+                    __result = 6;
+                    break;
+                case (TimeSpeed.Ultrafast, _):
+                    __result = 15;
+                    break;
+                default:
+                    __result = 1;
+                    break;
+            }
 
             return false;
         }


### PR DESCRIPTION
Using the switch should allow compiler to better optimize the method (looking at decompiled code and IL code, it seems it is the case for this method).

We could use the switch expression instead of the switch statement - the issue with that however is that it introduces a temporary variable in compiled code (the value it later assigns to __result), as well as it needs the values to be floats explicitly as it'll otherwise use an int variable that it later converts to float.

Adding the Ultrafast speed doesn't really change much - the biggest change I've seen is that some mods that display target tickrate will now do so correctly on speed 4, where they previously would show incorrect value of 60.