### PR TITLE
Changed verb syncing to work closer like IThingHolder

### DIFF
--- a/Source/Client/MultiplayerData.cs
+++ b/Source/Client/MultiplayerData.cs
@@ -124,8 +124,6 @@ namespace Multiplayer.Client
             dict["HediffComp"] = GetDefInfo(RwImplSerialization.hediffCompTypes, TypeHash);
             dict["IStoreSettingsParent"] = GetDefInfo(RwImplSerialization.storageParents, TypeHash);
             dict["IPlantToGrowSettable"] = GetDefInfo(RwImplSerialization.plantToGrowSettables, TypeHash);
-            dict["IVerbOwner"] = GetDefInfo(RwImplSerialization.verbOwners, TypeHash);
-            dict["ISelectable"] = GetDefInfo(RwImplSerialization.selectables, TypeHash);
             dict["DefTypes"] = GetDefInfo(DefSerialization.DefTypes, TypeHash);
 
             dict["GameComponent"] = GetDefInfo(RwImplSerialization.gameCompTypes, TypeHash);

--- a/Source/Client/MultiplayerData.cs
+++ b/Source/Client/MultiplayerData.cs
@@ -124,6 +124,8 @@ namespace Multiplayer.Client
             dict["HediffComp"] = GetDefInfo(RwImplSerialization.hediffCompTypes, TypeHash);
             dict["IStoreSettingsParent"] = GetDefInfo(RwImplSerialization.storageParents, TypeHash);
             dict["IPlantToGrowSettable"] = GetDefInfo(RwImplSerialization.plantToGrowSettables, TypeHash);
+            dict["IVerbOwner"] = GetDefInfo(RwImplSerialization.verbOwners, TypeHash);
+            dict["ISelectable"] = GetDefInfo(RwImplSerialization.selectables, TypeHash);
             dict["DefTypes"] = GetDefInfo(DefSerialization.DefTypes, TypeHash);
 
             dict["GameComponent"] = GetDefInfo(RwImplSerialization.gameCompTypes, TypeHash);

--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -317,6 +317,14 @@ namespace Multiplayer.Client
                     }
                 }, true // implicit
             },
+            {
+                (ByteWriter data, IVerbOwner obj) => {
+                    WriteWithImpl<IVerbOwner>(data, obj, supportedVerbOwnerTypes);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<IVerbOwner>(data, supportedVerbOwnerTypes);
+                }, true // Implicit
+            },
             #endregion
 
             #region AI
@@ -1013,6 +1021,83 @@ namespace Multiplayer.Client
             },
             #endregion
 
+            #region Interfaces
+            {
+                (ByteWriter data, ISelectable obj) => {
+                    if (obj == null)
+                    {
+                        WriteSync(data, ISelectableImpl.None);
+                    }
+                    else if (obj is Thing thing)
+                    {
+                        WriteSync(data, ISelectableImpl.Thing);
+                        WriteSync(data, thing);
+                    }
+                    else if (obj is Zone zone)
+                    {
+                        WriteSync(data, ISelectableImpl.Zone);
+                        WriteSync(data, zone);
+                    }
+                    else if (obj is WorldObject worldObj)
+                    {
+                        WriteSync(data, ISelectableImpl.WorldObject);
+                        WriteSync(data, worldObj);
+                    }
+                    else
+                    {
+                        throw new SerializationException($"Unknown ISelectable type: {obj.GetType()}");
+                    }
+                },
+                (ByteReader data) => {
+                    ISelectableImpl impl = ReadSync<ISelectableImpl>(data);
+
+                    return impl switch
+                    {
+                        ISelectableImpl.None => null,
+                        ISelectableImpl.Thing => ReadSync<Thing>(data),
+                        ISelectableImpl.Zone => ReadSync<Zone>(data),
+                        ISelectableImpl.WorldObject => ReadSync<WorldObject>(data),
+                        _ => throw new Exception($"Unknown ISelectable {impl}")
+                    };
+                }, true
+            },
+            {
+                (ByteWriter data, IStoreSettingsParent obj) => {
+                    WriteWithImpl<IStoreSettingsParent>(data, obj, storageParents);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<IStoreSettingsParent>(data, storageParents);
+                }
+            },
+            {
+                (ByteWriter data, IPlantToGrowSettable obj) => {
+                    WriteWithImpl<IPlantToGrowSettable>(data, obj, plantToGrowSettables);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<IPlantToGrowSettable>(data, plantToGrowSettables);
+                }
+            },
+            {
+                (ByteWriter data, IThingHolder obj) => {
+                    WriteWithImpl<IThingHolder>(data, obj, supportedThingHolders);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<IThingHolder>(data, supportedThingHolders);
+                }
+            },
+            {
+                (ByteWriter data, IStorageGroupMember obj) =>
+                {
+                    if (obj is Thing thing)
+                        WriteSync(data, thing);
+                    else
+                        throw new SerializationException($"Unknown IStorageGroupMember type: {obj.GetType()}");
+                },
+                (ByteReader data) => (IStorageGroupMember)ReadSync<Thing>(data)
+            },
+
+            #endregion
+
             #region Storage
             {
                 (ByteWriter data, StorageSettings storage) => {
@@ -1056,59 +1141,6 @@ namespace Multiplayer.Client
 
                     var id = data.ReadInt32();
                     return map.passingShipManager.passingShips.FirstOrDefault(s => s.loadID == id);
-                }, true // Implicit
-            },
-            #endregion
-
-            #region Interfaces
-            {
-                (ByteWriter data, ISelectable obj) => {
-                    WriteWithImpl<ISelectable>(data, obj, selectables);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<ISelectable>(data, selectables);
-                }, true // Implicit
-            },
-            {
-                (ByteWriter data, IStoreSettingsParent obj) => {
-                    WriteWithImpl<IStoreSettingsParent>(data, obj, storageParents);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<IStoreSettingsParent>(data, storageParents);
-                }
-            },
-            {
-                (ByteWriter data, IPlantToGrowSettable obj) => {
-                    WriteWithImpl<IPlantToGrowSettable>(data, obj, plantToGrowSettables);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<IPlantToGrowSettable>(data, plantToGrowSettables);
-                }
-            },
-            {
-                (ByteWriter data, IThingHolder obj) => {
-                    WriteWithImpl<IThingHolder>(data, obj, supportedThingHolders);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<IThingHolder>(data, supportedThingHolders);
-                }
-            },
-            {
-                (ByteWriter data, IStorageGroupMember obj) =>
-                {
-                    if (obj is Thing thing)
-                        WriteSync(data, thing);
-                    else
-                        throw new SerializationException($"Unknown IStorageGroupMember type: {obj.GetType()}");
-                },
-                (ByteReader data) => (IStorageGroupMember)ReadSync<Thing>(data)
-            },
-            {
-                (ByteWriter data, IVerbOwner obj) => {
-                    WriteWithImpl<IVerbOwner>(data, obj, verbOwners);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<IVerbOwner>(data, verbOwners);
                 }, true // Implicit
             },
             #endregion

--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -317,14 +317,6 @@ namespace Multiplayer.Client
                     }
                 }, true // implicit
             },
-            {
-                (ByteWriter data, IVerbOwner obj) => {
-                    WriteWithImpl<IVerbOwner>(data, obj, supportedVerbOwnerTypes);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<IVerbOwner>(data, supportedVerbOwnerTypes);
-                }, true // Implicit
-            },
             #endregion
 
             #region AI
@@ -1021,83 +1013,6 @@ namespace Multiplayer.Client
             },
             #endregion
 
-            #region Interfaces
-            {
-                (ByteWriter data, ISelectable obj) => {
-                    if (obj == null)
-                    {
-                        WriteSync(data, ISelectableImpl.None);
-                    }
-                    else if (obj is Thing thing)
-                    {
-                        WriteSync(data, ISelectableImpl.Thing);
-                        WriteSync(data, thing);
-                    }
-                    else if (obj is Zone zone)
-                    {
-                        WriteSync(data, ISelectableImpl.Zone);
-                        WriteSync(data, zone);
-                    }
-                    else if (obj is WorldObject worldObj)
-                    {
-                        WriteSync(data, ISelectableImpl.WorldObject);
-                        WriteSync(data, worldObj);
-                    }
-                    else
-                    {
-                        throw new SerializationException($"Unknown ISelectable type: {obj.GetType()}");
-                    }
-                },
-                (ByteReader data) => {
-                    ISelectableImpl impl = ReadSync<ISelectableImpl>(data);
-
-                    return impl switch
-                    {
-                        ISelectableImpl.None => null,
-                        ISelectableImpl.Thing => ReadSync<Thing>(data),
-                        ISelectableImpl.Zone => ReadSync<Zone>(data),
-                        ISelectableImpl.WorldObject => ReadSync<WorldObject>(data),
-                        _ => throw new Exception($"Unknown ISelectable {impl}")
-                    };
-                }, true
-            },
-            {
-                (ByteWriter data, IStoreSettingsParent obj) => {
-                    WriteWithImpl<IStoreSettingsParent>(data, obj, storageParents);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<IStoreSettingsParent>(data, storageParents);
-                }
-            },
-            {
-                (ByteWriter data, IPlantToGrowSettable obj) => {
-                    WriteWithImpl<IPlantToGrowSettable>(data, obj, plantToGrowSettables);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<IPlantToGrowSettable>(data, plantToGrowSettables);
-                }
-            },
-            {
-                (ByteWriter data, IThingHolder obj) => {
-                    WriteWithImpl<IThingHolder>(data, obj, supportedThingHolders);
-                },
-                (ByteReader data) => {
-                    return ReadWithImpl<IThingHolder>(data, supportedThingHolders);
-                }
-            },
-            {
-                (ByteWriter data, IStorageGroupMember obj) =>
-                {
-                    if (obj is Thing thing)
-                        WriteSync(data, thing);
-                    else
-                        throw new SerializationException($"Unknown IStorageGroupMember type: {obj.GetType()}");
-                },
-                (ByteReader data) => (IStorageGroupMember)ReadSync<Thing>(data)
-            },
-
-            #endregion
-
             #region Storage
             {
                 (ByteWriter data, StorageSettings storage) => {
@@ -1141,6 +1056,59 @@ namespace Multiplayer.Client
 
                     var id = data.ReadInt32();
                     return map.passingShipManager.passingShips.FirstOrDefault(s => s.loadID == id);
+                }, true // Implicit
+            },
+            #endregion
+
+            #region Interfaces
+            {
+                (ByteWriter data, ISelectable obj) => {
+                    WriteWithImpl<ISelectable>(data, obj, selectables);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<ISelectable>(data, selectables);
+                }, true // Implicit
+            },
+            {
+                (ByteWriter data, IStoreSettingsParent obj) => {
+                    WriteWithImpl<IStoreSettingsParent>(data, obj, storageParents);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<IStoreSettingsParent>(data, storageParents);
+                }
+            },
+            {
+                (ByteWriter data, IPlantToGrowSettable obj) => {
+                    WriteWithImpl<IPlantToGrowSettable>(data, obj, plantToGrowSettables);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<IPlantToGrowSettable>(data, plantToGrowSettables);
+                }
+            },
+            {
+                (ByteWriter data, IThingHolder obj) => {
+                    WriteWithImpl<IThingHolder>(data, obj, supportedThingHolders);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<IThingHolder>(data, supportedThingHolders);
+                }
+            },
+            {
+                (ByteWriter data, IStorageGroupMember obj) =>
+                {
+                    if (obj is Thing thing)
+                        WriteSync(data, thing);
+                    else
+                        throw new SerializationException($"Unknown IStorageGroupMember type: {obj.GetType()}");
+                },
+                (ByteReader data) => (IStorageGroupMember)ReadSync<Thing>(data)
+            },
+            {
+                (ByteWriter data, IVerbOwner obj) => {
+                    WriteWithImpl<IVerbOwner>(data, obj, verbOwners);
+                },
+                (ByteReader data) => {
+                    return ReadWithImpl<IVerbOwner>(data, verbOwners);
                 }, true // Implicit
             },
             #endregion

--- a/Source/Client/Syncing/Game/RwImplSerialization.cs
+++ b/Source/Client/Syncing/Game/RwImplSerialization.cs
@@ -12,8 +12,6 @@ namespace Multiplayer.Client
     {
         public static Type[] storageParents;
         public static Type[] plantToGrowSettables;
-        public static Type[] verbOwners;
-        public static Type[] selectables;
 
         public static Type[] thingCompTypes;
         public static Type[] hediffCompTypes;
@@ -34,12 +32,23 @@ namespace Multiplayer.Client
             typeof(WorldObjectComp)
         };
 
+        internal static Type[] supportedVerbOwnerTypes =
+        {
+            typeof(Thing),
+            typeof(Ability),
+            typeof(ThingComp),
+        };
+
+        // ReSharper disable once InconsistentNaming
+        internal enum ISelectableImpl : byte
+        {
+            None, Thing, Zone, WorldObject
+        }
+
         public static void Init()
         {
             storageParents = TypeUtil.AllImplementationsOrdered(typeof(IStoreSettingsParent));
             plantToGrowSettables = TypeUtil.AllImplementationsOrdered(typeof(IPlantToGrowSettable));
-            verbOwners = TypeUtil.AllImplementationsOrdered(typeof(IVerbOwner));
-            selectables = TypeUtil.AllImplementationsOrdered(typeof(ISelectable));
 
             thingCompTypes = TypeUtil.AllSubclassesNonAbstractOrdered(typeof(ThingComp));
             hediffCompTypes = TypeUtil.AllSubclassesNonAbstractOrdered(typeof(HediffComp));

--- a/Source/Client/Syncing/Game/RwImplSerialization.cs
+++ b/Source/Client/Syncing/Game/RwImplSerialization.cs
@@ -12,6 +12,8 @@ namespace Multiplayer.Client
     {
         public static Type[] storageParents;
         public static Type[] plantToGrowSettables;
+        public static Type[] verbOwners;
+        public static Type[] selectables;
 
         public static Type[] thingCompTypes;
         public static Type[] hediffCompTypes;
@@ -32,23 +34,12 @@ namespace Multiplayer.Client
             typeof(WorldObjectComp)
         };
 
-        internal static Type[] supportedVerbOwnerTypes =
-        {
-            typeof(Thing),
-            typeof(Ability),
-            typeof(ThingComp),
-        };
-
-        // ReSharper disable once InconsistentNaming
-        internal enum ISelectableImpl : byte
-        {
-            None, Thing, Zone, WorldObject
-        }
-
         public static void Init()
         {
             storageParents = TypeUtil.AllImplementationsOrdered(typeof(IStoreSettingsParent));
             plantToGrowSettables = TypeUtil.AllImplementationsOrdered(typeof(IPlantToGrowSettable));
+            verbOwners = TypeUtil.AllImplementationsOrdered(typeof(IVerbOwner));
+            selectables = TypeUtil.AllImplementationsOrdered(typeof(ISelectable));
 
             thingCompTypes = TypeUtil.AllSubclassesNonAbstractOrdered(typeof(ThingComp));
             hediffCompTypes = TypeUtil.AllSubclassesNonAbstractOrdered(typeof(HediffComp));

--- a/Source/Client/Syncing/Game/RwImplSerialization.cs
+++ b/Source/Client/Syncing/Game/RwImplSerialization.cs
@@ -32,15 +32,17 @@ namespace Multiplayer.Client
             typeof(WorldObjectComp)
         };
 
+        internal static Type[] supportedVerbOwnerTypes =
+        {
+            typeof(Thing),
+            typeof(Ability),
+            typeof(ThingComp),
+        };
+
         // ReSharper disable once InconsistentNaming
         internal enum ISelectableImpl : byte
         {
             None, Thing, Zone, WorldObject
-        }
-
-        internal enum VerbOwnerType : byte
-        {
-            None, Pawn, Ability, ThingComp
         }
 
         public static void Init()


### PR DESCRIPTION
One of the changes I've proposed in #411, but without any API implementation.

List of changes:
- `VerbOwnerType` enum was removed and replaced by `supportedVerbOwnerTypes` array
- The array includes `typeof(Thing)` instead of `typeof(Pawn)` for increased compatibility
- `IVerbOwner` sync worker entry was added
- `Verb` sync worker entry was modified to sync the owner as `IVerbOwner`

Those changes should result in greater compatibility, as new supported `IVerbOwner` types can now be added to the array and synced using their own sync workers.

This should also end up simplifying `Verb` sync worker going forward, as we won't have to expand it anymore in the future - only the array of supported types.

Things that I did not include, but we may want to potentially consider:
- Add more vanilla types to the list of supported verb owners, which could include:
  - `HediffComp` (specifically due to `HediffComp_VerbGiver`) - in vanilla RW they don't have gizmos, but a mod could add a custom hediff comp that adds them
  - `Pawn_MeleeVerbs_TerrainSource` - likely will never get gizmos, probably will be completely pointless to include
  - `Pawn_NativeVerbs` - same as above
- Automatically including all subtypes of `IVerbOwner` which have a(n explicit) sync worker
  - Would simplify mod compat, as mods would (likely) never need to modify the list of supported verb owners
  - Could have potentially unintended consequences?