### PR TITLE
Sync non-exclusive prisoner interaction mode, change syncing exclusive mode

### DIFF
--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -225,6 +225,10 @@ namespace Multiplayer.Client
                 (ByteWriter data, Pawn_NeedsTracker joinerTracker) => WriteSync(data, joinerTracker?.pawn),
                 (ByteReader data) => ReadSync<Pawn>(data)?.needs
             },
+            {
+                (ByteWriter data, Pawn_GuestTracker guestTracker) => WriteSync(data, guestTracker?.pawn),
+                (ByteReader data) => ReadSync<Pawn>(data)?.guest
+            },
             #endregion
 
             #region Policies

--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -17,7 +17,6 @@ namespace Multiplayer.Client
         public static ISyncField SyncHostilityResponse;
         public static ISyncField SyncFollowDrafted;
         public static ISyncField SyncFollowFieldwork;
-        public static ISyncField SyncInteractionMode;
         public static ISyncField SyncSlaveInteractionMode;
         public static ISyncField SyncIdeoForConversion;
         public static ISyncField SyncBeCarried;
@@ -90,7 +89,6 @@ namespace Multiplayer.Client
             SyncHostilityResponse = Sync.Field(typeof(Pawn), nameof(Pawn.playerSettings), nameof(Pawn_PlayerSettings.hostilityResponse));
             SyncFollowDrafted = Sync.Field(typeof(Pawn), nameof(Pawn.playerSettings), nameof(Pawn_PlayerSettings.followDrafted));
             SyncFollowFieldwork = Sync.Field(typeof(Pawn), nameof(Pawn.playerSettings), nameof(Pawn_PlayerSettings.followFieldwork));
-            SyncInteractionMode = Sync.Field(typeof(Pawn), nameof(Pawn.guest), nameof(Pawn_GuestTracker.interactionMode));
             SyncSlaveInteractionMode = Sync.Field(typeof(Pawn), nameof(Pawn.guest), nameof(Pawn_GuestTracker.slaveInteractionMode));
             SyncIdeoForConversion = Sync.Field(typeof(Pawn), nameof(Pawn.guest), nameof(Pawn_GuestTracker.ideoForConversion));
             SyncBeCarried = Sync.Field(typeof(Pawn), nameof(Pawn.health), nameof(Pawn_HealthTracker.beCarriedByCaravanIfSick));
@@ -258,7 +256,6 @@ namespace Multiplayer.Client
         {
             Pawn pawn = __instance.SelPawn;
             SyncMedCare.Watch(pawn);
-            SyncInteractionMode.Watch(pawn);
             SyncSlaveInteractionMode.Watch(pawn);
             SyncIdeoForConversion.Watch(pawn);
         }

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -39,6 +39,8 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(Pawn_JobTracker), nameof(Pawn_JobTracker.TryTakeOrderedJob)).SetContext(SyncContext.QueueOrder_Down).ExposeParameter(0);
             SyncMethod.Register(typeof(Pawn_JobTracker), nameof(Pawn_JobTracker.TryTakeOrderedJobPrioritizedWork)).SetContext(SyncContext.QueueOrder_Down).ExposeParameter(0);
             SyncMethod.Register(typeof(Pawn_TrainingTracker), nameof(Pawn_TrainingTracker.SetWantedRecursive));
+            SyncMethod.Register(typeof(Pawn_GuestTracker), nameof(Pawn_GuestTracker.SetExclusiveInteraction)).CancelIfAnyArgNull();
+            SyncMethod.Register(typeof(Pawn_GuestTracker), nameof(Pawn_GuestTracker.ToggleNonExclusiveInteraction)).CancelIfAnyArgNull();
             SyncMethod.Register(typeof(Zone), nameof(Zone.Delete));
             SyncMethod.Register(typeof(BillStack), nameof(BillStack.AddBill)).ExposeParameter(0); // Only used for pasting
             SyncMethod.Register(typeof(BillStack), nameof(BillStack.Delete)).CancelIfAnyArgNull();


### PR DESCRIPTION
Changes:

- Added a sync worker for `Pawn_GuestTracker`, as it's needed for the sync methods
- Synced non-exclusive prisoner interaction modes
  - This affects hemogen farm and bloodfeed (as well as extra modes added by mods)
  - The synced method is `Pawn_GuestTracker:ToggleNonExclusiveInteraction`
  - As opposed to normal prisoner/slave interaction modes, it would not be possible to sync it as a field since the field is a list of allowed modes
- Changed syncing of exclusive prisoner interaction modes by using a sync methods rather than sync fields
  - The synced method is `Pawn_GuestTracker:SetExclusiveInteraction`
  - The changes to the field didn't need to be handled as a sync field anymore, so I've changed it to a sync method