### PR TITLE
Make AOE game condition causer use correct map time, fixes #210

### DIFF
--- a/Source/Client/AsyncTime/SetMapTime.cs
+++ b/Source/Client/AsyncTime/SetMapTime.cs
@@ -163,6 +163,18 @@ namespace Multiplayer.Client
         }
     }
 
+    [HarmonyPatch(typeof(CompCauseGameCondition), nameof(CompCauseGameCondition.EnforceConditionOn))]
+    static class MapConditionCauserMapTime
+    {
+        static void Prefix(Map map, ref TimeSnapshot? __state)
+        {
+            if (Multiplayer.Client == null) return;
+            __state = TimeSnapshot.GetAndSetFromMap(map);
+        }
+
+        static void Finalizer(TimeSnapshot? __state) => __state?.Set();
+    }
+
     public struct TimeSnapshot
     {
         public int ticks;


### PR DESCRIPTION
In simple terms, this will fix issues with condition causers, like smoke spewer or psychic suppressor sites.

`CompCauseGameCondition` iterates over the list of each maps that it affects, where it either creates the game condition, or updates the remaining ticks for it.

The issue is that it uses `Find.TickManager.TicksGame` when doing so, which causes the affected maps to receive the time from either the world (if the `Thing` the comp is part of happens to be attached to a world object), or the specific map (if the `Thing` is spawned on an actual map).

The change here is to properly use the actual ticks from the specific map that is affected.

A slight side note - this won't fix maps where the game condition is active, but the condition causer was destroyed. This is due to the condition causer updating the game condition, while the game condition itself does not have any references to the causer itself.