### PR TITLE
Update Krafs.Rimworld.Ref NuGet package to 1.4.3901

### DIFF
--- a/Source/Client/Multiplayer.csproj
+++ b/Source/Client/Multiplayer.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Krafs.Publicizer" Version="2.0.1" />
     <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3704" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3901" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.5.0" />
   </ItemGroup>

--- a/Source/Common/Common.csproj
+++ b/Source/Common/Common.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3551-beta" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3901" />
     <PackageReference Include="LiteNetLib" Version="0.9.5.2" />
     <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />

--- a/Source/MultiplayerLoader/MultiplayerLoader.csproj
+++ b/Source/MultiplayerLoader/MultiplayerLoader.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3704" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3901" />
     <PackageReference Include="Krafs.Publicizer" Version="2.0.1" />
     <PackageReference Include="Zetrith.Prepatcher" Version="1.1.1" />
     <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />


### PR DESCRIPTION
Considering that in About.xml we mention that MP requires v1.4.3901, we may as well use NuGet package for that specific version.

This doesn't really change anything besides that, but should ensure we don't touch anything that may have been removed and that we'll be able to reference anything new in code.

The NuGet reference was a bit inconsistent across projects, since Multiplayer and the Loader were both using 1.4.3704, while Common was using 1.4.3551-beta.