### PR TITLE
Use a randomized seed for long events

### DIFF
--- a/Source/Client/Patches/Seeds.cs
+++ b/Source/Client/Patches/Seeds.cs
@@ -98,11 +98,12 @@ namespace Multiplayer.Client
         {
             if (Multiplayer.Client != null && (Multiplayer.Ticking || Multiplayer.ExecutingCmds))
             {
-                action = PushState + action + Rand.PopState;
+                var seed = Rand.Int;
+                action = (() => PushState(seed)) + action + Rand.PopState;
             }
         }
 
-        static void PushState() => Rand.PushState(4);
+        static void PushState(int seed) => Rand.PushState(seed);
     }
 
     // Seed the rotation random


### PR DESCRIPTION
Previously, we've used a constant seed for long events. This change will replace it with a randomized seed which is selected whenever a long event is queued.

This should allow for more randomness in long events, and is required by the labyrinth map generation to produce unique maps, instead of only having a single possible layout.