### PR TITLE
Update external annotations

### DIFF
--- a/Source/Client/ExternalAnnotations/0Harmony/Annotations.xml
+++ b/Source/Client/ExternalAnnotations/0Harmony/Annotations.xml
@@ -1,7 +1,7 @@
 <assembly name="0Harmony">
-    <member name="T:HarmonyLib.HarmonyPatch">
-        <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
-          <argument>3</argument>
-        </attribute>
-    </member>
+  <member name="T:HarmonyLib.HarmonyPatch">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>3</argument>
+    </attribute>
+  </member>
 </assembly>

--- a/Source/Client/ExternalAnnotations/Assembly-CSharp/Annotations.xml
+++ b/Source/Client/ExternalAnnotations/Assembly-CSharp/Annotations.xml
@@ -1,8 +1,11 @@
 <assembly name="Assembly-CSharp">
-    <member name="T:Verse.DebugActionAttribute">
-        <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor"/>
-    </member>
-    <member name="T:Verse.DebugOutputAttribute">
-        <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor"/>
-    </member>
+  <member name="T:LudeonTK.DebugActionAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor"/>
+  </member>
+  <member name="T:LudeonTK.DebugActionYielderAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor"/>
+  </member>
+  <member name="T:LudeonTK.DebugOutputAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor"/>
+  </member>
 </assembly>


### PR DESCRIPTION
- Updated all the RimWorld's debug attributes to use `LudeonTK` namespace
- Added `DebugActionYielderAttribute` to the implicit use attributes
- Changed all external annotation xml files to use 2 spaces, matching `.editorconfig` style