### PR TITLE
Optimize operations on dictionaries, fix small issue

### DIFF
--- a/Source/Client/Patches/TimestampFixer.cs
+++ b/Source/Client/Patches/TimestampFixer.cs
@@ -52,8 +52,8 @@ public static class TimestampFixer
 
     public static void ProcessExposable(IExposable exposable)
     {
-        if (timestampFields.ContainsKey(exposable.GetType()))
-            foreach (var del in timestampFields[exposable.GetType()])
+        if (timestampFields.TryGetValue(exposable.GetType(), out var fieldGetters))
+            foreach (var del in fieldGetters)
                 del(exposable) += currentOffset!.Value;
     }
 }

--- a/Source/Client/UI/Layouter.cs
+++ b/Source/Client/UI/Layouter.cs
@@ -131,9 +131,7 @@ public static class Layouter
             PushGroup(new El { rect = rect.AtZero(), spacing = spacing });
 
             // Add to linked list
-            if (!firstTopLevel.ContainsKey(windowId))
-                firstTopLevel[windowId] = currentGroup;
-            else
+            if (!firstTopLevel.TryAdd(windowId, currentGroup))
                 currentTopLevel!.nextTopLevel = currentGroup;
 
             // Set current list pointer

--- a/Source/Client/Util/TypeCache.cs
+++ b/Source/Client/Util/TypeCache.cs
@@ -36,11 +36,8 @@ public static class TypeCache
     {
         foreach (var type in GenTypes.AllTypes)
         {
-            if (!typeByName.ContainsKey(type.Name))
-                typeByName[type.Name] = type;
-
-            if (!typeByFullName.ContainsKey(type.Name))
-                typeByFullName[type.FullName] = type;
+            typeByName.TryAdd(type.Name, type);
+            typeByFullName.TryAdd(type.FullName, type);
         }
     }
 


### PR DESCRIPTION
Occurrences of `ContainsKey` followed by indexer getter/setter were replaced by `TryGetValue`/`TryAdd`. In both cases they'll have the same effect.

This also fixes a minor issue with `TypeCache` where `typeByFullName` would check for existence of `Type.Name`, but insert `Type.FullName`.

For extra context/explanation behind dictionary operation changes:

`TryAdd`, `Add`, and indexer all use the same method for adding to dictionary (`TryInsert`, using a different `InsertionBehavior`). This also means that all of them do a check if a value exists in the dictionary before adding the value - and this is the only way they differ. When an entry with a given key exists `TryAdd` just returns early, `Add` will throw an exception, and indexer setter will replace it.

As for `TryGetValue` - it just consolidates the `ContainsKey` and indexer getter into a single call, as all 3 methods call `FindEntry`. This will drop the amount of `FindEntry` calls by 1 each time it's used.