### PR TITLE
Psychic ritual syncing

### DIFF
--- a/Source/Client/Persistent/PsychicRitualBeginProxy.cs
+++ b/Source/Client/Persistent/PsychicRitualBeginProxy.cs
@@ -1,0 +1,57 @@
+﻿using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.AI.Group;
+
+namespace Multiplayer.Client.Persistent;
+
+public class PsychicRitualBeginProxy : Dialog_BeginPsychicRitual, ISwitchToMap
+{
+    public static PsychicRitualBeginProxy drawing;
+
+    public PsychicRitualSession Session => map.MpComp().sessionManager.GetFirstOfType<PsychicRitualSession>();
+
+    public PsychicRitualBeginProxy(
+        PsychicRitualDef def,
+        PsychicRitualCandidatePool candidatePool,
+        PsychicRitualRoleAssignments assignments,
+        Map map) :
+        base(def, candidatePool, assignments, map)
+    {
+        // Recache the pending issues for the ritual.
+        // Each time the ritual is started, this method is called. However,
+        // in MP we can have multiple rituals active at a time, so ensure
+        // that we recache if the ritual is valid on a specific map.
+        // If there's ever issues with this, we may need to call this
+        // in DoWindowContents, however it shouldn't be needed.
+        def.InitializeCast(map);
+    }
+
+    public override void DoWindowContents(Rect inRect)
+    {
+        drawing = this;
+
+        try
+        {
+            var session = Session;
+
+            if (session == null)
+            {
+                soundClose = SoundDefOf.Click;
+                Close();
+            }
+
+            base.DoWindowContents(inRect);
+        }
+        finally
+        {
+            drawing = null;
+        }
+    }
+
+    public override void Start()
+    {
+        if (CanBegin)
+            Session?.Start();
+    }
+}

--- a/Source/Client/Persistent/PsychicRitualPatches.cs
+++ b/Source/Client/Persistent/PsychicRitualPatches.cs
@@ -1,0 +1,45 @@
+﻿using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.AI.Group;
+
+namespace Multiplayer.Client.Persistent;
+
+[HarmonyPatch(typeof(Widgets), nameof(Widgets.ButtonTextWorker))]
+static class MakeCancelPsychicRitualButtonRed
+{
+    static void Prefix(string label, ref bool __state)
+    {
+        if (PsychicRitualBeginProxy.drawing == null) return;
+        if (label != "CancelButton".Translate()) return;
+
+        GUI.color = new Color(1f, 0.3f, 0.35f);
+        __state = true;
+    }
+
+    static void Postfix(bool __state, ref Widgets.DraggableResult __result)
+    {
+        if (!__state) return;
+
+        GUI.color = Color.white;
+        if (__result.AnyPressed())
+        {
+            PsychicRitualBeginProxy.drawing.Session?.Remove();
+            __result = Widgets.DraggableResult.Idle;
+        }
+    }
+}
+
+[HarmonyPatch(typeof(PsychicRitualGizmo), nameof(PsychicRitualGizmo.InitializePsychicRitual))]
+static class CancelDialogBeginPsychicRitual
+{
+    static bool Prefix(PsychicRitualDef_InvocationCircle psychicRitualDef, Thing target)
+    {
+        if (Multiplayer.Client == null)
+            return true;
+
+        PsychicRitualSession.OpenOrCreateSession(psychicRitualDef, target);
+        return false;
+    }
+}

--- a/Source/Client/Persistent/PsychicRitualSession.cs
+++ b/Source/Client/Persistent/PsychicRitualSession.cs
@@ -1,0 +1,120 @@
+﻿using Multiplayer.API;
+using RimWorld;
+using Verse;
+using Verse.AI.Group;
+
+namespace Multiplayer.Client.Persistent;
+
+public class PsychicRitualSession : SemiPersistentSession, ISessionWithCreationRestrictions
+{
+    public Map map;
+    public PsychicRitualDef ritual;
+    public PsychicRitualCandidatePool candidatePool;
+    public MpPsychicRitualAssignments assignments;
+
+    public override Map Map => map;
+
+    public PsychicRitualSession(Map map) : base(map)
+    {
+        this.map = map;
+    }
+
+    public PsychicRitualSession(Map map, PsychicRitualDef ritual, PsychicRitualCandidatePool candidatePool, MpPsychicRitualAssignments assignments) : this(map)
+    {
+        this.ritual = ritual;
+        this.assignments = assignments;
+        this.candidatePool = candidatePool;
+        this.assignments.session = this;
+    }
+
+    public static void OpenOrCreateSession(PsychicRitualDef_InvocationCircle ritual, Thing target)
+    {
+        // We need Find.CurrentMap to match the map we're creating the session in
+        var map = Find.CurrentMap;
+        if (map != target.Map)
+        {
+            Log.Error($"Error opening/creating {nameof(PsychicRitualSession)} - current map ({Find.CurrentMap}) does not match ritual spot map ({target.Map}).");
+            return;
+        }
+
+        var session = map.MpComp().sessionManager.GetFirstOfType<PsychicRitualSession>();
+        if (session == null)
+            CreateSession(ritual, target);
+        else
+            session.OpenWindow();
+    }
+
+    // Need CurrentMap for PsychicRitualDef.FindCandidatePool call
+    [SyncMethod(SyncContext.CurrentMap)]
+    public static void CreateSession(PsychicRitualDef_InvocationCircle ritual, Thing target)
+    {
+        var map = Find.CurrentMap;
+
+        // Get role assignments and candidate pool
+        var candidatePool = ritual.FindCandidatePool();
+        var assignments = MpUtil.ShallowCopy(ritual.BuildRoleAssignments(target), new MpPsychicRitualAssignments());
+
+        var manager = map.MpComp().sessionManager;
+        var session = manager.GetOrAddSession(new PsychicRitualSession(map, ritual, candidatePool, assignments));
+
+        if (TickPatch.currentExecutingCmdIssuedBySelf)
+            session.OpenWindow();
+    }
+
+    [SyncMethod]
+    public void Remove()
+    {
+        map.MpComp().sessionManager.RemoveSession(this);
+    }
+
+    [SyncMethod]
+    public void Start()
+    {
+        Remove();
+        ritual.MakeNewLord(assignments);
+        Find.PsychicRitualManager.RegisterCooldown(ritual);
+    }
+
+    public void OpenWindow(bool sound = true)
+    {
+        var dialog = new PsychicRitualBeginProxy(
+            ritual,
+            candidatePool,
+            assignments,
+            map);
+
+        if (!sound)
+            dialog.soundAppear = null;
+
+        Find.WindowStack.Add(dialog);
+    }
+
+    public override void Sync(SyncWorker sync)
+    {
+        sync.Bind(ref ritual);
+        sync.Bind(ref candidatePool);
+
+        SyncType assignmentsType = typeof(MpPsychicRitualAssignments);
+        assignmentsType.expose = true;
+        sync.Bind(ref assignments, assignmentsType);
+        assignments.session = this;
+    }
+
+    public override bool IsCurrentlyPausing(Map map) => map == this.map;
+
+    public override FloatMenuOption GetBlockingWindowOptions(ColonistBar.Entry entry)
+    {
+        return new FloatMenuOption("MpPsychicRitualSession".Translate(), () =>
+        {
+            SwitchToMapOrWorld(entry.map);
+            OpenWindow();
+        });
+    }
+
+    public bool CanExistWith(Session other) => other is not PsychicRitualSession;
+}
+
+public class MpPsychicRitualAssignments : PsychicRitualRoleAssignments
+{
+    public PsychicRitualSession session;
+}

--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -9,6 +9,7 @@ using HarmonyLib;
 using Multiplayer.Client.Patches;
 using MultiplayerLoader;
 using Verse;
+using Verse.AI.Group;
 
 namespace Multiplayer.Client
 {
@@ -271,6 +272,11 @@ namespace Multiplayer.Client
             SyncDelegate.Lambda(typeof(Dialog_BeginRitual), nameof(Dialog_BeginRitual.DrawRoleSelection), 3); // Select role, set confirm text
             SyncDelegate.Lambda(typeof(Dialog_BeginRitual), nameof(Dialog_BeginRitual.DrawRoleSelection), 4); // Select role, no confirm text
 
+            SyncMethod.Register(typeof(PsychicRitual), nameof(PsychicRitual.CancelPsychicRitual));
+            SyncMethod.Register(typeof(PsychicRitual), nameof(PsychicRitual.LeavePsychicRitual)); // Make pawn leave ritual
+
+            SyncMethod.Register(typeof(GameComponent_PsychicRitualManager), nameof(GameComponent_PsychicRitualManager.ClearAllCooldowns)).SetDebugOnly(); // Dev reset all psychic ritual cooldowns
+
             /*
                 PawnRoleSelectionWidgetBase
 
@@ -286,6 +292,9 @@ namespace Multiplayer.Client
 
             SyncMethod.Register(typeof(RitualRoleAssignments), nameof(RitualRoleAssignments.TryAssignSpectate));
             SyncMethod.Register(typeof(RitualRoleAssignments), nameof(RitualRoleAssignments.RemoveParticipant));
+
+            SyncMethod.Register(typeof(PsychicRitualRoleAssignments), nameof(PsychicRitualRoleAssignments.TryAssignSpectate));
+            SyncMethod.Register(typeof(PsychicRitualRoleAssignments), nameof(PsychicRitualRoleAssignments.RemoveParticipant));
 
             SyncRituals.ApplyPrepatches(null);
         }


### PR DESCRIPTION
I've decided to look into this over the past 2-3 days and have mostly finished it, however there's still a few things that are needed (so it's currently a draft). Things still needing work:
- Modify ritual prepatches to also work with psychic rituals, so assigning roles will be synced
- Add localization for `MpPsychicRitualSession`

Info on psychic ritual session, dialog, and patches I've included:
- Heavily based on ritual patches (started by copy-pasting session/proxy code related to them)
- I've not used "PsychicRitualData" like how it's done with "RitualData" for normal rituals, as I've decided there wasn't as much data to handle
  - If needed, I can easily change this
- I've synced the start call by overriding the "Start" method in ritual proxy
  - This can also be applied to normal rituals to remove a harmony patch
  - In case of normal rituals, we could also include a confirmation dialog to match vanilla behaviour
- Syncing of creating session was done by patching `PsychicRitualGizmo.InitializePsychicRitual`
  - As opposed to normal rituals that can be started in multiple places, this is the only location those can be created from
- I believe everything else should have comments, match behaviour of other session, or be self-explanatory
  - If explanation for anything else is needed, let me know, and I'll include it in code comments or on GitHub

A slight side note about dialogs with sessions (and styling station dialog) - perhaps we should make a single harmony patch to `Widgets.ButtonTextWorker` with a generalized way to use it? As it stands right now, we basically make two patches per session (prefix and postfix). Having a more generalized way to handle it may be useful in the future.