### PR TITLE
More resilient syncing of bill repeat mode

### DIFF
--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -4,6 +4,9 @@ using RimWorld;
 using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
 using UnityEngine;
 using Verse;
 using static Verse.Widgets;
@@ -396,12 +399,34 @@ namespace Multiplayer.Client
             }
         }
 
-        [MpPrefix(typeof(BillRepeatModeUtility), nameof(BillRepeatModeUtility.MakeConfigFloatMenu), lambdaOrdinal: 0)]
-        [MpPrefix(typeof(BillRepeatModeUtility), nameof(BillRepeatModeUtility.MakeConfigFloatMenu), lambdaOrdinal: 1)]
-        [MpPrefix(typeof(BillRepeatModeUtility), nameof(BillRepeatModeUtility.MakeConfigFloatMenu), lambdaOrdinal: 2)]
-        static void BillRepeatMode(object __instance)
+        [MpTranspiler(typeof(BillRepeatModeUtility), nameof(BillRepeatModeUtility.MakeConfigFloatMenu))]
+        static IEnumerable<CodeInstruction> BillConfigFloatMenuTranspiler(IEnumerable<CodeInstruction> insts, MethodBase orig)
         {
-            SyncBillProduction.Watch(__instance.GetPropertyOrField("bill"));
+            // Find the last occurence of Find.WindowStack.Add(new FloatMenu(opts)) by searching for Find.WindowStack property access.
+            var findWindowStackGetProp = AccessTools.DeclaredPropertyGetter(typeof(Find), nameof(Find.WindowStack));
+            var found = false;
+            foreach (var inst in insts)
+            {
+                if (inst.Calls(findWindowStackGetProp))
+                {
+                    found = true;
+                    yield return new CodeInstruction(OpCodes.Ldarg_0); // Bill_Production bill
+                    yield return new CodeInstruction(OpCodes.Ldloc_1); // List<FloatMenuOption> options
+                    yield return new CodeInstruction(OpCodes.Call, ((Delegate) SyncBillConfigFloatMenuOptions).Method);
+                }
+
+                yield return inst;
+            }
+
+            if (!found)
+            {
+                throw new Exception("Unexpected code structure in BillRepeatModeUtility.MakeConfigFloatMenu");
+            }
+        }
+
+        private static void SyncBillConfigFloatMenuOptions(Bill_Production bill, List<FloatMenuOption> opts)
+        {
+            WatchMenuOptions(() => SyncBillProduction.Watch(bill), opts);
         }
 
         [MpPrefix(typeof(ITab_Bills), nameof(ITab_Bills.TabUpdate))]
@@ -491,8 +516,19 @@ namespace Multiplayer.Client
             foreach (var entry in dropdowns)
             {
                 if (entry.option.action != null)
-                    entry.option.action = (SyncFieldUtil.FieldWatchPrefix + watchAction + entry.option.action + SyncFieldUtil.FieldWatchPostfix);
+                    entry.option.action = SyncFieldUtil.FieldWatchPrefix + watchAction + entry.option.action + SyncFieldUtil.FieldWatchPostfix;
                 yield return entry;
+            }
+        }
+
+        static void WatchMenuOptions(Action watchAction, IEnumerable<FloatMenuOption> opts)
+        {
+            foreach (var entry in opts)
+            {
+                if (entry.action != null)
+                {
+                    entry.action = SyncFieldUtil.FieldWatchPrefix + watchAction + entry.action + SyncFieldUtil.FieldWatchPostfix;
+                }
             }
         }
 

--- a/Source/Client/Util/MpPatch.cs
+++ b/Source/Client/Util/MpPatch.cs
@@ -195,7 +195,7 @@ namespace Multiplayer.Client
         {
         }
 
-        public MpTranspiler(Type type, string method, Type[] argTypes) : base(type, method, argTypes)
+        public MpTranspiler(Type type, string method, Type[] argTypes = null) : base(type, method, argTypes)
         {
         }
 


### PR DESCRIPTION
The current approach of injecting watching into lambdas is fine as long as there aren't any mods adding additional options. This approach breaks down once there are more repeat modes (as added by [_Everybody Gets One_](https://steamcommunity.com/sharedfiles/filedetails/?id=1687566130)). The EGO mod desyncs upon the first completion of a bill with a new repeat mode set ("Desnycs after the first item is made with a"x per colonists" bill." - copied from Modlist spreadsheet).
 The desync was caused by the custom repeat modes not being synchronized. The mod adds it's own options into the FloatMenuOption list, but Multiplayer doesn't realize that (as it only monitors the 3 lambdas, not the whole list of options). After the client resyncs, the bill is redownloaded by the client and then it can see the real repeat mode configured (at least until it's re-changed again to a new repeat mode). The new approach works by injecting code at the very end of constructing menu options, just before they are passed to `Find.WindowStack`. This way any mod that adds custom repeat modes will have bill modes synchronized properly. Once merged, `Everybody Gets One` can have it's status upgraded from 1 to 2 (custom repeat modes will work, editing who counts as a person will not).