### PR TITLE
Added sync worker for IGeneResourceDrain

### DIFF
--- a/Source/Client/Syncing/Dict/SyncDictDlc.cs
+++ b/Source/Client/Syncing/Dict/SyncDictDlc.cs
@@ -261,6 +261,16 @@ namespace Multiplayer.Client
                 }
             },
             {
+                (ByteWriter data, IGeneResourceDrain gizmo) =>
+                {
+                    if (gizmo is Gene gene)
+                        WriteSync(data, gene);
+                    else
+                        throw new Exception($"Unsupported {nameof(IGeneResourceDrain)} type: {gizmo.GetType()}");
+                },
+                (ByteReader data) => ReadSync<Gene>(data) as IGeneResourceDrain
+            },
+            {
                 (ByteWriter data, MechanitorControlGroup group) =>
                 {
                     WriteSync(data, group.tracker.Pawn);

--- a/Source/Client/Syncing/Dict/SyncDictDlc.cs
+++ b/Source/Client/Syncing/Dict/SyncDictDlc.cs
@@ -261,12 +261,12 @@ namespace Multiplayer.Client
                 }
             },
             {
-                (ByteWriter data, IGeneResourceDrain gizmo) =>
+                (ByteWriter data, IGeneResourceDrain resourceDrain) =>
                 {
-                    if (gizmo is Gene gene)
+                    if (resourceDrain is Gene gene)
                         WriteSync(data, gene);
                     else
-                        throw new Exception($"Unsupported {nameof(IGeneResourceDrain)} type: {gizmo.GetType()}");
+                        throw new Exception($"Unsupported {nameof(IGeneResourceDrain)} type: {resourceDrain.GetType()}");
                 },
                 (ByteReader data) => ReadSync<Gene>(data) as IGeneResourceDrain
             },


### PR DESCRIPTION
Unnecessary for MP with no other mods. Added for the purpose of mod compatibility.

All vanilla implementations of IGeneResourceDrain, as well as all modded ones I could find, are a subtype of the Gene class - so for implementation, I check if it's a subtype of it and throw an exception otherwise.