### PR TITLE
Create PauseLockSession during PostLoadInit in ExposeData

### DIFF
--- a/Source/Client/Comp/World/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/World/MultiplayerWorldComp.cs
@@ -37,7 +37,7 @@ public class MultiplayerWorldComp : IHasSessionData
 
         sessionManager.ExposeSessions();
         // Ensure a pause lock session exists if there's any pause locks registered
-        if (!PauseLockSession.pauseLocks.NullOrEmpty())
+        if (!PauseLockSession.pauseLocks.NullOrEmpty() && Scribe.mode == LoadSaveMode.PostLoadInit)
             sessionManager.AddSession(new PauseLockSession(null));
 
         DoBackCompat();


### PR DESCRIPTION
Normally, calling `UniqueIDsManager.GetNextID` gives a warning when that happens, which made me realize that it's potentially unsafe to do so - the IDs may have not been loaded at that point. This should not happen when saving the data, as the session should exist at that point.

The solution here is to only create the session when `Scribe.mode` is `LoadSaveMode.PostLoadInit`. This ensures the IDs are initialized and getting the next ID won't cause any issues.