### PR TITLE
Remove duplicate sync method lambda.

### DIFF
--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -73,7 +73,6 @@ namespace Multiplayer.Client
             SyncMethod.Lambda(typeof(CompRefuelable), nameof(CompRefuelable.CompGetGizmosExtra), 5).SetDebugOnly();     // Set fuel to max
 
             SyncMethod.Lambda(typeof(CompShuttle), nameof(CompShuttle.CompGetGizmosExtra), 1);  // Toggle autoload
-            SyncMethod.Lambda(typeof(ShipJob_Wait), nameof(ShipJob_Wait.GetJobGizmos), 1);      // Send shuttle
 
             SyncDelegate.LocalFunc(typeof(RoyalTitlePermitWorker_CallShuttle), nameof(RoyalTitlePermitWorker_CallShuttle.CallShuttleToCaravan), "Launch").ExposeParameter(1);  // Call shuttle permit on caravan
 


### PR DESCRIPTION
`ShipJob_Wait` is synced slightly below, on lines 104-105 (or 105-106 before this change):

https://github.com/SokyranTheDragon/Multiplayer/blob/a3a8c5e530798cccc887fcaaaba1de74cbc8e1aa/Source/Client/Syncing/Game/SyncDelegates.cs#L104-L105