### PR TITLE
Minor maintenance on CaravanSplittingProxy

### DIFF
--- a/Source/Client/Persistent/CaravanSplittingProxy.cs
+++ b/Source/Client/Persistent/CaravanSplittingProxy.cs
@@ -1,3 +1,4 @@
+using Multiplayer.Client.Util;
 using RimWorld.Planet;
 using UnityEngine;
 using Verse;
@@ -65,7 +66,7 @@ namespace Multiplayer.Client.Persistent
                 Widgets.Label(rect, "SplitCaravan".Translate());
                 Text.Font = GameFont.Small;
                 Text.Anchor = TextAnchor.UpperLeft;
-                CaravanUIUtility.DrawCaravanInfo(new CaravanUIUtility.CaravanInfo(SourceMassUsage, SourceMassCapacity, cachedSourceMassCapacityExplanation, SourceTilesPerDay, cachedSourceTilesPerDayExplanation, SourceDaysWorthOfFood, SourceForagedFoodPerDay, cachedSourceForagedFoodPerDayExplanation, SourceVisibility, cachedSourceVisibilityExplanation, -1f, -1f, null), new CaravanUIUtility.CaravanInfo(DestMassUsage, DestMassCapacity, cachedDestMassCapacityExplanation, DestTilesPerDay, cachedDestTilesPerDayExplanation, DestDaysWorthOfFood, DestForagedFoodPerDay, cachedDestForagedFoodPerDayExplanation, DestVisibility, cachedDestVisibilityExplanation, -1f, -1f, null), caravan.Tile, (!caravan.pather.Moving) ? null : new int?(TicksToArrive), -9999f, new Rect(12f, 35f, inRect.width - 24f, 40f), true, null, false);
+                CaravanUIUtility.DrawCaravanInfo(new CaravanUIUtility.CaravanInfo(SourceMassUsage, SourceMassCapacity, cachedSourceMassCapacityExplanation, SourceTilesPerDay, cachedSourceTilesPerDayExplanation, SourceDaysWorthOfFood, SourceForagedFoodPerDay, cachedSourceForagedFoodPerDayExplanation, SourceVisibility, cachedSourceVisibilityExplanation), new CaravanUIUtility.CaravanInfo(DestMassUsage, DestMassCapacity, cachedDestMassCapacityExplanation, DestTilesPerDay, cachedDestTilesPerDayExplanation, DestDaysWorthOfFood, DestForagedFoodPerDay, cachedDestForagedFoodPerDayExplanation, DestVisibility, cachedDestVisibilityExplanation), caravan.Tile, caravan.pather.Moving ? TicksToArrive : null, -9999f, new Rect(12f, 35f, inRect.width - 24f, 40f));
                 tabsList.Clear();
                 tabsList.Add(new TabRecord("PawnsTab".Translate(), delegate
                 {
@@ -75,7 +76,7 @@ namespace Multiplayer.Client.Persistent
                 {
                     tab = Tab.Items;
                 }, tab == Tab.Items));
-                tabsList.Add(new TabRecord("FoodAndMedicineTab".Translate(), delegate
+                tabsList.Add(new TabRecord("TravelSupplies".Translate(), delegate
                 {
                     tab = Tab.FoodAndMedicine;
                 }, tab == Tab.FoodAndMedicine));
@@ -83,7 +84,7 @@ namespace Multiplayer.Client.Persistent
                 Widgets.DrawMenuSection(inRect);
                 TabDrawer.DrawTabs(inRect, tabsList, 200f);
                 inRect = inRect.ContractedBy(17f);
-                GUI.BeginGroup(inRect);
+                Widgets.BeginGroup(inRect);
                 Rect rect2 = inRect.AtZero();
                 DoBottomButtons(rect2);
                 Rect inRect2 = rect2;
@@ -105,7 +106,7 @@ namespace Multiplayer.Client.Persistent
                 {
                     CountToTransferChanged();
                 }
-                GUI.EndGroup();
+                Widgets.EndGroup();
             }
             finally
             {
@@ -120,39 +121,25 @@ namespace Multiplayer.Client.Persistent
         /// <param name="rect"></param>
         private new void DoBottomButtons(Rect rect)
         {
-            float num = rect.width / 2f;
-            Vector2 bottomButtonSize = BottomButtonSize;
-            float x = num - bottomButtonSize.x / 2f;
-            float y = rect.height - 55f;
-            Vector2 bottomButtonSize2 = BottomButtonSize;
-            float x2 = bottomButtonSize2.x;
-            Vector2 bottomButtonSize3 = BottomButtonSize;
-            Rect rect2 = new Rect(x, y, x2, bottomButtonSize3.y);
-            if (Widgets.ButtonText(rect2, "AcceptButton".Translate(), true, false, true))
+            Rect acceptRect = new Rect(rect.width / 2f - BottomButtonSize.x / 2f, rect.height - 55f, BottomButtonSize.x, BottomButtonSize.y);
+            if (Widgets.ButtonText(acceptRect, "AcceptButton".Translate(), true, false))
             {
                 AcceptButtonClicked();
             }
-            float num2 = rect2.x - 10f;
-            Vector2 bottomButtonSize4 = BottomButtonSize;
-            float x3 = num2 - bottomButtonSize4.x;
-            float y2 = rect2.y;
-            Vector2 bottomButtonSize5 = BottomButtonSize;
-            float x4 = bottomButtonSize5.x;
-            Vector2 bottomButtonSize6 = BottomButtonSize;
-            Rect rect3 = new Rect(x3, y2, x4, bottomButtonSize6.y);
-            if (Widgets.ButtonText(rect3, "ResetButton".Translate(), true, false, true))
+
+            Rect resetRect = new Rect(acceptRect.x - 10f - BottomButtonSize.x, acceptRect.y, BottomButtonSize.x, BottomButtonSize.y);
+            if (Widgets.ButtonText(resetRect, "ResetButton".Translate(), true, false))
             {
                 ResetButtonClicked();
             }
-            float x5 = rect2.xMax + 10f;
-            float y3 = rect2.y;
-            Vector2 bottomButtonSize7 = BottomButtonSize;
-            float x6 = bottomButtonSize7.x;
-            Vector2 bottomButtonSize8 = BottomButtonSize;
-            Rect rect4 = new Rect(x5, y3, x6, bottomButtonSize8.y);
-            if (Widgets.ButtonText(rect4, "CancelButton".Translate(), true, false, true))
+
+            using (MpStyle.Set(new Color(1f, 0.3f, 0.35f)))
             {
-                CancelButtonClicked();
+                Rect cancelRect = new Rect(acceptRect.xMax + 10f, acceptRect.y, BottomButtonSize.x, BottomButtonSize.y);
+                if (Widgets.ButtonText(cancelRect, "CancelButton".Translate(), true, false))
+                {
+                    CancelButtonClicked();
+                }
             }
         }
 


### PR DESCRIPTION
- The cancel button will be red to match the behaviour of other session dialogs
- The proper translation key is used for travel supplies tab
- GUI.Begin/EndGroup was replaced by Widgets.Begin/EndGroup to match vanilla dialog (it seems Widgets call fixes some Unity bugs on Linux/Steam Deck)
- Removed a lot of temporary variables in DoBottomButtons
- Cleaned up CaravanUIUtility.DrawCaravanInfo call by removing default values, removing `new int?()`, and inverting the conditional operator