### PR TITLE
Use more `nameof` and use Harmony to access properties rather than methods

### DIFF
--- a/Source/Client/Factions/Blueprints.cs
+++ b/Source/Client/Factions/Blueprints.cs
@@ -177,8 +177,8 @@ namespace Multiplayer.Client
     static class SpawnBuildingAsPossiblePatch
     {
         static MethodInfo SpawningWipes = AccessTools.Method(typeof(GenSpawn), nameof(GenSpawn.SpawningWipes));
-        public static MethodInfo ThingListGet = AccessTools.Method(typeof(List<Thing>), "get_Item");
-        static FieldInfo ThingDefField = AccessTools.Field(typeof(Thing), "def");
+        public static MethodInfo ThingListGet = AccessTools.IndexerGetter(typeof(List<Thing>), [typeof(int)]);
+        static FieldInfo ThingDefField = AccessTools.Field(typeof(Thing), nameof(Thing.def));
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
         {

--- a/Source/Client/MultiplayerStatic.cs
+++ b/Source/Client/MultiplayerStatic.cs
@@ -313,9 +313,9 @@ namespace Multiplayer.Client
             {
                 var designatorFinalizer = AccessTools.Method(typeof(DesignatorPatches), nameof(DesignatorPatches.DesignateFinalizer));
                 var designatorMethods = new[] {
-                     ("DesignateSingleCell", new[]{ typeof(IntVec3) }),
-                     ("DesignateMultiCell", new[]{ typeof(IEnumerable<IntVec3>) }),
-                     ("DesignateThing", new[]{ typeof(Thing) }),
+                     (nameof(DesignatorPatches.DesignateSingleCell), new[]{ typeof(IntVec3) }),
+                     (nameof(DesignatorPatches.DesignateMultiCell), new[]{ typeof(IEnumerable<IntVec3>) }),
+                     (nameof(DesignatorPatches.DesignateThing), new[]{ typeof(Thing) }),
                 };
 
                 foreach (Type t in typeof(Designator).AllSubtypesAndSelf()

--- a/Source/Client/Patches/ArbiterPatches.cs
+++ b/Source/Client/Patches/ArbiterPatches.cs
@@ -14,7 +14,7 @@ namespace Multiplayer.Client
     {
         static MethodBase TargetMethod()
         {
-            return AccessTools.Method(typeof(GUI), "get_" + nameof(GUI.skin));
+            return AccessTools.PropertyGetter(typeof(GUI), nameof(GUI.skin));
         }
 
         static bool Prefix(ref GUISkin __result)
@@ -28,7 +28,7 @@ namespace Multiplayer.Client
     [HarmonyPatch]
     static class RenderTextureCreatePatch
     {
-        static MethodInfo IsCreated = AccessTools.Method(typeof(RenderTexture), "IsCreated");
+        static MethodInfo IsCreated = AccessTools.Method(typeof(RenderTexture), nameof(RenderTexture.IsCreated));
         static FieldInfo ArbiterField = AccessTools.Field(typeof(Multiplayer), nameof(Multiplayer.arbiterInstance));
 
         static IEnumerable<MethodBase> TargetMethods()

--- a/Source/Client/Persistent/RitualPatches.cs
+++ b/Source/Client/Persistent/RitualPatches.cs
@@ -107,7 +107,7 @@ namespace Multiplayer.Client.Persistent
     [HarmonyPatch]
     static class DontClearDialogBeginRitualCache
     {
-        private static MethodInfo listClear = AccessTools.Method(typeof(List<Precept_Role>), "Clear");
+        private static MethodInfo listClear = AccessTools.Method(typeof(List<Precept_Role>), nameof(List<Precept_Role>.Clear));
 
         static IEnumerable<MethodBase> TargetMethods()
         {

--- a/Source/Client/Persistent/TradingUI.cs
+++ b/Source/Client/Persistent/TradingUI.cs
@@ -451,7 +451,7 @@ namespace Multiplayer.Client
 
             for (int i = 0; i < 2; i++)
             {
-                int getAllTradeables = finder.Forward(OpCodes.Callvirt, AccessTools.Method(typeof(TradeDeal), "get_AllTradeables"));
+                int getAllTradeables = finder.Forward(OpCodes.Callvirt, AccessTools.PropertyGetter(typeof(TradeDeal), nameof(TradeDeal.AllTradeables)));
 
                 insts.RemoveRange(getAllTradeables - 1, 2);
                 insts.Insert(getAllTradeables - 1, new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(TradingWindow), nameof(TradingWindow.AllTradeables))));

--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -128,8 +128,8 @@ namespace Multiplayer.Client
             SyncFactionAcceptRoyalFavor = Sync.Field(typeof(Faction), nameof(Faction.allowRoyalFavorRewards));
             SyncFactionAcceptGoodwill = Sync.Field(typeof(Faction), nameof(Faction.allowGoodwillRewards));
 
-            SyncThingFilterHitPoints = Sync.Field(typeof(ThingFilterContext), "Filter/AllowedHitPointsPercents").SetBufferChanges();
-            SyncThingFilterQuality = Sync.Field(typeof(ThingFilterContext), "Filter/AllowedQualityLevels").SetBufferChanges();
+            SyncThingFilterHitPoints = Sync.Field(typeof(ThingFilterContext), $"{nameof(ThingFilterContext.Filter)}/{nameof(ThingFilter.AllowedHitPointsPercents)}").SetBufferChanges();
+            SyncThingFilterQuality = Sync.Field(typeof(ThingFilterContext), $"{nameof(ThingFilterContext.Filter)}/{nameof(ThingFilter.AllowedQualityLevels)}").SetBufferChanges();
 
             SyncBillPaused = Sync.Field(typeof(Bill_Production), nameof(Bill_Production.paused)).SetBufferChanges();
             SyncBillSuspended = Sync.Field(typeof(Bill), nameof(Bill.suspended));

--- a/Source/Client/Syncing/Game/SyncThingFilters.cs
+++ b/Source/Client/Syncing/Game/SyncThingFilters.cs
@@ -7,7 +7,7 @@ namespace Multiplayer.Client;
 
 public static class SyncThingFilters
 {
-    [MpPrefix(typeof(ThingFilter), "SetAllow", new[] { typeof(StuffCategoryDef), typeof(bool) })]
+    [MpPrefix(typeof(ThingFilter), nameof(ThingFilter.SetAllow), [typeof(StuffCategoryDef), typeof(bool)])]
     static bool ThingFilter_SetAllow(StuffCategoryDef cat, bool allow)
     {
         if (!Multiplayer.ShouldSync || ThingFilterMarkers.DrawnThingFilter == null) return true;
@@ -15,7 +15,7 @@ public static class SyncThingFilters
         return false;
     }
 
-    [MpPrefix(typeof(ThingFilter), "SetAllow", new[] { typeof(SpecialThingFilterDef), typeof(bool) })]
+    [MpPrefix(typeof(ThingFilter), nameof(ThingFilter.SetAllow), [typeof(SpecialThingFilterDef), typeof(bool)])]
     static bool ThingFilter_SetAllow(SpecialThingFilterDef sfDef, bool allow)
     {
         if (!Multiplayer.ShouldSync || ThingFilterMarkers.DrawnThingFilter == null) return true;
@@ -23,7 +23,7 @@ public static class SyncThingFilters
         return false;
     }
 
-    [MpPrefix(typeof(ThingFilter), "SetAllow", new[] { typeof(ThingDef), typeof(bool) })]
+    [MpPrefix(typeof(ThingFilter), nameof(ThingFilter.SetAllow), [typeof(ThingDef), typeof(bool)])]
     static bool ThingFilter_SetAllow(ThingDef thingDef, bool allow)
     {
         if (!Multiplayer.ShouldSync || ThingFilterMarkers.DrawnThingFilter == null) return true;
@@ -31,7 +31,7 @@ public static class SyncThingFilters
         return false;
     }
 
-    [MpPrefix(typeof(ThingFilter), "SetAllow", new[] { typeof(ThingCategoryDef), typeof(bool), typeof(IEnumerable<ThingDef>), typeof(IEnumerable<SpecialThingFilterDef>) })]
+    [MpPrefix(typeof(ThingFilter), nameof(ThingFilter.SetAllow), [typeof(ThingCategoryDef), typeof(bool), typeof(IEnumerable<ThingDef>), typeof(IEnumerable<SpecialThingFilterDef>)])]
     static bool ThingFilter_SetAllow(ThingCategoryDef categoryDef, bool allow)
     {
         if (!Multiplayer.ShouldSync || ThingFilterMarkers.DrawnThingFilter == null) return true;
@@ -39,7 +39,7 @@ public static class SyncThingFilters
         return false;
     }
 
-    [MpPrefix(typeof(ThingFilter), "SetAllowAll")]
+    [MpPrefix(typeof(ThingFilter), nameof(ThingFilter.SetAllowAll))]
     static bool ThingFilter_SetAllowAll()
     {
         if (!Multiplayer.ShouldSync || ThingFilterMarkers.DrawnThingFilter == null) return true;
@@ -47,7 +47,7 @@ public static class SyncThingFilters
         return false;
     }
 
-    [MpPrefix(typeof(ThingFilter), "SetDisallowAll")]
+    [MpPrefix(typeof(ThingFilter), nameof(ThingFilter.SetDisallowAll))]
     static bool ThingFilter_SetDisallowAll()
     {
         if (!Multiplayer.ShouldSync || ThingFilterMarkers.DrawnThingFilter == null) return true;

--- a/Source/Client/Syncing/Game/ThingFilterMarkers.cs
+++ b/Source/Client/Syncing/Game/ThingFilterMarkers.cs
@@ -23,7 +23,7 @@ static class ThingFilterMarkers
         }
     }
 
-    [MpPrefix(typeof(ITab_Storage), "FillTab")]
+    [MpPrefix(typeof(ITab_Storage), nameof(ITab_Storage.FillTab))]
     static void TabStorageFillTab_Prefix(ITab_Storage __instance)
     {
         var selThing = __instance.SelObject;
@@ -37,42 +37,42 @@ static class ThingFilterMarkers
         DrawnThingFilter = new TabStorageWrapper(selParent);
     }
 
-    [MpPostfix(typeof(ITab_Storage), "FillTab")]
+    [MpPostfix(typeof(ITab_Storage), nameof(ITab_Storage.FillTab))]
     static void TabStorageFillTab_Postfix() => DrawnThingFilter = null;
 
-    [MpPrefix(typeof(Dialog_BillConfig), "DoWindowContents")]
+    [MpPrefix(typeof(Dialog_BillConfig), nameof(Dialog_BillConfig.DoWindowContents))]
     static void BillConfig_Prefix(Dialog_BillConfig __instance) =>
         DrawnThingFilter = new BillConfigWrapper(__instance.bill);
 
-    [MpPostfix(typeof(Dialog_BillConfig), "DoWindowContents")]
+    [MpPostfix(typeof(Dialog_BillConfig), nameof(Dialog_BillConfig.DoWindowContents))]
     static void BillConfig_Postfix() => DrawnThingFilter = null;
 
-    [MpPrefix(typeof(Dialog_ManageApparelPolicies), "DoContentsRect")]
+    [MpPrefix(typeof(Dialog_ManageApparelPolicies), nameof(Dialog_ManageApparelPolicies.DoContentsRect))]
     static void ManageOutfit_Prefix(Dialog_ManageApparelPolicies __instance) =>
         DrawnThingFilter = new OutfitWrapper(__instance.SelectedPolicy);
 
-    [MpPostfix(typeof(Dialog_ManageApparelPolicies), "DoContentsRect")]
+    [MpPostfix(typeof(Dialog_ManageApparelPolicies), nameof(Dialog_ManageApparelPolicies.DoContentsRect))]
     static void ManageOutfit_Postfix() => DrawnThingFilter = null;
 
-    [MpPrefix(typeof(Dialog_ManageFoodPolicies), "DoContentsRect")]
+    [MpPrefix(typeof(Dialog_ManageFoodPolicies), nameof(Dialog_ManageFoodPolicies.DoContentsRect))]
     static void ManageFoodRestriction_Prefix(Dialog_ManageFoodPolicies __instance) =>
         DrawnThingFilter = new FoodRestrictionWrapper(__instance.SelectedPolicy);
 
-    [MpPostfix(typeof(Dialog_ManageFoodPolicies), "DoContentsRect")]
+    [MpPostfix(typeof(Dialog_ManageFoodPolicies), nameof(Dialog_ManageFoodPolicies.DoContentsRect))]
     static void ManageFoodRestriction_Postfix() => DrawnThingFilter = null;
 
-    [MpPrefix(typeof(ITab_PenAutoCut), "FillTab")]
+    [MpPrefix(typeof(ITab_PenAutoCut), nameof(ITab_PenAutoCut.FillTab))]
     static void TabPenAutocutFillTab_Prefix(ITab_PenAutoCut __instance) =>
         DrawnThingFilter = new PenAutocutWrapper(__instance.SelectedCompAnimalPenMarker);
 
-    [MpPostfix(typeof(ITab_PenAutoCut), "FillTab")]
+    [MpPostfix(typeof(ITab_PenAutoCut), nameof(ITab_PenAutoCut.FillTab))]
     static void TabPenAutocutFillTab_Postfix() => DrawnThingFilter = null;
 
-    [MpPrefix(typeof(ITab_PenAnimals), "FillTab")]
+    [MpPrefix(typeof(ITab_PenAnimals), nameof(ITab_PenAnimals.FillTab))]
     static void TabPenAnimalsFillTab_Prefix(ITab_PenAnimals __instance) =>
         DrawnThingFilter = new PenAnimalsWrapper(__instance.SelectedCompAnimalPenMarker);
 
-    [MpPostfix(typeof(ITab_PenAnimals), "FillTab")]
+    [MpPostfix(typeof(ITab_PenAnimals), nameof(ITab_PenAnimals.FillTab))]
     static void TabPenAnimalsFillTab_Postfix() => DrawnThingFilter = null;
 
     [MpPrefix(typeof(ITab_WindTurbineAutoCut), nameof(ITab_WindTurbineAutoCut.FillTab))]

--- a/Source/Client/Util/MpUI.cs
+++ b/Source/Client/Util/MpUI.cs
@@ -258,7 +258,7 @@ namespace Multiplayer.Client.Util
             {
                 te.scrollOffset = scrollOffset;
                 te.text = new string(PassChar, password.Length);
-                AccessTools.Field(typeof(TextEditor), "m_RevealCursor").SetValue(te, true);
+                AccessTools.Field(typeof(TextEditor), nameof(TextEditor.m_RevealCursor)).SetValue(te, true);
                 te.UpdateScrollOffsetIfNeeded(new Event());
             }
         }


### PR DESCRIPTION
String constant, wherever possible (assuming I haven't missed some), were replaced by the use of `nameof`.

Replaced places where properties are accessed with `AccessTools.PropertyGetter` or `AccessTools.IndexerGetter`, rather than `AccessTools.Method` by using `get_` in the method name.

Also, I've changed array initialization to use collection expressions in `SyncThingFilters` class, since I was already modifying it.