### PR TITLE
Include if async time and multifaction are active in desync logs

### DIFF
--- a/Source/Client/Desyncs/SaveableDesyncInfo.cs
+++ b/Source/Client/Desyncs/SaveableDesyncInfo.cs
@@ -91,6 +91,8 @@ public class SaveableDesyncInfo
             .AppendLine($"Rimworld Developer Mode - Client|||{Prefs.DevMode}")
             .AppendLine("\n###Server Info###")
             .AppendLine($"Player Count|||{Multiplayer.session.players.Count}")
+            .AppendLine($"Async time active|||{Multiplayer.GameComp.asyncTime}")
+            .AppendLine($"Multifaction active|||{Multiplayer.GameComp.multifaction}")
             .AppendLine("\n###CPU Info###")
             .AppendLine($"Processor Name|||{SystemInfo.processorType}")
             .AppendLine($"Processor Speed (MHz)|||{SystemInfo.processorFrequency}")


### PR DESCRIPTION
As far as I'm aware, this information is currently not included in the desync logs. It was sometimes possible to determine if it was by analyzing log files or desync files, but it was not an ideal solution.

Having this info could occasionally prove useful, especially if person sharing the logs is currently not able to respond when asked if async/multifaction were active.