### PR TITLE
Fix exposing fields for SyncDelegates

### DIFF
--- a/Source/Client/Syncing/Handler/SyncDelegate.cs
+++ b/Source/Client/Syncing/Handler/SyncDelegate.cs
@@ -72,7 +72,7 @@ namespace Multiplayer.Client
                 else if (!fieldTypes[i].IsCompilerGenerated())
                 {
                     var type = (SyncType)fieldTypes[i];
-                    if (exposeFields != null && exposeFields.Contains(path))
+                    if (exposeFields != null && exposeFields.Contains(fieldPathsNoTypes[i]))
                         type.expose = true;
 
                     writer(val, type, path);
@@ -96,7 +96,12 @@ namespace Multiplayer.Client
                 else if (fieldType.IsCompilerGenerated())
                     value = Activator.CreateInstance(fieldType);
                 else
-                    value = SyncSerialization.ReadSyncObject(data, fieldType);
+                {
+                    SyncType type = fieldType;
+                    if (exposeFields != null && exposeFields.Contains(noTypePath))
+                        type.expose = true;
+                    value = SyncSerialization.ReadSyncObject(data, type);
+                }
 
                 if (value == null)
                 {


### PR DESCRIPTION
Currently, exposing fields expects the method to provide a full path to the fields, instead of a field relative to the parent object.

For example, before this change the paths needed to be: `RimWorld.SocialCardUtility+<>c__DisplayClass42_1/roleChangeRitual`, `RimWorld.SocialCardUtility+<>c__DisplayClass42_1/ritualTarget`, `RimWorld.SocialCardUtility+<>c__DisplayClass42_1/CS$<>8__locals1/pawn`

After this change, the paths now need to be:
`roleChangeRitual`, `ritualTarget`, `CS$<>8__locals1/pawn`

On top of that, exposing the fields had no effect on reading them, which caused reading to fail due to the types not having sync workers. This will fix it by actually exposing the fields while reading.