### PR TITLE
Change the patch on `MapDeiniter` to target `Deinit_NewTemp` instead of `Deinit`

### DIFF
--- a/Source/Client/Saving/CrossRefs.cs
+++ b/Source/Client/Saving/CrossRefs.cs
@@ -165,7 +165,7 @@ namespace Multiplayer.Client
     }
 
     [HarmonyPatch(typeof(MapDeiniter))]
-    [HarmonyPatch(nameof(MapDeiniter.Deinit))]
+    [HarmonyPatch(nameof(MapDeiniter.Deinit_NewTemp))]
     public static class DeinitMapPatch
     {
         static void Prefix(Map map)


### PR DESCRIPTION
`MapDeiniter.Deinit` is marked as obsolete, never called from vanilla code, and calls `MapDeiniter.Deinit_NewTemp`. Unless there is a reason for it, I don't see why the patch should apply to the obsolete method anymore.