### PR TITLE
Include map count in desync info

### DIFF
--- a/Source/Client/Desyncs/SaveableDesyncInfo.cs
+++ b/Source/Client/Desyncs/SaveableDesyncInfo.cs
@@ -93,6 +93,7 @@ public class SaveableDesyncInfo
             .AppendLine($"Player Count|||{Multiplayer.session.players.Count}")
             .AppendLine($"Async time active|||{Multiplayer.GameComp.asyncTime}")
             .AppendLine($"Multifaction active|||{Multiplayer.GameComp.multifaction}")
+            .AppendLine($"Map Count|||{Find.Maps?.Count.ToStringSafe()}")
             .AppendLine("\n###CPU Info###")
             .AppendLine($"Processor Name|||{SystemInfo.processorType}")
             .AppendLine($"Processor Speed (MHz)|||{SystemInfo.processorFrequency}")


### PR DESCRIPTION
It may be a bit of a niche use case, but some desyncs happen only (or a lot more frequently) when players are looking at different maps. Making a list of "which map was each player looking at" would be much more difficult to implement, but just having the map count can suggest if an issue could have possibly happened due to having multiple active maps or not.

I've added a bit of extra null safety (instead of just using `Find.Maps.Count`) as I've encountered a couple of weird situations in the past where `Find.Maps.Count` ended up throwing `NullReferenceException`. This may have been a weird mod conflict/interaction, but I've decided to be on the safer side here.