### PR TITLE
Synced ChoiceLetter_AcceptCreepJoiner

### DIFF
--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -320,6 +320,13 @@ namespace Multiplayer.Client
             // Growth moment for a child
             CloseDialogsForExpiredLetters.RegisterDefaultLetterChoice(AccessTools.Method(typeof(SyncDelegates), nameof(PickRandomTraitAndPassions)), typeof(ChoiceLetter_GrowthMoment));
             SyncMethod.Register(typeof(ChoiceLetter_GrowthMoment), nameof(ChoiceLetter_GrowthMoment.MakeChoices)).ExposeParameter(1);
+
+            // Creep joiner
+            SyncMethod.LambdaInGetter(typeof(ChoiceLetter_AcceptCreepJoiner), nameof(ChoiceLetter_AcceptCreepJoiner.Choices), 0); // Accept joiner
+            SyncMethod.LambdaInGetter(typeof(ChoiceLetter_AcceptCreepJoiner), nameof(ChoiceLetter_AcceptCreepJoiner.Choices), 1); // Arrest joiner
+            CloseDialogsForExpiredLetters.RegisterDefaultLetterChoice(
+                SyncMethod.LambdaInGetter(typeof(ChoiceLetter_AcceptCreepJoiner), nameof(ChoiceLetter_AcceptCreepJoiner.Choices), 2)
+                    .method); // Reject joiner
         }
 
         static void SyncBabyToChildLetter(ChoiceLetter_BabyToChild letter)


### PR DESCRIPTION
It was synced by `PersistentDialog` syncing if the dialog was opened by interacting with the joiner pawn. However, it is not synced when interacted using the choice letter (which this PR fixes).

Preferably, we'd disable the dialog opening when interacted (and only allow through choice letter) since it opens it for all players, and is rather disruptive. However, I'm leaving it for another PR.