### PR TITLE
Fix only one faction having access to Anomaly research in Multifaction

### DIFF
--- a/Source/Client/Comp/World/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/World/MultiplayerWorldComp.cs
@@ -78,6 +78,18 @@ public class MultiplayerWorldComp : IHasSessionData
             AddSpectatorFaction();
             RemoveOpponentFaction();
         }
+
+        // Fix old save files by ensuring all factions have access to Anomaly research if
+        // it was enabled. This needs to be done since Anomaly state is shared by all players.
+        var anomaly = Find.Anomaly;
+        // Don't use anomaly.Level, as it'll return 0 due to monolith not being
+        // spawned. If we want to include that check then we'd need to move this
+        // code into a postfix to Building_VoidMonolith:SpawnSetup.
+        if (anomaly.level > 0 && anomaly.monolith != null)
+        {
+            foreach (var (_, data) in factionData)
+                data.researchManager.Notify_MonolithLevelChanged(anomaly.level);
+        }
     }
 
     private void ExposeFactionData()

--- a/Source/Client/Factions/FactionCreator.cs
+++ b/Source/Client/Factions/FactionCreator.cs
@@ -114,6 +114,10 @@ public static class FactionCreator
     {
         PawnUtility.GiveAllStartingPlayerPawnsThought(ThoughtDefOf.NewColonyOptimism);
         ResearchUtility.ApplyPlayerStartingResearch();
+        // Initialize anomaly. Since the Anomaly comp is currently shared by all players,
+        // we need to ensure that any new factions have access to anomaly research if
+        // anomaly content was started.
+        Find.ResearchManager.Notify_MonolithLevelChanged(Find.Anomaly.Level);
     }
 
     private static void PrepareGameInitData(int sessionId)

--- a/Source/Client/Factions/FactionRepeater.cs
+++ b/Source/Client/Factions/FactionRepeater.cs
@@ -175,4 +175,18 @@ namespace Multiplayer.Client
             );
     }
 
+    [HarmonyPatch(typeof(ResearchManager), nameof(ResearchManager.Notify_MonolithLevelChanged))]
+    static class MonolithLevelChangedPatch
+    {
+        static bool ignore;
+
+        static bool Prefix(int newLevel) =>
+            FactionRepeater.Template(
+                Multiplayer.game?.worldComp.factionData,
+                d => d.researchManager.Notify_MonolithLevelChanged(newLevel),
+                null,
+                ref ignore
+            );
+    }
+
 }

--- a/Source/Client/Networking/HostUtil.cs
+++ b/Source/Client/Networking/HostUtil.cs
@@ -150,6 +150,14 @@ namespace Multiplayer.Client
 
                     factionData.researchManager.progress = new(playerFactionData.researchManager.progress);
                     factionData.researchManager.techprints = new(playerFactionData.researchManager.techprints);
+                    factionData.researchManager.anomalyKnowledge = new(playerFactionData.researchManager.anomalyKnowledge);
+                    factionData.researchManager.currentAnomalyKnowledgeProjects = new(playerFactionData.researchManager.currentAnomalyKnowledgeProjects ?? Enumerable.Empty<ResearchManager.KnowledgeCategoryProject>());
+                    factionData.researchManager.tabInfoVisibility = new();
+                    if (playerFactionData.researchManager.tabInfoVisibility != null)
+                    {
+                        foreach (var (def, value) in playerFactionData.researchManager.tabInfoVisibility)
+                            factionData.researchManager.tabInfoVisibility[def] = value;
+                    }
                 }
 
             foreach (FactionWorldData data in worldComp.factionData.Values)


### PR DESCRIPTION
In Multifaction, only one of the factions can access the Anomaly research tab. Anomaly tab is unlocked when awakening the monolith, but the Anomaly state is global (rather than per-player) which means that there should ever be 1 monolith, and awakening it progresses the Anomaly level for everyone. The issue here is that the code that unlocks Anomaly research tab runs for a single player, meaning that everyone besides the person triggering it will be locked out of it. It also won't unlock for factions unlocked after raising the Anomaly level either.

Changes:
- Added a patch to `ResearchManager.Notify_MonolithLevelChanged`, and then called the method with faction repeater to ensure that unlocking research applies to all active factions
  - All that the patched method does is unlock all the research tabs locked behind a specific Anomaly level
  - However, this won't double some of the special events, like activating Gray Pall or the ending sequence
- Added a call to `ResearchManager:Notify_MonolithLevelChanged` inside `FactionCreator:InitNewGame` to unlock Anomaly research for new factions
  - This will only apply if the Anomaly level is high enough to unlock it
- Added code to call `ResearchManager:Notify_MonolithLevelChanged` inside `MultiplayerWorldComp:DoBackCompat` to unlock Anomaly research for factions created before the fix was introduced
  - Again, this will only apply if the Anomaly level is high enough to unlock it
  - I've picked `DoBackCompat` as it seemed fitting to me, but it could be moved to a different location if needed
  - As mentioned in the comments, the monolith is not spawned yet so the check isn't perfect - fixing it would require moving the code to a postfix for `Building_VoidMonolith:SpawnSetup`
- Added copying of all anomaly knowledge, unlocked research projects, and tab visibility inside of `HostUtil:SetupGameFromSingleplayer`
  - This roughly matches with original code for normal research, where research progress and applied techprints were copied

@Zetrith if you'd like me to move the code fixing existing save files somewhere else that's not `DoBackCompat`, or make some other changes, just let me know.