### PR TITLE
Remove a duplicate StorageGroup sync worker, merge both storage regions

### DIFF
--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -1091,9 +1091,7 @@ namespace Multiplayer.Client
                     return data.MpContext().map.storageGroups.groups.Find(g => g.loadID == loadId);
                 }
             },
-            #endregion
 
-            #region Storage
             {
                 (ByteWriter data, StorageSettings storage) => {
                     WriteSync(data, storage.owner);
@@ -1102,10 +1100,6 @@ namespace Multiplayer.Client
                     IStoreSettingsParent parent = ReadSync<IStoreSettingsParent>(data);
                     return parent?.GetStoreSettings();
                 }
-            },
-            {
-                (ByteWriter data, StorageGroup group) => WriteSync(data, group.members.First()),
-                (ByteReader data) => ReadSync<IStorageGroupMember>(data).Group
             },
             #endregion
 


### PR DESCRIPTION
It seems a second StorageGroup sync worker was added recently, but the old one was kept in. I've removed the old one since the new one seems to be better (as it doesn't rely on a `Thing`, just a map and ID).

On top of that, I've merged the two regions named Storage.