### PR TITLE
Fixed bugs/desyncs with auto selecting travel supplies

### DIFF
--- a/Source/Client/Persistent/CaravanFormingProxy.cs
+++ b/Source/Client/Persistent/CaravanFormingProxy.cs
@@ -33,6 +33,8 @@ namespace Multiplayer.Client
                     startingTile = session.startingTile;
                     destinationTile = session.destinationTile;
                     autoSelectTravelSupplies = session.autoSelectTravelSupplies;
+                    if (autoSelectTravelSupplies)
+                        SelectApproximateBestTravelSupplies();
 
                     session.uiDirty = false;
                 }

--- a/Source/Client/Persistent/CaravanFormingSession.cs
+++ b/Source/Client/Persistent/CaravanFormingSession.cs
@@ -145,7 +145,6 @@ namespace Multiplayer.Client
             if (autoSelectTravelSupplies != value)
             {
                 autoSelectTravelSupplies = value;
-                PrepareDummyDialog().SelectApproximateBestTravelSupplies();
                 uiDirty = true;
             }
         }


### PR DESCRIPTION
From some testing, it seems changing destination tile didn't update the travel supplies (possibly in other situations too). This could have led to incorrect supplies or (in some cases) desyncs.