### PR TITLE
Fix void monolith float menu causing desync with `CompProximityLetter`

### DIFF
--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -246,6 +246,14 @@ namespace Multiplayer.Client
             SyncDelegate.Lambda(typeof(Hediff_MetalhorrorImplant), nameof(Hediff_MetalhorrorImplant.GetGizmos), 6).SetDebugOnly(); // Change biosignature
             SyncMethod.Lambda(typeof(Hediff_Shambler), nameof(Hediff_Shambler.GetGizmos), 0).SetDebugOnly(); // Self raise
 
+            // Void monolith
+            // Targeting should be handled by syncing `ITargetingSource:OrderForceTarget`
+            SyncMethod.Lambda(typeof(Building_VoidMonolith), nameof(Building_VoidMonolith.GetGizmos), 1).SetDebugOnly(); // Dev activate
+            SyncMethod.Lambda(typeof(Building_VoidMonolith), nameof(Building_VoidMonolith.GetGizmos), 2).SetDebugOnly(); // Dev relink
+            // TryTakeOrderedJob call is already synced, but we also need to make sure that
+            // CompProximityLetter.letterSent is set to true to prevent a desync.
+            SyncDelegate.Lambda(typeof(Building_VoidMonolith), nameof(Building_VoidMonolith.GetFloatMenuOptions), 0);
+
             InitRituals();
             InitChoiceLetters();
             InitDevTools();

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -379,11 +379,6 @@ namespace Multiplayer.Client
             // Jammed door
             SyncMethod.Register(typeof(Building_JammedDoor), nameof(Building_JammedDoor.UnlockDoor)).SetDebugOnly(); // Dev unjam door
 
-            // Void monolith
-            // Targeting should be handled by syncing `ITargetingSource:OrderForceTarget`
-            SyncMethod.Lambda(typeof(Building_VoidMonolith), nameof(Building_VoidMonolith.GetGizmos), 1).SetDebugOnly(); // Dev activate
-            SyncMethod.Lambda(typeof(Building_VoidMonolith), nameof(Building_VoidMonolith.GetGizmos), 2).SetDebugOnly(); // Dev relink
-
             // Harbinger Tree
             SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.CreateCorpseStockpile)).SetContext(SyncContext.MapSelected);
             SyncMethod.Register(typeof(HarbingerTree), nameof(HarbingerTree.AddNutrition)).SetDebugOnly();


### PR DESCRIPTION
`CompProximityLetter` (void monolith, ancient mechanitor exostrider) sends a letter when a player pawn gets close to it. This is disabled (`CompProximityLetter.letterSent` is set to true) when the void monolith is automatically activated, or when a pawn is ordered to interact with it.

When a pawn interacts with the monolith by using the gizmo, the method disabling the letter is synced. However, when using float menu to do it the letter is only disabled for the player who ordered it, as the method is not synced (instead, the interaction is synced by `Pawn_JobTracker.TryTakeOrderedJob` call). It then displays the letter for everyone besides the player who ordered the interaction, causing desync (new ID assigned, causing desync trace mismatch).

The fix was rather simple and required syncing the method the float menu calls when clicked. Investigating what caused the desync took much longer.

I've also moved the void monolith sync methods from `SyncMethods` file to `SyncDelegates` to keep them categorized, specifically by keeping them together with the newly added sync delegate.