### PR TITLE
Rework FixNullMotes patch

### DIFF
--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -426,31 +426,6 @@ namespace Multiplayer.Client
         }
     }
 
-    [HarmonyPatch(typeof(MoteMaker), nameof(MoteMaker.MakeStaticMote))]
-    [HarmonyPatch(new[] {typeof(Vector3), typeof(Map), typeof(ThingDef), typeof(float), typeof(bool), typeof(float)})]
-    static class FixNullMotes
-    {
-        static Dictionary<Type, Mote> cache = new();
-
-        static void Postfix(ThingDef moteDef, ref Mote __result) {
-            if (__result != null) return;
-
-            if (moteDef.mote.needsMaintenance) return;
-
-            var thingClass = moteDef.thingClass;
-
-            if (cache.TryGetValue(thingClass, out Mote value)) {
-                __result = value;
-            } else {
-                __result = (Mote) Activator.CreateInstance(thingClass);
-
-                cache.Add(thingClass, __result);
-            }
-
-            __result.def = moteDef;
-        }
-    }
-
     [HarmonyPatch(typeof(DiaOption), nameof(DiaOption.Activate))]
     static class NodeTreeDialogSync
     {


### PR DESCRIPTION
This should fix #447, rendering #481 unnecessary. I've decided to still leave that code as an extra safety precaution, but it should be now safe to revert those changes.

As for the changes/fixes, this should fix issues with Bioferrite Harvester and Electroharvester cables not creating motes after switching maps. Additional minor change is that FixNullMotes patch was moved from generic "Patches" to "Determinism", as the patch itself changes some non-deterministic behavior.

The current `FixNullMotes` patch would create a single mote per mote's `ThingDef.thingClass` and then reuse it. It ensured that the call to `MoteMaker.MakeStaticMote` never produced null, however the mote itself was more of a dummy mote (not initialized with any data).

This caused issue with the cables that would periodically attempt to spawn motes. If the mote would not be possible to spawn (drawn off-screen/on a different map), the MP patch would return the cached mote. The cable connection comp would then keep that mote forever, as it can only discard it if the mote is null or destroyed (which would never happen with the dummy note). Because of this, our dummy mote never ended up being discarded by the comp making the cable never draw another mote.

This PR ensures this doesn't happen by reworking "FixNullMotes" to actually spawn the motes, rather than returning a dummy mote. This is done by:
- Setting `makeOffscreen` to true in a prefix, skipping current map check
- Adding `& false` to `MoteCounter.Saturated` calls, allowing to spawn motes even if the mote counter is saturated
- The check for off-screen motes was left as-is, as that one should be deterministic and safe.

Additional change is to call `Initialize` for both `Building_BioferriteHarvester` and `Building_Electroharvester` in `SpawnSetup`, always creating cables for those buildings. Without it, the cables for those 2 aren't created after loading into the game (they're only created when rendered or a connection is added/removed). Since the cables aren't created the motes can't be created either, causing a discrepancy between players (unless they all had the cables created at the same time).

A final note on the original patch - it seems that it was made to fix desyncs caused by motes spawned by `CompAbilityEffect_Waterskip` (and potentially other issues at the time, but I can't find any mention of those). However, this specific issue seems to no longer be relevant as the waterskip now uses flecks rather than motes.