### PR TITLE
Fix ambiguous match on `GetMethod` calls when looping over `AllSubtypesAndSelf`

### DIFF
--- a/Source/Client/MultiplayerStatic.cs
+++ b/Source/Client/MultiplayerStatic.cs
@@ -287,17 +287,17 @@ namespace Multiplayer.Client
             {
                 var designatorFinalizer = AccessTools.Method(typeof(DesignatorPatches), "DesignateFinalizer");
                 var designatorMethods = new[] {
-                     "DesignateSingleCell",
-                     "DesignateMultiCell",
-                     "DesignateThing",
+                     ("DesignateSingleCell", new[]{ typeof(IntVec3) }),
+                     ("DesignateMultiCell", new[]{ typeof(IEnumerable<IntVec3>) }),
+                     ("DesignateThing", new[]{ typeof(Thing) }),
                 };
 
                 foreach (Type t in typeof(Designator).AllSubtypesAndSelf()
                              .Except(typeof(Designator_MechControlGroup))) // Opens float menu, sync that instead
                 {
-                    foreach (string m in designatorMethods)
+                    foreach ((string m, Type[] args) in designatorMethods)
                     {
-                        MethodInfo method = t.GetMethod(m, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+                        MethodInfo method = t.GetMethod(m, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly, null, args, null);
                         if (method == null) continue;
 
                         MethodInfo prefix = AccessTools.Method(typeof(DesignatorPatches), m);
@@ -357,13 +357,21 @@ namespace Multiplayer.Client
             {
                 var thingMethodPrefix = new HarmonyMethod(typeof(ThingMethodPatches).GetMethod("Prefix"));
                 var thingMethodPostfix = new HarmonyMethod(typeof(ThingMethodPatches).GetMethod("Postfix"));
-                var thingMethods = new[] { "Tick", "TickRare", "TickLong", "SpawnSetup", "TakeDamage", "Kill" };
+                var thingMethods = new[]
+                {
+                    ("Tick", Type.EmptyTypes),
+                    ("TickRare", Type.EmptyTypes),
+                    ("TickLong", Type.EmptyTypes),
+                    ("SpawnSetup", new[]{ typeof(Map), typeof(bool) }),
+                    ("TakeDamage", new[]{ typeof(DamageInfo) }),
+                    ("Kill", new[]{ typeof(DamageInfo?), typeof(Hediff) })
+                };
 
                 foreach (Type t in typeof(Thing).AllSubtypesAndSelf())
                 {
-                    foreach (string m in thingMethods)
+                    foreach ((string m, Type[] args) in thingMethods)
                     {
-                        MethodInfo method = t.GetMethod(m, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+                        MethodInfo method = t.GetMethod(m, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly, null, args, null);
                         if (method != null)
                         {
                             try
@@ -400,7 +408,7 @@ namespace Multiplayer.Client
 
                 foreach (var t in typeof(InspectTabBase).AllSubtypesAndSelf())
                 {
-                    var method = t.GetMethod("FillTab", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                    var method = t.GetMethod("FillTab", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly, null, Type.EmptyTypes, null);
                     if (method != null && !method.IsAbstract)
                     {
                         try

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -63,10 +63,10 @@ namespace Multiplayer.Client
             {
                 var types = typeof(CompAssignableToPawn).AllSubtypesAndSelf().ToArray();
                 var assignMethods = types
-                    .Select(t => t.GetMethod(nameof(CompAssignableToPawn.TryAssignPawn), AccessTools.allDeclared))
+                    .Select(t => t.GetMethod(nameof(CompAssignableToPawn.TryAssignPawn), AccessTools.allDeclared, null, new[] { typeof(Pawn) }, null))
                     .AllNotNull();
                 var unassignMethods = types
-                    .Select(t => t.GetMethod(nameof(CompAssignableToPawn.TryUnassignPawn), AccessTools.allDeclared))
+                    .Select(t => t.GetMethod(nameof(CompAssignableToPawn.TryUnassignPawn), AccessTools.allDeclared, null, new[] { typeof(Pawn), typeof(bool), typeof(bool) }, null))
                     .AllNotNull();
 
                 var unassignSerializer = Serializer.New(


### PR DESCRIPTION
This should fix the (surprisingly) rare situations when a class we're patching includes a method with same name but different parameters.

Currently, this fixes a conflict with Vehicle Framework.