### PR TITLE
Fix MultiplayerPawnComp init for pawns with no comps (like Toxalope)

### DIFF
--- a/Source/Client/Patches/MultiplayerPawnComp.cs
+++ b/Source/Client/Patches/MultiplayerPawnComp.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 using Verse;
 
 namespace Multiplayer.Client
@@ -16,6 +17,8 @@ namespace Multiplayer.Client
         {
             if (__instance is Pawn)
             {
+                // Initialize comps if null, otherwise AllComps will return ThingWithComps.EmptyCompsList
+                __instance.comps ??= new List<ThingComp>();
                 MultiplayerPawnComp comp = new MultiplayerPawnComp() {parent = __instance};
                 __instance.AllComps.Add(comp);
             }


### PR DESCRIPTION
If a pawn has no comps, then `ThingWithComps.comps` is never initialized and being left as null, in which case `ThingWithComps.AllComps` will return `ThingWithComps.EmptyCompsList`.

The fix here is to initialize `ThingWithComps.comps` if it was null.