### PR TITLE
Added rule to load before Vanilla Expanded Framework

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -31,5 +31,6 @@ Discord - https://discord.gg/S4bxXpv
   </loadAfter>
   <loadBefore>
     <li>UnlimitedHugs.HugsLib</li>
+    <li>OskarPotocki.VanillaFactionsExpanded.Core</li>
   </loadBefore>
 </ModMetaData>


### PR DESCRIPTION
This is a minor change that shouldn't really affect anything. The main purpose of this is to try and enforce more proper load order, similarly to the reason we list HugsLib as a mod that we should load before. It may not be a perfect solution, but it'll definitely help for players unaware of the position MP should take, or those who only use built-in sorting functionality.

HugsLib is no longer receiving support and contains some bugs, and some mods are dropping it as dependency due to this. Meanwhile Vanilla Expanded Framework is seeing more and more use - be it from new Vanilla Expanded mods, or even unrelated mods that are using it for its features. It'll very likely keep getting supported, so it should stay relevant for long.