### PR TITLE
Sync rename dialogs (sync IRenameable.RenamableLabel setter)

### DIFF
--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -420,6 +420,13 @@ namespace Multiplayer.Client
 
                 foreach (var method in methods)
                     MP.RegisterSyncMethod(method);
+
+                // This OnRenamed method will create a storage group, which needs to be synced.
+                // No other vanilla rename dialogs need syncing OnRenamed, but modded ones potentially could need it.
+                MP.RegisterSyncMethod(typeof(Dialog_RenameBuildingStorage_CreateNew), nameof(Dialog_RenameBuildingStorage_CreateNew.OnRenamed))
+                    .TransformTarget(Serializer.New(
+                        (Dialog_RenameBuildingStorage_CreateNew dialog) => dialog.building,
+                        (IStorageGroupMember member) => new Dialog_RenameBuildingStorage_CreateNew(member)));
             }));
         }
 

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -406,6 +406,21 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(Building_BioferriteHarvester), nameof(Building_BioferriteHarvester.EjectContents)); // Eject contents
             SyncMethod.Lambda(typeof(Building_BioferriteHarvester), nameof(Building_BioferriteHarvester.GetGizmos), 1); // Toggle unload
             SyncMethod.Lambda(typeof(Building_BioferriteHarvester), nameof(Building_BioferriteHarvester.GetGizmos), 3).SetDebugOnly(); // Dev add +1
+
+            // Double ExecuteWhenFinished ensures it'll load after MP Compat late patches,
+            // so it will have registered all its sync workers already.
+            LongEventHandler.ExecuteWhenFinished(() => LongEventHandler.ExecuteWhenFinished(() =>
+            {
+                // Only get methods for types which we can sync. The syncing of renaming is of low enough importance
+                // that we don't need to worry about having errors if there's any that can't be synced
+                var methods = typeof(IRenameable).AllImplementing()
+                    .Where(t => Multiplayer.serialization.CanHandle(t))
+                    .Select(t => AccessTools.DeclaredPropertySetter(t, nameof(IRenameable.RenamableLabel)))
+                    .AllNotNull();
+
+                foreach (var method in methods)
+                    MP.RegisterSyncMethod(method);
+            }));
         }
 
         [MpPrefix(typeof(PawnColumnWorker_CopyPasteTimetable), nameof(PawnColumnWorker_CopyPasteTimetable.PasteTo))]


### PR DESCRIPTION
Synced all implementations of `IRenameable.RenamableLabel` setter for types that can be synced.

I've decided to only apply the sync worker for types that can be synced for safety, as the rename dialogs are of low enough importance that encountering errors or other issues because of them would not be desirable. After all, if rename dialog is not synced then it should not cause any issues besides a minor visual desync (unless there's a mod that does something special with the name, which I've not really encountered).

I've wrapped the portion of the code registering it in a double call to `LongEventHandler.ExecuteWhenFinished` to ensure it runs after MP Compat's late patches, ensuring all Sync Workers will be registered by it at this point.

Because of no logging when there's `IRenameable` that can't be synced, I've included a debug action which will list all types implementing `IRenameable.RenamableLabel` setter, separated into synced and unsynced ones. This will allow us to easily check if we need to create a sync worker for any of the `IRenameable` implementations.

On top of that, I've also synced `Dialog_RenameBuildingStorage_CreateNew:OnRenamed`. It creates a storage group, which requires syncing on top of renaming. No other vanilla dialog needs syncing dialogs like those, but some mods may require it as well.