### PR TITLE
Updated the list of ignored mod configs

### DIFF
--- a/Source/Client/Networking/JoinData.cs
+++ b/Source/Client/Networking/JoinData.cs
@@ -128,7 +128,6 @@ namespace Multiplayer.Client
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public static string[] ignoredConfigsModIds =
         {
-            // The old mod management code also included TacticalGroupsMod.xml and GraphicSetter.xml but I couldn't find their ids
             // todo unhardcode it
             "rwmt.multiplayer",
             "hodlhodl.twitchtoolkit", // contains username
@@ -141,7 +140,11 @@ namespace Multiplayer.Client
             "jelly.modswitch",
             "betterscenes.rimconnect", // contains secret key for streamer
             "jaxe.rimhud",
-            //"zetrith.prepatcher"
+            "telefonmast.graphicssettings",
+            "derekbickley.ltocolonygroupsfinal",
+            "dra.multiplayercustomtickrates", // syncs its own settings
+            "merthsoft.designatorshapes", // settings for UI and stuff meaningless for MP
+            //"zetrith.prepatcher",
         };
 
         public const string TempConfigsDir = "MultiplayerTempConfigs";


### PR DESCRIPTION
- Added Graphics Settings+
  - It used to be included according to the comment
- Added [LTO] Colony Groups
  - It used to be included according to the comment
- Added Designator Shapes
  - Almost all settings are UI-related
  - First non-UI setting is pause when selecting flood fill, which MP Compat disables due to pausing causing issues
  - Second non-UI setting is flood fill cell limit, which doesn't matter due to the designator syncing selected cells themselves
- Added Multiplayer - Custom Tickrates
  - The mod handles syncing its own setting when hosting
- Removed the comment about excluded mods, since both of those were included