### PR TITLE
Fix SyncAction causing mods to load resources too early

### DIFF
--- a/Source/Client/Syncing/Handler/SyncAction.cs
+++ b/Source/Client/Syncing/Handler/SyncAction.cs
@@ -113,8 +113,18 @@ namespace Multiplayer.Client
 
                     postfix.priority = MpPriority.MpLast;
 
-                    Multiplayer.harmony.PatchMeasure(method, prefix, postfix);
-                    SyncActions.syncActions[method] = this;
+                    // Types with StaticConstructorOnStartup may be loading resources, which causes issues with
+                    // modded types. I assume that vanilla types end up loading their resources at some point earlier.
+                    if (method.DeclaringType?.Assembly != typeof(Game).Assembly && method.DeclaringType.HasAttribute<StaticConstructorOnStartup>())
+                        LongEventHandler.ExecuteWhenFinished(Patch);
+                    else
+                        Patch();
+
+                    void Patch()
+                    {
+                        Multiplayer.harmony.PatchMeasure(method, prefix, postfix);
+                        SyncActions.syncActions[method] = this;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Whenever we patch methods for `SyncAction`, it would cause any non-vanilla types to attempt to load their static data. This caused them to load resources like graphics, which failed and caused issues with those mods.

I've fixed it by delaying patching of any non-vanilla methods whose declaring types have `StaticConstructorOnStartup` attribute on them.

I've decided to let unaffected methods be patched early in case patching those early was by design due to anything I may be unaware of.

Currently, this should fix issues with Moving Bases from Vanilla Expanded Framework.