### PR TITLE
fix for v1.5 UnnaturalCorpse event

### DIFF
--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -123,31 +123,38 @@ namespace Multiplayer.Client.Patches
                 __result.allOnScreen = false;
         }
     }
-    
+
     [HarmonyPatch]
-    static class UnnaturalCorpsePatch // v1.5
+    static class UnnaturalCorpsePatch
     {
         static IEnumerable<MethodBase> TargetMethods()
         {
+            // both of these actually combine "is valid" semantics with "is unseen"
             yield return AccessTools.DeclaredMethod(typeof(AnomalyUtility), nameof(AnomalyUtility.IsValidUnseenCell));
             yield return AccessTools.DeclaredMethod(typeof(UnnaturalCorpse), nameof(UnnaturalCorpse.IsOutsideView));
         }
         
-        static MethodInfo CellRectContains = AccessTools.Method(typeof(CellRect), nameof(CellRect.Contains));
-    
-        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
+        // primarily for `IsValidUnseenCell()` but works fine for `IsOutsideView()` as well (maybe others)
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts, ILGenerator gen)
         {
-            foreach (var inst in insts)
-            {
-                yield return inst;
-    
-                // consider it always outside view (not contained in CurrentViewRect)
-                if (inst.operand == CellRectContains)
-                {
-                    yield return new CodeInstruction(OpCodes.Ldc_I4_0);
-                    yield return new CodeInstruction(OpCodes.And);
-                }
-            }
+            var cm = new CodeMatcher(insts, gen);
+            
+            cm.MatchStartForward(Code.Call[AccessTools.DeclaredPropertyGetter(typeof(Find), nameof(Find.CurrentMap))]);
+            cm.SearchForward(inst => inst.Branches(out _));
+            // consider it always on current map, so we can proceed (with finding a nice walkable cell etc.)
+            //  keeping `Beq` and `Bne` avoids needing `Code.Pop, Code.Pop`
+            if (cm.Opcode == OpCodes.Beq_S)
+                cm.Advance(1).Insert(Code.Br_S[cm.InstructionAt(-1).operand]);  // force jump as if equal
+            else if (cm.Opcode == OpCodes.Bne_Un_S)
+                cm.CreateLabelWithOffsets(1, out var label).Operand = label;    // not-equal jump goes nowhere
+            else
+                cm.ThrowIfFalse("Couldn't find equality branch opcode following `Find.CurrentMap`", _ => false);
+
+            cm.MatchStartForward(Code.Call[AccessTools.DeclaredMethod(typeof(CellRect), nameof(CellRect.Contains))]);
+            // consider it always outside view (not contained in `CurrentViewRect`) so we can proceed
+            cm.Advance(1).Insert(Code.Ldc_I4_0, Code.And);
+            
+            return cm.Instructions();
         }
     }
     


### PR DESCRIPTION
I'm in the Discord as `@CodeOptimist`, ping me any time.
Tested and appears to work.

I tried to copy the existing style, I thought the `Ldc_I4_1`  `Or` used by `DrawTrackerTickPatch` beneath this was clever and that also transpiles a `CellRect.Contains()`, so I used the same though here we return false with `Ldc_I4_0` `And`. I put this patch next to that patch because of the similarity, though perhaps move it if it belongs with other v1.5 patches.

~I don't know much about this actual event, hopefully having the corpse move with one (or both) players watching doesn't ruin the whole gimmick, as doing things unwatched seems a little special/unique to this? Checking if it's unwatched by all clients sounds... complex.~


Here's the unpatched vanilla methods:

`UnnaturalCorpse`
```cs
private bool IsOutsideView()
{
	return (!base.SpawnedOrAnyParentSpawned || !base.MapHeld.reservationManager.IsReservedByAnyoneOf(this, Faction.OfPlayer)) && (Find.CurrentMap != base.MapHeld || !Find.CameraDriver.CurrentViewRect.ExpandedBy(1).Contains(base.PositionHeld));
}
```

`AnomalyUtility`
```cs
public static bool IsValidUnseenCell(CellRect view, IntVec3 cell, Map map)
{
	return (map != Find.CurrentMap || !view.Contains(cell)) && !cell.Fogged(map) && cell.Walkable(map) && cell.GetFence(map) == null && cell.GetDoor(map) == null;
}
```

As my first PR: You're always free to aggressively reject/refactor/rewrite. 👍 
Cheers. 🍻