### PR TITLE
More Anomaly syncing

### DIFF
--- a/Source/Client/Syncing/Dict/SyncDictDlc.cs
+++ b/Source/Client/Syncing/Dict/SyncDictDlc.cs
@@ -285,6 +285,23 @@ namespace Multiplayer.Client
                 }
             },
             #endregion
+
+            #region Anomaly
+
+            {
+                (ByteWriter data, ActivityGizmo gizmo) => WriteSync(data, gizmo.Comp),
+                (ByteReader data) =>
+                {
+                    var comp = ReadSync<CompActivity>(data);
+
+                    // The gizmo may not yet be initialized for the comp.
+                    comp.gizmo ??= new ActivityGizmo(comp.parent);
+
+                    return (ActivityGizmo)comp.gizmo;
+                }
+            }
+
+            #endregion
         };
 	}
 }

--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -23,10 +23,12 @@ namespace Multiplayer.Client
             SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddHumanlikeOrders), 7).CancelIfAnyFieldNull().SetContext(mouseKeyContext);  // Capture slave
             SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddHumanlikeOrders), 8).CancelIfAnyFieldNull().SetContext(mouseKeyContext);  // Capture prisoner
             SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddHumanlikeOrders), 9).CancelIfAnyFieldNull().SetContext(mouseKeyContext);  // Carry to cryptosleep casket
-            SyncDelegate.LocalFunc(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddHumanlikeOrders), "CarryToShuttleAct").CancelIfAnyFieldNull().SetContext(mouseKeyContext); // Carry to shuttle
+            SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddHumanlikeOrders), 12).CancelIfAnyFieldNull().SetContext(mouseKeyContext); // Capture entity
             SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddHumanlikeOrders), 50).CancelIfAnyFieldNull().SetContext(mouseKeyContext); // Reload
+            SyncDelegate.LocalFunc(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddHumanlikeOrders), "CarryToShuttleAct").CancelIfAnyFieldNull().SetContext(mouseKeyContext); // Carry to shuttle
             SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddDraftedOrders), 3).CancelIfAnyFieldNull().SetContext(mouseKeyContext);    // Drafted carry to bed
             SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddDraftedOrders), 4).CancelIfAnyFieldNull().SetContext(mouseKeyContext);    // Drafted carry to bed (arrest)
+            SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddDraftedOrders), 5).CancelIfAnyFieldNull().SetContext(mouseKeyContext);    // Drafted carry entity to holding building
             SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddDraftedOrders), 6).CancelIfAnyFieldNull().SetContext(mouseKeyContext);    // Drafted carry to transport shuttle
             SyncDelegate.Lambda(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddDraftedOrders), 7).CancelIfAnyFieldNull().SetContext(mouseKeyContext);    // Drafted carry to cryptosleep casket
 

--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -197,7 +197,7 @@ namespace Multiplayer.Client
             SyncDelegate.Lambda(typeof(Pawn), nameof(Pawn.GetGizmos), 5).SetDebugOnly(); // Set growth tier
 
             // Building_HoldingPlatform and related comps
-            SyncDelegate.Lambda(typeof(Building_HoldingPlatform), nameof(Building_HoldingPlatform.GetGizmos), 1); // Set escape tick
+            SyncDelegate.Lambda(typeof(Building_HoldingPlatform), nameof(Building_HoldingPlatform.GetGizmos), 1).SetDebugOnly(); // Set escape tick
             SyncMethod.Lambda(typeof(CompActivity), nameof(CompActivity.CompGetGizmosExtra), 0).SetDebugOnly();   // Dev activity -5%
             SyncMethod.Lambda(typeof(CompActivity), nameof(CompActivity.CompGetGizmosExtra), 1).SetDebugOnly();   // Dev activity +5%
             SyncMethod.Lambda(typeof(CompActivity), nameof(CompActivity.CompGetGizmosExtra), 2).SetDebugOnly();   // Dev go active/go passive

--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -87,6 +87,10 @@ namespace Multiplayer.Client
         public static ISyncField SyncEntityContainmentMode;
         public static ISyncField SyncExtractBioferrite;
 
+        public static ISyncField SyncActivityGizmoTarget;
+        public static ISyncField SyncActivityCompTarget;
+        public static ISyncField SyncActivityCompSuppression;
+
         public static void Init()
         {
             SyncMedCare = Sync.Field(typeof(Pawn), nameof(Pawn.playerSettings), nameof(Pawn_PlayerSettings.medCare));
@@ -218,6 +222,10 @@ namespace Multiplayer.Client
             SyncStudiableCompEnabled = Sync.Field(typeof(CompStudiable), nameof(CompStudiable.studyEnabled));
             SyncEntityContainmentMode = Sync.Field(typeof(CompHoldingPlatformTarget), nameof(CompHoldingPlatformTarget.containmentMode));
             SyncExtractBioferrite = Sync.Field(typeof(CompHoldingPlatformTarget), nameof(CompHoldingPlatformTarget.extractBioferrite));
+
+            SyncActivityGizmoTarget = Sync.Field(typeof(ActivityGizmo), nameof(ActivityGizmo.targetValuePct)).SetBufferChanges();
+            SyncActivityCompTarget = Sync.Field(typeof(CompActivity), nameof(CompActivity.suppressIfAbove)).SetBufferChanges();
+            SyncActivityCompSuppression = Sync.Field(typeof(CompActivity), nameof(CompActivity.suppressionEnabled));
         }
 
         [MpPrefix(typeof(StorytellerUI), nameof(StorytellerUI.DrawStorytellerSelectionInterface))]
@@ -533,6 +541,14 @@ namespace Multiplayer.Client
 
                 if (geneGizmo.gene is Gene_Hemogen)
                     SyncGeneHemogenAllowed.Watch(geneGizmo.gene);
+            }
+            else if (__instance is ActivityGizmo activityGizmo)
+            {
+                SyncActivityGizmoTarget.Watch(activityGizmo);
+
+                var comp = activityGizmo.Comp;
+                SyncActivityCompTarget.Watch(comp);
+                SyncActivityCompSuppression.Watch(comp);
             }
         }
 

--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -83,6 +83,9 @@ namespace Multiplayer.Client
         public static ISyncField SyncMechCarrierGizmoTargetValue;
         public static ISyncField SyncMechCarrierMaxToFill;
 
+        public static ISyncField SyncStudiableCompEnabled;
+        public static ISyncField SyncEntityContainmentMode;
+
         public static void Init()
         {
             SyncMedCare = Sync.Field(typeof(Pawn), nameof(Pawn.playerSettings), nameof(Pawn_PlayerSettings.medCare));
@@ -210,6 +213,9 @@ namespace Multiplayer.Client
             SyncMechAutoRepair = Sync.Field(typeof(CompMechRepairable), nameof(CompMechRepairable.autoRepair));
             SyncMechCarrierGizmoTargetValue = Sync.Field(typeof(MechCarrierGizmo), nameof(MechCarrierGizmo.targetValue)).SetBufferChanges();
             SyncMechCarrierMaxToFill = Sync.Field(typeof(CompMechCarrier), nameof(CompMechCarrier.maxToFill)).SetBufferChanges();
+
+            SyncStudiableCompEnabled = Sync.Field(typeof(CompStudiable), nameof(CompStudiable.studyEnabled));
+            SyncEntityContainmentMode = Sync.Field(typeof(CompHoldingPlatformTarget), nameof(CompHoldingPlatformTarget.containmentMode));
         }
 
         [MpPrefix(typeof(StorytellerUI), nameof(StorytellerUI.DrawStorytellerSelectionInterface))]
@@ -559,6 +565,22 @@ namespace Multiplayer.Client
         {
             SyncMechCarrierGizmoTargetValue.Watch(__instance);
             SyncMechCarrierMaxToFill.Watch(__instance.carrier);
+        }
+
+        [MpPrefix(typeof(ITab_StudyNotes), nameof(ITab_StudyNotes.DrawTitle))]
+        static void CompStudiableEnabledCheckbox(ITab_StudyNotes __instance)
+        {
+            var comp = __instance.StudiableThing.TryGetComp<CompStudiable>();
+            if (comp != null)
+                SyncStudiableCompEnabled.Watch(comp);
+        }
+
+        [MpPrefix(typeof(ITab_Entity), nameof(ITab_Entity.FillTab))]
+        static void CompHoldingPlatformTargetMode(ITab_Entity __instance)
+        {
+            var comp = __instance.SelPawn.TryGetComp<CompHoldingPlatformTarget>();
+            if (comp != null)
+                SyncEntityContainmentMode.Watch(comp);
         }
     }
 

--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -85,6 +85,7 @@ namespace Multiplayer.Client
 
         public static ISyncField SyncStudiableCompEnabled;
         public static ISyncField SyncEntityContainmentMode;
+        public static ISyncField SyncExtractBioferrite;
 
         public static void Init()
         {
@@ -216,6 +217,7 @@ namespace Multiplayer.Client
 
             SyncStudiableCompEnabled = Sync.Field(typeof(CompStudiable), nameof(CompStudiable.studyEnabled));
             SyncEntityContainmentMode = Sync.Field(typeof(CompHoldingPlatformTarget), nameof(CompHoldingPlatformTarget.containmentMode));
+            SyncExtractBioferrite = Sync.Field(typeof(CompHoldingPlatformTarget), nameof(CompHoldingPlatformTarget.extractBioferrite));
         }
 
         [MpPrefix(typeof(StorytellerUI), nameof(StorytellerUI.DrawStorytellerSelectionInterface))]
@@ -580,7 +582,10 @@ namespace Multiplayer.Client
         {
             var comp = __instance.SelPawn.TryGetComp<CompHoldingPlatformTarget>();
             if (comp != null)
+            {
                 SyncEntityContainmentMode.Watch(comp);
+                SyncExtractBioferrite.Watch(comp);
+            }
         }
     }
 

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -383,7 +383,7 @@ namespace Multiplayer.Client
             SyncMethod.Lambda(typeof(Building_VoidMonolith), nameof(Building_VoidMonolith.GetGizmos), 2).SetDebugOnly(); // Dev relink
 
             // Harbinger Tree
-            SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.CreateCorpseStockpile));
+            SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.CreateCorpseStockpile)).SetContext(SyncContext.MapSelected);
             SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.AddNutrition)).SetDebugOnly();
             SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.SpawnNewTree)).SetDebugOnly();
             SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.UpdateRoots)).SetDebugOnly();

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -386,7 +386,6 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.CreateCorpseStockpile)).SetContext(SyncContext.MapSelected);
             SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.AddNutrition)).SetDebugOnly();
             SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.SpawnNewTree)).SetDebugOnly();
-            SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.UpdateRoots)).SetDebugOnly();
             SyncMethod.LocalFunc(typeof(HarbingerTree), nameof(HarbingerTree.GetGizmos), "DelayedSplatter").SetDebugOnly(); // Set blood splatters delay
 
             // Pawn creep joiner tracker


### PR DESCRIPTION
I'm trying to avoid (too many) spoilers about anomaly, so I'm patching stuff as I go through and progress the DLC. I've gone through and tested some of the stuff that I already saw in game, and fixed whatever needed fixing.

Changes:

- Creating corpse stockpile for harbinger trees needed `SyncContext.MapSelected`
- Synced a float menu option for capturing entity into any holding building
  - The interaction would work if selecting a specific holding building
- Synced a float menu option for drafted carrying an entity to a holding building
  - It was not needed, but was synced like the other similar methods to save up on the amount of data that would end up being synced
- Moved the gizmo for carry to shuttle interaction lower, as the other sync delegates were ordered by their `lambdaOrdinal`
- Synced `CompStudiable.studyEnabled` field changes from `ITab_StudyNotes.DrawTitle`
  - Changing it using a gizmo was synced already
- Synced `CompHoldingPlatformTarget.containmentMode` field changes from `ITab_Entity.FillTab`