### PR TITLE
Fix issues with PauseLockSession

### DIFF
--- a/Source/Client/Comp/World/MultiplayerWorldComp.cs
+++ b/Source/Client/Comp/World/MultiplayerWorldComp.cs
@@ -37,7 +37,7 @@ public class MultiplayerWorldComp : IHasSessionData
 
         sessionManager.ExposeSessions();
         // Ensure a pause lock session exists if there's any pause locks registered
-        if (!PauseLockSession.pauseLocks.NullOrEmpty())
+        if (Scribe.mode == LoadSaveMode.PostLoadInit && !PauseLockSession.pauseLocks.NullOrEmpty())
             sessionManager.AddSession(new PauseLockSession(null));
 
         DoBackCompat();


### PR DESCRIPTION
When there's any pause locks registered, the PauseLockSession ended up being added too early (or being created when it was unnecessary, like during saving), which caused the game to assign it a random ID.

The fix here is to only create the session during a `PostLoadInit`.