### PR TITLE
Fix #410, update MP selector drawing

### DIFF
--- a/Source/Client/Session/PlayerInfo.cs
+++ b/Source/Client/Session/PlayerInfo.cs
@@ -20,6 +20,7 @@ public class PlayerInfo : IPlayerInfo
     public PlayerType type;
     public PlayerStatus status;
     public Color color;
+    public Material selectionBracketMaterial;
     public int factionId;
 
     public ulong steamId;
@@ -83,6 +84,7 @@ public class PlayerInfo : IPlayerInfo
             steamId = steamId,
             steamPersonaName = steamName,
             color = color,
+            selectionBracketMaterial = MaterialPool.MatFrom("UI/Overlays/SelectionBracket", ShaderDatabase.MetaOverlay, color * new Color(1, 1, 1, 0.5f)),
             ticksBehind = ticksBehind,
             simulating = simulating,
             factionId = factionId


### PR DESCRIPTION
Due to absence of any discussion around the issue and the approach for the solution, I've decided to just make a PR with one possible solution that I deemed the most straightforward.

The solution uses Vanilla `SelectionDrawer.DrawSelectionBracketFor` while providing the specific material, which will handle the color. The method was likely changed in 1.4 to support custom materials due to the need of custom colors for the selector due to storage groups.

The materials are stored inside of `PlayerInfo` object. The materials are created using `MaterialPool.MatFrom`, so they should be cached by the game (and will be re-used if a player leaves and rejoins).

`MaterialPropertyBlock` could no longer be used here due to the Vanilla method not using it, as it instead opted into using `Material` to override the default one.

As for performance, a slight hit is unavoidable due to the current handling not being fully complete, skipping couple of cases (mentioned in the referenced issue).

This is also compatible with Vehicle Framework, as its prefix to `SelectionDrawer.DrawSelectionBracketFor` will be actually used by MP to draw diagonal selection boxes around vehicles (instead of only rectangular ones, even if vehicle is driving diagonally).