### PR TITLE
Update RimWorld related dependencies

### DIFF
--- a/Source/Client/Multiplayer.csproj
+++ b/Source/Client/Multiplayer.csproj
@@ -27,9 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Publicizer" Version="2.0.1" />
-    <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4055-beta" />
+    <PackageReference Include="Krafs.Publicizer" Version="2.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4062" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.5.0" />
   </ItemGroup>

--- a/Source/Client/Persistent/PersistentDialogs.cs
+++ b/Source/Client/Persistent/PersistentDialogs.cs
@@ -501,7 +501,7 @@ namespace Multiplayer.Client
 
                 if (mode == LookMode.Value)
                 {
-                    var args = new[] { value, "value", type.GetDefaultValue(), false };
+                    var args = new[] { value, "value", Common.Extensions.GetDefaultValue(type), false };
                     ScribeValues.MakeGenericMethod(type).Invoke(null, args);
                     if (Scribe.mode == LoadSaveMode.LoadingVars)
                         value = args[0];

--- a/Source/Common/Common.csproj
+++ b/Source/Common/Common.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3901" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4062" />
     <PackageReference Include="LiteNetLib" Version="0.9.5.2" />
-    <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.5.0" />
   </ItemGroup>

--- a/Source/MultiplayerLoader/MultiplayerLoader.csproj
+++ b/Source/MultiplayerLoader/MultiplayerLoader.csproj
@@ -10,10 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3901" />
-    <PackageReference Include="Krafs.Publicizer" Version="2.0.1" />
-    <PackageReference Include="Zetrith.Prepatcher" Version="1.1.1" />
-    <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4062" />
+    <PackageReference Include="Krafs.Publicizer" Version="2.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Zetrith.Prepatcher" Version="1.2.0" />
+    <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
     <ProjectReference Include="..\Common\Common.csproj"  />
   </ItemGroup>
 

--- a/Source/Server/Server.csproj
+++ b/Source/Server/Server.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Common\Common.csproj" />
-      <PackageReference Include="Lib.Harmony" Version="2.2.2" />
+      <PackageReference Include="Lib.Harmony" Version="2.3.3" />
       <PackageReference Include="Tomlyn" Version="0.16.2" />
     </ItemGroup>
 

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
         <PackageReference Include="coverlet.collector" Version="3.1.2" />
 
-        <PackageReference Include="Lib.Harmony" Version="2.2.2" />
+        <PackageReference Include="Lib.Harmony" Version="2.3.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/TestsOnMono/TestsOnMono.csproj
+++ b/Source/TestsOnMono/TestsOnMono.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Common\Common.csproj" />
-      <PackageReference Include="Lib.Harmony" Version="2.2.2" />
+      <PackageReference Include="Lib.Harmony" Version="2.3.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Dependencies update to the latest version (in solutions using those):
- `Lib.Harmony` from 2.2.2 to 2.3.3
- `Krafs.Rimworld.Ref`
  - Updated from 1.5.4055-beta to 1.5.4062 in `Multiplayer.csproj`
  - Updated from 1.4.3901 to 1.5.4062 in `Common.csproj` and `MultiplayerLoader.csproj`
- `Krafs.Publicizer` from 2.0.1 to 2.2.1
  - This includes changes done automatically when updating, namely adding `PrivateAssets` and `IncludeAssets` in .csproj files
- `Zetrith.Prepatcher` from 1.1.1 to 1.2.0

An additional (and required) change is that `PresistentDialogs` now uses an explicit call to `Extensions.GetDefaultValue`. This is done due to a name conflict with `AccessToolsExtensions:GetDefaultValue`. (Perhaps we should use Harmony's `GetDefaultValue`, as it also handles `null` and `typeof(void)` types?)