### PR TITLE
Replace Enumerable.Count(list) with list.Count

### DIFF
--- a/Source/Client/Networking/JoinData.cs
+++ b/Source/Client/Networking/JoinData.cs
@@ -23,7 +23,7 @@ namespace Multiplayer.Client
         {
             var data = new ByteWriter();
 
-            data.WriteInt32(activeModsSnapshot.Count());
+            data.WriteInt32(activeModsSnapshot.Count);
             foreach (var m in activeModsSnapshot)
             {
                 data.WriteString(m.PackageIdNonUnique);

--- a/Source/Client/UI/IngameDebug.cs
+++ b/Source/Client/UI/IngameDebug.cs
@@ -50,7 +50,7 @@ public static class IngameDebug
                 $"{Find.IdeoManager.classicMode} {Multiplayer.game.sync.knownClientOpinions.Count} {Multiplayer.game.sync.knownClientOpinions.FirstOrDefault()?.startTick} {async.mapTicks} {TickPatch.serverFrozen} {TickPatch.frozenAt} ");
 
             text.Append(
-                $"z: {Find.CurrentMap.haulDestinationManager.AllHaulDestinationsListForReading.Count()} d: {Find.CurrentMap.designationManager.designationsByDef.Count} hc: {Find.CurrentMap.listerHaulables.ThingsPotentiallyNeedingHauling().Count}");
+                $"z: {Find.CurrentMap.haulDestinationManager.AllHaulDestinationsListForReading.Count} d: {Find.CurrentMap.designationManager.designationsByDef.Count} hc: {Find.CurrentMap.listerHaulables.ThingsPotentiallyNeedingHauling().Count}");
 
             if (Find.CurrentMap.ParentFaction != null)
             {

--- a/Source/Client/UI/MainMenuAnimation.cs
+++ b/Source/Client/UI/MainMenuAnimation.cs
@@ -61,7 +61,7 @@ namespace Multiplayer.Client
             newPulseTimer += Time.deltaTime;
             if (newPulseTimer > 1 / 12f)
             {
-                var edge = edges[rand.Next(edges.Count())];
+                var edge = edges[rand.Next(edges.Count)];
                 var switchEndpoints = rand.NextDouble() < 0.5;
                 pulses.Add(new Pulse(switchEndpoints ? edge.v2 : edge.v1, switchEndpoints ? edge.v1 : edge.v2) { starting = true });
                 newPulseTimer = 0;
@@ -132,7 +132,7 @@ namespace Multiplayer.Client
 
             while (newEnd == null && attempts < 20)
             {
-                var randEdge = edges[rand.Next(edges.Count())];
+                var randEdge = edges[rand.Next(edges.Count)];
                 var otherVert = randEdge.OtherVert(pulse.end);
                 if (otherVert != null && otherVert != pulse.start && otherVert != pulse.end)
                     newEnd = otherVert;


### PR DESCRIPTION
Minor change that should not really affect anything, as `Enumerable.Count()` would still end up calling `list.Count`:

```csharp
switch (source)
{
    // Skipped irrelevant code
    case ICollection<TSource> sources:
        return sources.Count;
    // Skipped irrelevant code
}
```