### PR TITLE
Remove growth vat storage owner patch (fixed in vanilla)

### DIFF
--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -563,11 +563,6 @@ namespace Multiplayer.Client
     public static class StoragesKeepsTheirOwners
     {
         [HarmonyPostfix]
-        [HarmonyPatch(typeof(Building_GrowthVat), nameof(Building_GrowthVat.ExposeData))]
-        static void PostBuildingGrowthVat(Building_GrowthVat __instance)
-            => FixStorage(__instance, __instance.allowedNutritionSettings);
-
-        [HarmonyPostfix]
         [HarmonyPatch(typeof(CompBiosculpterPod), nameof(CompBiosculpterPod.PostExposeData))]
         static void PostCompBiosculpterPod(CompBiosculpterPod __instance)
             => FixStorage(__instance, __instance.allowedNutritionSettings);


### PR DESCRIPTION
Remove the storage parent fix (#407) for growth vat, as this was fixed by vanilla.