### PR TITLE
Make RNG in multiplayer more random, fix small RNG bug

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncTimeComp.cs
@@ -80,13 +80,17 @@ namespace Multiplayer.Client
         public TickList tickListLong = new(TickerType.Long);
 
         // Shared random state for ticking and commands
-        public ulong randState = 1;
+        public ulong randState;
 
         public Queue<ScheduledCommand> cmds = new();
 
         public AsyncTimeComp(Map map)
         {
             this.map = map;
+
+            // Use the world's constant rand seed and map tile ID as our initial randState.
+            // Only fill the seed part, leave the iterations out.
+            randState = (uint)Gen.HashCombineInt(map.uniqueID, Find.World.ConstantRandSeed);
         }
 
         public void Tick()

--- a/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
@@ -62,13 +62,17 @@ public class AsyncWorldTimeComp : IExposable, ITickable
     public int TickableId => -1;
 
     public World world;
-    public ulong randState = 2;
+    public ulong randState;
 
     public int worldTicks;
 
     public AsyncWorldTimeComp(World world)
     {
         this.world = world;
+
+        // Use the world's constant rand seed as our initial randState.
+        // Only fill the seed part, leave the iterations out.
+        randState = (uint)world.ConstantRandSeed;
     }
 
     public void ExposeData()

--- a/Source/Client/Patches/Seeds.cs
+++ b/Source/Client/Patches/Seeds.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
+using Multiplayer.Client.Util;
 using Verse;
 using Verse.Grammar;
 
@@ -37,7 +38,7 @@ namespace Multiplayer.Client
             if (Multiplayer.Client == null) return;
             if (Scribe.mode != LoadSaveMode.LoadingVars && Scribe.mode != LoadSaveMode.ResolvingCrossRefs && Scribe.mode != LoadSaveMode.PostLoadInit) return;
 
-            int seed = __instance.uniqueID;
+            int seed = Gen.HashCombineInt(__instance.uniqueID, Find.World.ConstantRandSeed);
             Rand.PushState(seed);
 
             __state = true;
@@ -58,7 +59,7 @@ namespace Multiplayer.Client
         {
             if (Multiplayer.Client == null) return;
 
-            int seed = __instance.uniqueID;
+            int seed = Gen.HashCombineInt(__instance.uniqueID, Find.World.ConstantRandSeed);
             Rand.PushState(seed);
 
             __state = true;
@@ -71,14 +72,14 @@ namespace Multiplayer.Client
         }
     }
 
-    [HarmonyPatch(typeof(CaravanEnterMapUtility), nameof(CaravanEnterMapUtility.Enter), new[] { typeof(Caravan), typeof(Map), typeof(Func<Pawn, IntVec3>), typeof(CaravanDropInventoryMode), typeof(bool) })]
+    [HarmonyPatch(typeof(CaravanEnterMapUtility), nameof(CaravanEnterMapUtility.Enter), typeof(Caravan), typeof(Map), typeof(Func<Pawn, IntVec3>), typeof(CaravanDropInventoryMode), typeof(bool))]
     static class SeedCaravanEnter
     {
         static void Prefix(Map map, ref bool __state)
         {
             if (Multiplayer.Client == null) return;
 
-            int seed = map.uniqueID;
+            int seed = Gen.HashCombineInt(map.uniqueID, Find.World.ConstantRandSeed);
             Rand.PushState(seed);
 
             __state = true;
@@ -105,7 +106,7 @@ namespace Multiplayer.Client
     }
 
     // Seed the rotation random
-    [HarmonyPatch(typeof(GenSpawn), nameof(GenSpawn.Spawn), new[] { typeof(Thing), typeof(IntVec3), typeof(Map), typeof(Rot4), typeof(WipeMode), typeof(bool), typeof(bool) })]
+    [HarmonyPatch(typeof(GenSpawn), nameof(GenSpawn.Spawn), typeof(Thing), typeof(IntVec3), typeof(Map), typeof(Rot4), typeof(WipeMode), typeof(bool), typeof(bool))]
     static class GenSpawnRotatePatch
     {
         static MethodInfo Rot4GetRandom = AccessTools.Property(typeof(Rot4), nameof(Rot4.Random)).GetGetMethod();
@@ -116,9 +117,16 @@ namespace Multiplayer.Client
             {
                 if (inst.operand == Rot4GetRandom)
                 {
+                    // Load newThing.thingIdNumber to the stack
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(Thing), nameof(Thing.thingIDNumber)));
-                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Rand), nameof(Rand.PushState), new[] { typeof(int) }));
+                    // Load Find.World.ConstantRandSeed to the stack
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.PropertyGetter(typeof(Find), nameof(Find.World)));
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.PropertyGetter(typeof(World), nameof(World.ConstantRandSeed)));
+                    // Pop our 2 values, call Gen.HashCombineInt with them, and push the outcome to the stack
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Gen), nameof(Gen.HashCombineInt), [typeof(int), typeof(int)]));
+                    // Pop the value off the stack and call Rand.PushState with it as the argument
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Rand), nameof(Rand.PushState), [typeof(int)]));
                 }
 
                 yield return inst;
@@ -153,7 +161,7 @@ namespace Multiplayer.Client
         {
             yield return AccessTools.Method(typeof(GrammarResolver), nameof(GrammarResolver.Resolve));
             yield return AccessTools.Method(typeof(PawnBioAndNameGenerator), nameof(PawnBioAndNameGenerator.GeneratePawnName));
-            yield return AccessTools.Method(typeof(NameGenerator), nameof(NameGenerator.GenerateName), new[] { typeof(RulePackDef), typeof(Predicate<string>), typeof(bool), typeof(string), typeof(string), typeof(List<Rule>) });
+            yield return AccessTools.Method(typeof(NameGenerator), nameof(NameGenerator.GenerateName), [typeof(RulePackDef), typeof(Predicate<string>), typeof(bool), typeof(string), typeof(string), typeof(List<Rule>)]);
         }
 
         [HarmonyPriority(MpPriority.MpFirst)]
@@ -177,13 +185,13 @@ namespace Multiplayer.Client
     {
         static IEnumerable<MethodBase> TargetMethods()
         {
-            yield return AccessTools.Method(typeof(PawnRenderer), nameof(PawnRenderer.SetAllGraphicsDirty));
+            yield return MpMethodUtil.GetLambda(typeof(PawnRenderer), nameof(PawnRenderer.SetAllGraphicsDirty), 0);
         }
 
         [HarmonyPriority(MpPriority.MpFirst)]
         static void Prefix(PawnRenderer __instance, ref bool __state)
         {
-            Rand.PushState(__instance.pawn.thingIDNumber);
+            Rand.PushState(Gen.HashCombineInt(__instance.pawn.thingIDNumber, Find.World.ConstantRandSeed));
             __state = true;
         }
 


### PR DESCRIPTION
`AsyncWorldTimeComp` uses the world's ConstantRandomSeed rather than the constant value of 2. Using the world's ConstantRandomSeed should ensure a unique seed for each save (even if using the same seed).

`AsyncTimeComp` is no longer using the constant value of 1. It now uses the map's unique ID to ensure each map has a unique seed, combined with the world's ConstantRandomSeed to ensure a unique seed for each save file as well.

Several of the seeded methods in `Seeds.cs` now also use world's ConstantRandomSeed to make their RNG feel more unique. Some of those could use `Find.TickManager.TicksGame`, either together with or instead of world's ConstantRandomSeed - which would ensure a different outcome based on the passage of time in-game. However, this depends on whether of not we want this.

I've also updated the patch to `PawnRenderer.SetAllGraphicsDirty` to instead target the lambda the method is calling. Given that the lambda is called in a `LongEventHandler.ExecuteWhenFinished` block, the actual call to the lambda may end up being delayed and us seeding the method would do nothing. On top of that, given that pawn rendering is now using multithreading, if this method was called from a different thread - it could potentially cause some issues, since (I believe) RimWorld's RNG is not thread safe. I am unsure if this could happen, but it's better to be safe here.

Sadly, I haven't applied those changes to every single possible method where we're seeding RNG. `SeedGameLoad` is not really possible to safely seed without further changes. Since that this method is called when there's nothing loaded into the game we could use as our seed, the host would have to generate the seed themselves and share it with all the players when they are joining. Given the extra work, I've opted for leaving this as-is for now.

I've also left `RandPatches`, given that those weren't seeded in the first place.