### PR TITLE
Added a check if CompPollutionPump current map patch failed

### DIFF
--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -528,17 +528,22 @@ namespace Multiplayer.Client.Patches
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
         {
+            var patched = false;
+
             foreach (var inst in insts)
             {
                 if (inst.operand == currentMapGetter)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Call, MethodOf.Lambda(CompMap));
+                    patched = true;
                     continue;
                 }
 
                 yield return inst;
             }
+
+            if (!patched) Log.Warning($"No current map usage found for {nameof(CompPollutionPump)}.{nameof(CompPollutionPump.CompTick)}, patch is likely no longer needed");
         }
 
         static Map CompMap(CompPollutionPump pump)


### PR DESCRIPTION
Added a simple check if patch for `CompPollutionPump.CompTick` to replace `Find.CurrentMap` with a safe call was successful. If the patch failed a warning will be logged.

This should give a heads-up if this gets fixed in a future vanilla release, meaning this patch is no longer needed.