### PR TITLE
Fixed potential infinite recursion `ISyncSimple` crashes

### DIFF
--- a/Source/Client/Syncing/SyncSerialization.cs
+++ b/Source/Client/Syncing/SyncSerialization.cs
@@ -54,12 +54,10 @@ namespace Multiplayer.Client
             if (type == typeof(ISyncSimple))
                 return true;
             if (typeof(ISyncSimple).IsAssignableFrom(type))
-            {
                 return ImplSerialization.syncSimples.
                     Where(t => type.IsAssignableFrom(t)).
                     SelectMany(AccessTools.GetDeclaredFields).
                     All(f => CanHandle(f.FieldType));
-            }
             if (typeof(Def).IsAssignableFrom(type))
                 return true;
             if (typeof(Designator).IsAssignableFrom(type))

--- a/Source/Client/Syncing/SyncSerialization.cs
+++ b/Source/Client/Syncing/SyncSerialization.cs
@@ -15,8 +15,6 @@ namespace Multiplayer.Client
 {
     public static class SyncSerialization
     {
-        private static bool simplifiedSyncSimpleCheck = false;
-
         public static void Init()
         {
             RwImplSerialization.Init();
@@ -53,24 +51,14 @@ namespace Multiplayer.Client
                     || gtd == typeof(HashSet<>)
                     || typeof(ITuple).IsAssignableFrom(gtd))
                     && CanHandleGenericArgs(type);
+            if (type == typeof(ISyncSimple))
+                return true;
             if (typeof(ISyncSimple).IsAssignableFrom(type))
             {
-                // Prevent infinite recursive calls to CanHandle on ISyncSimple subtypes.
-                if (simplifiedSyncSimpleCheck)
-                    return true;
-
-                try
-                {
-                    simplifiedSyncSimpleCheck = true;
-                    return ImplSerialization.syncSimples.
-                        Where(t => type.IsAssignableFrom(t)).
-                        SelectMany(AccessTools.GetDeclaredFields).
-                        All(f => CanHandle(f.FieldType));
-                }
-                finally
-                {
-                    simplifiedSyncSimpleCheck = false;
-                }
+                return ImplSerialization.syncSimples.
+                    Where(t => type.IsAssignableFrom(t)).
+                    SelectMany(AccessTools.GetDeclaredFields).
+                    All(f => CanHandle(f.FieldType));
             }
             if (typeof(Def).IsAssignableFrom(type))
                 return true;


### PR DESCRIPTION
Calls to `SyncSerialization.CanHandle` can cause a crash due to infinite recursion when used with a subtype of `ISyncSimple`.

The crash would happen when a subtype of `ISyncSimple` would have a `ISyncSimple` field. The `CanHandle` checks all fields of a type implementing `ISyncSimple`, as well as all its subtypes, to see if they can be synced. However, as it encounters `ISyncSimple` during the check, it would then check if it can sync `ISyncSimple`, which would then check if it can sync `ISyncSimple` again and again until a crash.

I've originally attempted to fix this by modifying the conditions to skip in specific situations, like the type being an interface, or for recursively checking subtypes of self, etc. - this ended up very messy, and I would just end up finding another example that would cause a crash. I've opted out for this solution as it should handle all of the weird edge cases we may encounter.

Some simple examples of types that would cause a crash:

```csharp
class TestSync : ISyncSimple
{
    ISyncSimple test;
}
```
```csharp
class TestSync : ISyncSimple
{
    List<ISyncSimple> test;
}
```