### PR TITLE
Sync atmospheric heater "reset" gizmo

### DIFF
--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -51,7 +51,6 @@ namespace Multiplayer.Client
             SyncMethod.Lambda(typeof(Building_TurretGun), nameof(Building_TurretGun.GetGizmos), 1);          // Reset forced target
             SyncMethod.Lambda(typeof(UnfinishedThing), nameof(UnfinishedThing.GetGizmos), 0);                // Cancel unfinished thing
             SyncMethod.Lambda(typeof(UnfinishedThing), nameof(UnfinishedThing.GetGizmos), 1).SetDebugOnly(); // Dev complete
-            SyncMethod.Lambda(typeof(CompTempControl), nameof(CompTempControl.CompGetGizmosExtra), 2);       // Reset temperature
 
             SyncDelegate.LambdaInGetter(typeof(Designator), nameof(Designator.RightClickFloatMenuOptions), 0) // Designate all
                 .TransformField("things", Serializer.SimpleReader(() => Find.CurrentMap.listerThings.AllThings)).SetContext(SyncContext.CurrentMap);

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -106,6 +106,8 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(Building_ShipComputerCore), nameof(Building_ShipComputerCore.TryLaunch));
             SyncMethod.Register(typeof(CompPower), nameof(CompPower.TryManualReconnect));
             SyncMethod.Register(typeof(CompTempControl), nameof(CompTempControl.InterfaceChangeTargetTemperature_NewTemp));
+            SyncMethod.Lambda(typeof(CompTempControl), nameof(CompTempControl.CompGetGizmosExtra), 2);               // Reset temperature
+            SyncMethod.Lambda(typeof(Comp_AtmosphericHeater), nameof(Comp_AtmosphericHeater.CompGetGizmosExtra), 0); // Reset temperature
             SyncMethod.Register(typeof(CompTransporter), nameof(CompTransporter.CancelLoad), Array.Empty<SyncType>());
             SyncMethod.Register(typeof(MapPortal), nameof(MapPortal.CancelLoad));
             SyncMethod.Register(typeof(StorageSettings), nameof(StorageSettings.CopyFrom)).ExposeParameter(0);


### PR DESCRIPTION
`Comp_AtmosphericHeater` is a subtype of `CompTempControl`, but has the `CompGetGizmosExtra` method rewritten. The +/- 1/10 degrees change was working fine, as it called the synced method `InterfaceChangeTargetTemperature_NewTemp`. However, this was not the case for the reset gizmo, as it set the temperature directly. I've synced the reset gizmo for the atmospheric heater itself, so it should work fine now.

Also moved the `CompTempControl` gizmo syncing from `SyncDelegates` to `SyncMethods`, right next to where the other sync method for the type was registered. I believe it should have been there to begin with, and I must have made a mistake while working through all the new and changed gizmos in 1.5.