### PR TITLE
Fix syncing of copy/paste gizmos for Biosculpter/Growth Vat/Mortar, fixes #255

### DIFF
--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -560,7 +560,7 @@ namespace Multiplayer.Client
     }
 
     [HarmonyPatch]
-    public static class NutritionStoragesKeepsItsOwner
+    public static class StoragesKeepsTheirOwners
     {
         [HarmonyPostfix]
         [HarmonyPatch(typeof(Building_GrowthVat), nameof(Building_GrowthVat.ExposeData))]

--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -558,4 +558,32 @@ namespace Multiplayer.Client
             );
         }
     }
+
+    [HarmonyPatch]
+    public static class NutritionStoragesKeepsItsOwner
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(Building_GrowthVat), nameof(Building_GrowthVat.ExposeData))]
+        static void PostBuildingGrowthVat(Building_GrowthVat __instance)
+            => FixStorage(__instance, __instance.allowedNutritionSettings);
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(CompBiosculpterPod), nameof(CompBiosculpterPod.PostExposeData))]
+        static void PostCompBiosculpterPod(CompBiosculpterPod __instance)
+            => FixStorage(__instance, __instance.allowedNutritionSettings);
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(CompChangeableProjectile), nameof(CompChangeableProjectile.PostExposeData))]
+        static void PostCompChangeableProjectile(CompChangeableProjectile __instance)
+            => FixStorage(__instance, __instance.allowedShellsSettings);
+
+        // Fix syncing of copy/paste due to null StorageSettings.owner by assigning the parent
+        // in ExposeData. The patched types omit passing/assigning self as the owner by passing
+        // Array.Empty<object>() as the argument to expose data on StorageSetting.
+        static void FixStorage(IStoreSettingsParent __instance, StorageSettings ___allowedNutritionSettings)
+        {
+            if (Scribe.mode == LoadSaveMode.PostLoadInit)
+                ___allowedNutritionSettings.owner ??= __instance;
+        }
+    }
 }


### PR DESCRIPTION
This fixes issue of copy/paste gizmos not working properly for:
- Growth vats (`Building_GrowthVat`)
- Biosculpter pods (`CompBiosculpterPod`)
- Mortars (`CompChangeableProjectile`)

The issue happened due to the storages associated to those losing their owner after loading them through `ExposeData`. The solution was to re-assign their owner in PostLoadInit.

The patch is included in the generic `Patches.cs` file, as I felt it did not really fit any other existing source file containing patches (potentially could fit into `VanillaTweaks.cs`).

However, if needed I could create a separate file for them or move them to a different location. I can also split them into separate patches, so a single class doesn't contain 3 postfixes (I've put them all in the same class to have basically-identical patches together).