### PR TITLE
Update WorldObject sync worker delegate to handle pocket maps

### DIFF
--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -878,7 +878,8 @@ namespace Multiplayer.Client
                     if (objId == -1)
                         return null;
 
-                    return Find.World.worldObjects.AllWorldObjects.Find(w => w.ID == objId);
+                    return Find.World.worldObjects.AllWorldObjects.Find(w => w.ID == objId) ??
+                           Find.World.pocketMaps.Find(p => p.ID == objId);
                 }, true // Implicit
             },
             {


### PR DESCRIPTION
When a pocket map is generated, it is added to `Find.World.pocketMaps` rather than `Find.World.worldObjects.AllWorldObjects`.

This change will make sync worker fallback to pocket maps list if it did not find the map in world objects list.