### PR TITLE
Disable Trade/Transport/Caravan Session Buttons for Other Factions

### DIFF
--- a/Source/Client/Comp/Map/MultiplayerMapComp.cs
+++ b/Source/Client/Comp/Map/MultiplayerMapComp.cs
@@ -35,12 +35,12 @@ namespace Multiplayer.Client
             sessionManager = new(map);
         }
 
-        public CaravanFormingSession CreateCaravanFormingSession(bool reform, Action onClosed, bool mapAboutToBeRemoved, IntVec3? meetingSpot = null)
+        public CaravanFormingSession CreateCaravanFormingSession(Faction faction, bool reform, Action onClosed, bool mapAboutToBeRemoved, IntVec3? meetingSpot = null)
         {
             var caravanForming = sessionManager.GetFirstOfType<CaravanFormingSession>();
             if (caravanForming == null)
             {
-                caravanForming = new CaravanFormingSession(map, reform, onClosed, mapAboutToBeRemoved, meetingSpot);
+                caravanForming = new CaravanFormingSession(faction, map, reform, onClosed, mapAboutToBeRemoved, meetingSpot);
                 if (!sessionManager.AddSession(caravanForming))
                 {
                     // Shouldn't happen if the session doesn't exist already, show an error just in case
@@ -51,12 +51,12 @@ namespace Multiplayer.Client
             return caravanForming;
         }
 
-        public TransporterLoading CreateTransporterLoadingSession(List<CompTransporter> transporters)
+        public TransporterLoading CreateTransporterLoadingSession(Faction faction, List<CompTransporter> transporters)
         {
             var transporterLoading = sessionManager.GetFirstOfType<TransporterLoading>();
             if (transporterLoading == null)
             {
-                transporterLoading = new TransporterLoading(map, transporters);
+                transporterLoading = new TransporterLoading(faction, map, transporters);
                 if (!sessionManager.AddSession(transporterLoading))
                 {
                     // Shouldn't happen if the session doesn't exist already, show an error just in case

--- a/Source/Client/Persistent/CaravanFormingPatches.cs
+++ b/Source/Client/Persistent/CaravanFormingPatches.cs
@@ -7,6 +7,7 @@ using Multiplayer.Client.Patches;
 using UnityEngine;
 using Verse;
 using static Verse.Widgets;
+using System.Reflection;
 
 namespace Multiplayer.Client.Persistent
 {
@@ -168,25 +169,27 @@ namespace Multiplayer.Client.Persistent
             if (__instance.GetType() != typeof(Dialog_FormCaravan))
                 return;
 
+            Faction faction = Faction.OfPlayer;
+
             // Handles showing the dialog from TimedForcedExit.CompTick -> TimedForcedExit.ForceReform
             // (note TimedForcedExit is obsolete)
             if (Multiplayer.ExecutingCmds || Multiplayer.Ticking)
             {
                 var comp = map.MpComp();
                 if (comp.sessionManager.GetFirstOfType<CaravanFormingSession>() == null)
-                    comp.CreateCaravanFormingSession(reform, onClosed, mapAboutToBeRemoved, designatedMeetingPoint);
+                    comp.CreateCaravanFormingSession(faction, reform, onClosed, mapAboutToBeRemoved, designatedMeetingPoint);
             }
             else // Handles opening from the interface: forming gizmos, reforming gizmos and caravan hitching spots
             {
-                StartFormingCaravan(map, reform, designatedMeetingPoint);
+                StartFormingCaravan(faction, map, reform, designatedMeetingPoint);
             }
         }
 
         [SyncMethod]
-        internal static void StartFormingCaravan(Map map, bool reform = false, IntVec3? designatedMeetingPoint = null, int? routePlannerWaypoint = null)
+        internal static void StartFormingCaravan(Faction faction, Map map, bool reform = false, IntVec3? designatedMeetingPoint = null, int? routePlannerWaypoint = null)
         {
             var comp = map.MpComp();
-            var session = comp.CreateCaravanFormingSession(reform, null, false, designatedMeetingPoint);
+            var session = comp.CreateCaravanFormingSession(faction, reform, null, false, designatedMeetingPoint);
 
             if (TickPatch.currentExecutingCmdIssuedBySelf)
             {
@@ -224,7 +227,7 @@ namespace Multiplayer.Client.Persistent
                 return true;
 
             // Override behavior in multiplayer
-            DialogFormCaravanCtorPatch.StartFormingCaravan(origin, routePlannerWaypoint: tile);
+            DialogFormCaravanCtorPatch.StartFormingCaravan(Faction.OfPlayer, origin, routePlannerWaypoint: tile);
 
             return false;
         }
@@ -239,6 +242,103 @@ namespace Multiplayer.Client.Persistent
                 return !mapParent.Map.AsyncTime().Paused;
 
             return true;
+        }
+    }
+
+    [HarmonyPatch()]
+    static class DisableCaravanFormCheckboxForOtherFactions
+    {
+        static MethodInfo TargetMethod() {
+            return typeof(Widgets).GetMethod("Checkbox", [
+                typeof(Vector2), typeof(bool).MakeByRefType(), typeof(float), typeof(bool), typeof(bool), typeof(Texture2D), typeof(Texture2D)
+            ]);
+        }
+
+        static bool Prefix(Vector2 topLeft, bool checkOn, bool disabled)
+        {
+            if (CaravanFormingProxy.drawing == null || CaravanFormingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (disabled)
+                return true;
+
+            Widgets.Checkbox(topLeft, ref checkOn, disabled: true);
+            return false;
+        }
+    }
+
+    [HarmonyPatch()]
+    static class DisableCaravanFormSuppliesCheckboxForOtherFactions
+    {
+        static MethodInfo TargetMethod() {
+            return typeof(Widgets).GetMethod("CheckboxLabeled", [
+                typeof(Rect), typeof(string), typeof(bool).MakeByRefType(), typeof(bool), typeof(Texture2D), typeof(Texture2D), typeof(bool), typeof(bool)
+            ]);
+        }
+
+        static bool Prefix(Rect rect, string label, bool checkOn, bool disabled)
+        {
+            if (CaravanFormingProxy.drawing == null || CaravanFormingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (disabled || label != "AutomaticallySelectTravelSupplies".Translate())
+                return true;
+
+            Widgets.CheckboxLabeled(rect, label, ref checkOn, disabled: true, null, null, placeCheckboxNearText: true);
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Widgets), nameof(Widgets.ButtonText), typeof(Rect), typeof(string), typeof(bool), typeof(bool), typeof(bool), typeof(TextAnchor))]
+    static class DisableCaravanFormControlButtonsForOtherFactions
+    {
+        static bool Prefix(Rect rect, string label, ref bool __result)
+        {
+            if (CaravanFormingProxy.drawing == null || CaravanFormingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (label != "ResetButton".Translate() && label != "CancelButton".Translate() && label != "ChangeRouteButton".Translate() && label != "Send".Translate())
+                return true;
+
+            __result = false;
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Widgets), nameof(Widgets.ButtonText))]
+    [HarmonyPatch(new[] { typeof(Rect), typeof(string), typeof(bool), typeof(bool), typeof(bool), typeof(TextAnchor) })]
+    static class DisableCaravanFormCountButtonsForOtherFactions
+    {
+        static bool Prefix(Rect rect, string label, ref bool __result)
+        {
+            if (CaravanFormingProxy.drawing == null || CaravanFormingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (label != "0" && label != "<<" && label != "<" && label != ">" && label != ">>" && label != ">M")
+                return true;
+
+            GUI.color = Widgets.InactiveColor;
+            Widgets.TextArea(rect, label, true);
+            GUI.color = Color.white;
+            __result = false;
+            return false;
+        }
+    }
+
+    [HarmonyPatch()]
+    static class DisableCaravanFormCountTextBoxForOtherFactions
+    {
+        static MethodInfo TargetMethod() {
+            return typeof(Widgets).GetMethod("TextFieldNumeric", BindingFlags.Public | BindingFlags.Static).MakeGenericMethod(typeof(int));
+        }
+        static bool Prefix(Rect rect, int val)
+        {
+            if (CaravanFormingProxy.drawing == null || CaravanFormingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            GUI.color = Color.white;
+            Widgets.TextArea(rect, val.ToString(), true);
+            return false;
         }
     }
 }

--- a/Source/Client/Persistent/CaravanFormingSession.cs
+++ b/Source/Client/Persistent/CaravanFormingSession.cs
@@ -11,6 +11,8 @@ namespace Multiplayer.Client
     {
         public Map map;
 
+        public Faction faction;
+
         public bool reform;
         public Action onClosed;
         public bool mapAboutToBeRemoved;
@@ -24,12 +26,13 @@ namespace Multiplayer.Client
 
         public override Map Map => map;
 
-        public CaravanFormingSession(Map map) : base(map)
+        public CaravanFormingSession(Faction faction, Map map) : base(map)
         {
             this.map = map;
+            this.faction = faction;
         }
 
-        public CaravanFormingSession(Map map, bool reform, Action onClosed, bool mapAboutToBeRemoved, IntVec3? meetingSpot = null) : this(map)
+        public CaravanFormingSession(Faction faction, Map map, bool reform, Action onClosed, bool mapAboutToBeRemoved, IntVec3? meetingSpot = null) : this(faction, map)
         {
             this.reform = reform;
             this.onClosed = onClosed;

--- a/Source/Client/Persistent/Trading.cs
+++ b/Source/Client/Persistent/Trading.cs
@@ -22,6 +22,8 @@ namespace Multiplayer.Client
         public MpTradeDeal deal;
         public bool giftsOnly;
 
+        public Faction NegotiatorFaction => playerNegotiator?.Faction;
+
         public string Label
         {
             get

--- a/Source/Client/Persistent/TradingUI.cs
+++ b/Source/Client/Persistent/TradingUI.cs
@@ -48,7 +48,7 @@ namespace Multiplayer.Client
             if (selectedTab == -1 && trading.Count > 0)
                 selectedTab = 0;
 
-            if (selectedTab == -1)
+            if (selectedTab == -1 || tabs.Count == 0)
             {
                 Close();
                 return;
@@ -56,7 +56,7 @@ namespace Multiplayer.Client
 
             int rows = Mathf.CeilToInt(tabs.Count / 3f);
             inRect.yMin += rows * TabDrawer.TabHeight + 3;
-            TabDrawer.DrawTabs(inRect, tabs, rows);
+            TabDrawer.DrawTabs(inRect, tabs);
 
             inRect.yMin += 10f;
 
@@ -243,6 +243,77 @@ namespace Multiplayer.Client
             }
 
             return list;
+        }
+    }
+
+    [HarmonyPatch(typeof(Widgets), nameof(Widgets.ButtonText), typeof(Rect), typeof(string), typeof(bool), typeof(bool), typeof(bool), typeof(TextAnchor))]
+    static class DisableTradeControlButtonsForOtherFactions
+    {
+        static bool Prefix(Rect rect, string label, ref bool __result)
+        {
+            if (TradingWindow.drawingTrade == null || MpTradeSession.current.NegotiatorFaction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (label != "ResetButton".Translate() && label != "CancelButton".Translate() && label != "OfferGifts".Translate() && label != "AcceptButton".Translate())
+                return true;
+
+            __result = false;
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Widgets), nameof(Widgets.ButtonImageWithBG))]
+    static class DisableTradeModeButtonForOtherFactions
+    {
+        private static readonly Texture2D GiftModeIcon = ContentFinder<Texture2D>.Get("UI/Buttons/GiftMode");
+	    private static readonly Texture2D TradeModeIcon = ContentFinder<Texture2D>.Get("UI/Buttons/TradeMode");
+
+        static bool Prefix(Rect butRect, Texture2D image, ref bool __result)
+        {
+            if (TradingWindow.drawingTrade == null || MpTradeSession.current.NegotiatorFaction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (image != GiftModeIcon && image != TradeModeIcon)
+                return true;
+
+            __result = false;
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Widgets), nameof(Widgets.ButtonText), typeof(Rect), typeof(string), typeof(bool), typeof(bool), typeof(bool), typeof(TextAnchor))]
+    static class DisableTradeCountButtonsForOtherFactions
+    {
+        static bool Prefix(Rect rect, string label, ref bool __result)
+        {
+            if (TradingWindow.drawingTrade == null || MpTradeSession.current.NegotiatorFaction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (label != "0" && label != "<<" && label != "<" && label != ">" && label != ">>" && label != ">M")
+                return true;
+
+            GUI.color = Widgets.InactiveColor;
+            Widgets.TextArea(rect, label, true);
+            GUI.color = Color.white;
+            __result = false;
+            return false;
+        }
+    }
+
+    [HarmonyPatch()]
+    static class DisableTradeCountTextBoxForOtherFactions
+    {
+        static MethodInfo TargetMethod() {
+            return typeof(Widgets).GetMethod("TextFieldNumeric", BindingFlags.Public | BindingFlags.Static).MakeGenericMethod(typeof(int));
+        }
+        static bool Prefix(Rect rect, int val)
+        {
+            if (TradingWindow.drawingTrade == null || MpTradeSession.current.NegotiatorFaction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            GUI.color = Color.white;
+            Widgets.TextArea(rect, val.ToString(), true);
+            return false;
         }
     }
 

--- a/Source/Client/Persistent/TransporterLoadingPatches.cs
+++ b/Source/Client/Persistent/TransporterLoadingPatches.cs
@@ -133,10 +133,85 @@ namespace Multiplayer.Client.Persistent
             if (Multiplayer.ExecutingCmds || Multiplayer.Ticking)
             {
                 var comp = map.MpComp();
-                TransporterLoading loading = comp.CreateTransporterLoadingSession(transporters);
+                TransporterLoading loading = comp.CreateTransporterLoadingSession(Faction.OfPlayer, transporters);
                 if (TickPatch.currentExecutingCmdIssuedBySelf)
                     loading.OpenWindow();
             }
+        }
+    }
+
+    [HarmonyPatch()]
+    static class DisableTransferCheckboxForOtherFactions
+    {
+        static MethodInfo TargetMethod() {
+            return typeof(Widgets).GetMethod("Checkbox", [
+                typeof(Vector2), typeof(bool).MakeByRefType(), typeof(float), typeof(bool), typeof(bool), typeof(Texture2D), typeof(Texture2D)
+            ]);
+        }
+
+        static bool Prefix(Vector2 topLeft, bool checkOn, bool disabled)
+        {
+            if (TransporterLoadingProxy.drawing == null || TransporterLoadingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (disabled)
+                return true;
+
+            Widgets.Checkbox(topLeft, ref checkOn, disabled: true);
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Widgets), nameof(Widgets.ButtonText), typeof(Rect), typeof(string), typeof(bool), typeof(bool), typeof(bool), typeof(TextAnchor))]
+    static class DisableLoadingControlButtonsForOtherFactions
+    {
+        static bool Prefix(Rect rect, string label, ref bool __result)
+        {
+            if (TransporterLoadingProxy.drawing == null || TransporterLoadingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (label != "ResetButton".Translate() && label != "CancelButton".Translate() && label != "AcceptButton".Translate())
+                return true;
+
+            __result = false;
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Widgets), nameof(Widgets.ButtonText))]
+    [HarmonyPatch(new[] { typeof(Rect), typeof(string), typeof(bool), typeof(bool), typeof(bool), typeof(TextAnchor) })]
+    static class DisableTransferCountButtonsForOtherFactions
+    {
+        static bool Prefix(Rect rect, string label, ref bool __result)
+        {
+            if (TransporterLoadingProxy.drawing == null || TransporterLoadingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            if (label != "0" && label != "<<" && label != "<" && label != ">" && label != ">>" && label != ">M")
+                return true;
+
+            GUI.color = Widgets.InactiveColor;
+            Widgets.TextArea(rect, label, true);
+            GUI.color = Color.white;
+            __result = false;
+            return false;
+        }
+    }
+
+    [HarmonyPatch()]
+    static class DisableTransferCountTextBoxForOtherFactions
+    {
+        static MethodInfo TargetMethod() {
+            return typeof(Widgets).GetMethod("TextFieldNumeric", BindingFlags.Public | BindingFlags.Static).MakeGenericMethod(typeof(int));
+        }
+        static bool Prefix(Rect rect, int val)
+        {
+            if (TransporterLoadingProxy.drawing == null || TransporterLoadingProxy.drawing.Session?.faction == Multiplayer.RealPlayerFaction)
+                return true;
+
+            GUI.color = Color.white;
+            Widgets.TextArea(rect, val.ToString(), true);
+            return false;
         }
     }
 }

--- a/Source/Client/Persistent/TransporterLoadingSession.cs
+++ b/Source/Client/Persistent/TransporterLoadingSession.cs
@@ -12,18 +12,21 @@ namespace Multiplayer.Client
 
         public Map map;
 
+        public Faction faction;
+
         public List<CompTransporter> transporters;
         public List<ThingWithComps> pods;
         public List<TransferableOneWay> transferables;
 
         public bool uiDirty;
 
-        public TransporterLoading(Map map) : base(map)
+        public TransporterLoading(Faction faction, Map map) : base(map)
         {
             this.map = map;
+            this.faction = faction;
         }
 
-        public TransporterLoading(Map map, List<CompTransporter> transporters) : this(map)
+        public TransporterLoading(Faction faction, Map map, List<CompTransporter> transporters) : this(faction, map)
         {
             this.transporters = transporters;
             pods = transporters.Select(t => t.parent).ToList();


### PR DESCRIPTION
_Probably mark as low priority._

### What does it do
Disables buttons, checkboxes, and textboxes in caravan forming, load transport, and trade UI for factions not participating.

### Alternate Solution?
If RWMT prefers it, I can pivot to a simpler solution of just hiding session dialogs from other factions all together.  Its more simple and has fewer harmony patches, but in my opinion feels like it serves to isolate players from one another more.  Making the multiplayer experience feel more like "single player at the same time".

In the future, perhaps both solutions have merit when faction relations are considered.  Enemies have sessions hidden, neutral/friendly can view only.

### Notes
There is probably a better way to do this, I just wanted to see if I could do it and learn how. Definitely open to suggestions/improvements.

Why not caravan splitting session?  -  It seems that in multifaction, other factions cannot see the splitting session and there may be a bug in async-time preventing all maps from unpausing while the splitting session is open. 

Why not Ritual session or <x> session?  -  I don't own those DLC to test them.  Others are welcome take what I've done here, improve it and apply it to those sessions.

### Images:
Trade as seen from another faction:
![image](https://github.com/user-attachments/assets/5efbb595-4703-4157-aad5-fbdad26e270f)

Transport pod (similar to Caravan Forming):
![image](https://github.com/user-attachments/assets/71107357-859d-49d1-bf5d-6da3be7c17c0)

