### PR TITLE
Synced all research tab buttons, fixes #290

### DIFF
--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -955,6 +955,10 @@ namespace Multiplayer.Client
                     }
                 }, true // implicit
             },
+            {
+                (ByteWriter _, ResearchManager _) => { },
+                (ByteReader _) => Find.ResearchManager
+            },
             #endregion
 
             #region Areas

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -55,6 +55,15 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(AreaManager), nameof(AreaManager.TryMakeNewAllowed));
             SyncMethod.Register(typeof(MainTabWindow_Research), nameof(MainTabWindow_Research.DoBeginResearch))
                 .TransformTarget(Serializer.SimpleReader(() => new MainTabWindow_Research()));
+            SyncMethod.Register(typeof(ResearchManager), nameof(ResearchManager.StopProject));
+            // ResearchManager.SetCurrentProject changes the current project and is synced by
+            // MainTabWindow_Research.DoBeginResearch. It will still be called when selecting
+            // "Debug: Finish now". The issue with this is that when triggered by a player who
+            // can't execute debug-only methods it may change the current project to a research
+            // project which cannot be research due to prerequisites, allowing to research them.
+            SyncMethod.Register(typeof(ResearchManager), nameof(ResearchManager.SetCurrentProject)).SetDebugOnly();
+            SyncMethod.Register(typeof(ResearchManager), nameof(ResearchManager.FinishProject)).SetDebugOnly();
+            SyncMethod.Register(typeof(ResearchManager), nameof(ResearchManager.ApplyTechprint)).SetDebugOnly();
 
             SyncMethod.Register(typeof(DrugPolicyDatabase), nameof(DrugPolicyDatabase.MakeNewDrugPolicy));
             SyncMethod.Register(typeof(DrugPolicyDatabase), nameof(DrugPolicyDatabase.TryDelete)).CancelIfAnyArgNull();


### PR DESCRIPTION
This should sync stop research, dev finish now, and dev apply techprints. This required a sync worker delegate for `ResearchManager` to work.

I've decided to include `ResearchManager` sync worker in the `Game` region, as it's a game-wide element (doesn't matter where in the world your colony is, the research will be accessible by you). I've done so since `AreaManager` and `AutoSlaughterManager` are included under the `Maps` region. However, @Zetrith if you'd prefer me to change it and either move it to an existing region or make a new region (`Research`?) - just let me know and I'll update the PR.

I've left the current syncing for selecting research by using `MainTabWindow_Research.DoBeginResearch`, and made `ResearchManager.SetCurrentProject` debug-only. I've done this due to `ResearchManager.SetCurrentProject` being called by "Dev: Finish now" button, which would allow anyone without ability to execute debug-only methods to change their active research to any possible research, ignoring any prerequisites.

Alternative approach to this would be to drop the current sync method and make `ResearchManager.SetCurrentProject` synced normally, and then applying a Harmony patch to it which would check if the selected research is valid (and prevent it from being executed if not allowed).