### PR TITLE
Fix ping always showing 0ms when connecting without using LiteNetLib

### DIFF
--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -158,13 +158,19 @@ namespace Multiplayer.Common
         {
             NetTimer++;
 
+            // We aim to tick 30 times a second, so this is once per second.
             if (NetTimer % 30 == 0)
                 playerManager.SendLatencies();
 
             if (NetTimer % 6 == 0)
-                foreach (var player in JoinedPlayers)
-                    player.SendPacket(Packets.Server_KeepAlive, ByteWriter.GetBytes(player.keepAliveId), false);
+            {
+                foreach (var player in JoinedPlayers) {
+                    player.SendKeepAlivePacket();
+                }
+            }
 
+            // Send to simulating players as well to update the simulation window for them and actually update further
+            // during the same simulation.
             SendToPlaying(Packets.Server_TimeControl, ByteWriter.GetBytes(gameTimer, sentCmdsSnapshot, serverTimePerTick), false);
 
             serverTimePerTick = PlayingIngamePlayers.MaxOrZero(p => p.frameTime);

--- a/Source/Common/ServerPlayer.cs
+++ b/Source/Common/ServerPlayer.cs
@@ -25,7 +25,7 @@ namespace Multiplayer.Common
         public int lastCursorTick = -1;
 
         public int keepAliveId;
-        public Stopwatch keepAliveTimer = Stopwatch.StartNew();
+        public Stopwatch keepAliveTimer = new();
         public int keepAliveAt;
 
         public bool frozen;
@@ -74,6 +74,15 @@ namespace Multiplayer.Common
         public void SendChat(string msg)
         {
             SendPacket(Packets.Server_Chat, new object[] { msg });
+        }
+
+        public void SendKeepAlivePacket()
+        {
+            if (!keepAliveTimer.IsRunning)
+            {
+                keepAliveTimer.Start();
+            }
+            SendPacket(Packets.Server_KeepAlive, ByteWriter.GetBytes(keepAliveId), false);
         }
 
         public void SendPacket(Packets packet, byte[] data, bool reliable = true)


### PR DESCRIPTION
The root of the issue is that the keepAliveTimer was only started once when creating the ServerPlayer and then always just `Reset()` which does not start it again. The timer was only ever started once and then reset while not having counted any time.

To test this remove ServerPlayingState:194 (if connection is LNL: return) and OnNetworkLatencyUpdate in NetworkingLiteNet (or just connect using Steam)

As a drive-by improvement I added some minor comments nearby.