### PR TITLE
Separate time control hotkey logic to separate method

### DIFF
--- a/Source/Client/AsyncTime/TimeControlUI.cs
+++ b/Source/Client/AsyncTime/TimeControlUI.cs
@@ -118,6 +118,11 @@ public static class TimeControlPatch
         GenUI.AbsorbClicksInRect(timerRect);
         UIHighlighter.HighlightOpportunity(timerRect, "TimeControls");
 
+        DoTimeControlsHotkeys();
+    }
+
+    private static void DoTimeControlsHotkeys()
+    {
         if (Event.current.type != EventType.KeyDown)
             return;
 


### PR DESCRIPTION
This won't affect MP itself - it's done for the purpose of compatibility. Mods that disable/hide time controls GUI can call this method to easily modify the handling of hotkeys in MP.