### PR TITLE
Register sync methods directly rather than using API

### DIFF
--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -420,11 +420,11 @@ namespace Multiplayer.Client
                     .AllNotNull();
 
                 foreach (var method in methods)
-                    MP.RegisterSyncMethod(method);
+                    Sync.RegisterSyncMethod(method);
 
                 // This OnRenamed method will create a storage group, which needs to be synced.
                 // No other vanilla rename dialogs need syncing OnRenamed, but modded ones potentially could need it.
-                MP.RegisterSyncMethod(typeof(Dialog_RenameBuildingStorage_CreateNew), nameof(Dialog_RenameBuildingStorage_CreateNew.OnRenamed))
+                SyncMethod.Register(typeof(Dialog_RenameBuildingStorage_CreateNew), nameof(Dialog_RenameBuildingStorage_CreateNew.OnRenamed))
                     .TransformTarget(Serializer.New(
                         (Dialog_RenameBuildingStorage_CreateNew dialog) => dialog.building,
                         (IStorageGroupMember member) => new Dialog_RenameBuildingStorage_CreateNew(member)));


### PR DESCRIPTION
I think I must have used the API out of habit when writing this code, my bad. I've changed the code to use `SyncMethod.RegisterSyncMethod` and `SyncMethod.Register` rather than `MP.RegisterSyncMethod`.

This shouldn't change any functionality and is here mostly for consistency.