### PR TITLE
Exclude Spectator faction from FactionRepeater

### DIFF
--- a/Source/Client/Factions/FactionRepeater.cs
+++ b/Source/Client/Factions/FactionRepeater.cs
@@ -13,9 +13,13 @@ namespace Multiplayer.Client
         {
             if (Multiplayer.Client == null || ignore) return true;
 
+            var spectatorId = Multiplayer.WorldComp.spectatorFaction.loadID;
             ignore = true;
             foreach (var (id, data) in factionIdToData)
             {
+                if (id == spectatorId)
+                    continue;
+
                 map.PushFaction(id);
                 try
                 {


### PR DESCRIPTION
This should fix the issues with extra missions generating (and often causing errors) due to the game trying to generate them for the Spectator faction.