### PR TITLE
Fix errors caused by pocket maps with Multifaction/spectator faction

### DIFF
--- a/Source/Client/AsyncTime/StorytellerPatches.cs
+++ b/Source/Client/AsyncTime/StorytellerPatches.cs
@@ -139,3 +139,17 @@ static class SettlementIncidentTargetTagsPatch
         }
     }
 }
+
+[HarmonyPatch(typeof(StorytellerUtility), nameof(StorytellerUtility.DefaultThreatPointsNow))]
+static class FixMultifactionPocketMapDefaultThreatPointsNow
+{
+    static bool Prefix(IIncidentTarget target)
+    {
+        // StorytellerUtility.DefaultThreatPointsNow uses Find.AnyPlayerHomeMap if
+        // the target map is a pocket map. In such a situation, we stop the method
+        // from executing if Find.AnyPlayerHomeMap would return null, as otherwise
+        // we'll end up with a very frequent error spam from spectator faction and
+        // any other factions without a map.
+        return Multiplayer.Client == null || target is not Map { IsPocketMap: true } || Find.AnyPlayerHomeMap != null;
+    }
+}


### PR DESCRIPTION
`FactionRepeater` ends up repeating `Storyteller.StorytellerTick` for all factions (including spectator, even with Multifaction off). This causes issue due to `StorytellerUtility.DefaultThreatPointsNow` using `Find.AnyPlayerHomeMap` if the target is a pocket map, which for factions without a home map will return null and cause `NullReferenceException`.