### PR TITLE
Introduce Byte{Reader,Writer}.{Read,Write}Enum

### DIFF
--- a/Source/Client/Networking/JoinData.cs
+++ b/Source/Client/Networking/JoinData.cs
@@ -29,7 +29,7 @@ namespace Multiplayer.Client
                 data.WriteString(m.PackageIdNonUnique);
                 data.WriteString(m.Name);
                 data.WriteULong((ulong)m.GetPublishedFileId());
-                data.WriteByte((byte)m.Source);
+                data.WriteEnum(m.Source);
             }
 
             data.WriteInt32(modFilesSnapshot.Count());
@@ -74,7 +74,7 @@ namespace Multiplayer.Client
                 var packageId = data.ReadString();
                 var name = data.ReadString();
                 var steamId = data.ReadULong();
-                var source = (ContentSource)data.ReadByte();
+                var source = data.ReadEnum<ContentSource>();
 
                 remoteInfo.remoteMods.Add(new ModInfo() { packageId = packageId, name = name, steamId = steamId, source = source });
             }

--- a/Source/Client/Networking/NetworkingLiteNet.cs
+++ b/Source/Client/Networking/NetworkingLiteNet.cs
@@ -51,7 +51,7 @@ namespace Multiplayer.Client.Networking
             else
             {
                 var reader = new ByteReader(info.AdditionalData.GetRemainingBytes());
-                reason = (MpDisconnectReason)reader.ReadByte();
+                reason = reader.ReadEnum<MpDisconnectReason>();
                 data = reader.ReadPrefixedBytes();
             }
 

--- a/Source/Client/Networking/NetworkingSteam.cs
+++ b/Source/Client/Networking/NetworkingSteam.cs
@@ -66,7 +66,7 @@ namespace Multiplayer.Client.Networking
             if (msgId == (int)Packets.Special_Steam_Disconnect)
             {
                 Multiplayer.session.ProcessDisconnectPacket(
-                    (MpDisconnectReason)reader.ReadByte(),
+                    reader.ReadEnum<MpDisconnectReason>(),
                     reader.ReadPrefixedBytes()
                 );
                 OnDisconnect();

--- a/Source/Client/Networking/State/ClientJoiningState.cs
+++ b/Source/Client/Networking/State/ClientJoiningState.cs
@@ -63,8 +63,8 @@ namespace Multiplayer.Client
         {
             var writer = new ByteWriter();
 
-            writer.WriteInt32((int)MultiplayerData.modCtorRoundMode);
-            writer.WriteInt32((int)MultiplayerData.staticCtorRoundMode);
+            writer.WriteEnum(MultiplayerData.modCtorRoundMode);
+            writer.WriteEnum(MultiplayerData.staticCtorRoundMode);
             writer.WriteInt32(MultiplayerData.localDefInfos.Count);
 
             foreach (var kv in MultiplayerData.localDefInfos)
@@ -98,7 +98,7 @@ namespace Multiplayer.Client
 
             foreach (var local in MultiplayerData.localDefInfos)
             {
-                var status = (DefCheckStatus)defsData.ReadByte();
+                var status = defsData.ReadEnum<DefCheckStatus>();
                 local.Value.status = status;
 
                 if (status != DefCheckStatus.Ok)

--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -56,8 +56,7 @@ namespace Multiplayer.Client
         [PacketHandler(Packets.Server_PlayerList)]
         public void HandlePlayerList(ByteReader data)
         {
-            var action = (PlayerListAction)data.ReadByte();
-
+            var action = data.ReadEnum<PlayerListAction>();
             if (action == PlayerListAction.Add)
             {
                 var info = PlayerInfo.Read(data);
@@ -93,7 +92,7 @@ namespace Multiplayer.Client
             else if (action == PlayerListAction.Status)
             {
                 var id = data.ReadInt32();
-                var status = (PlayerStatus)data.ReadByte();
+                var status = data.ReadEnum<PlayerStatus>();
                 var player = Multiplayer.session.GetPlayerInfo(id);
 
                 if (player != null)

--- a/Source/Client/Session/MultiplayerSession.cs
+++ b/Source/Client/Session/MultiplayerSession.cs
@@ -140,7 +140,7 @@ namespace Multiplayer.Client
 
             if (reason == MpDisconnectReason.ConnectingFailed)
             {
-                var netReason = (DisconnectReason)reader.ReadByte();
+                var netReason = reader.ReadEnum<DisconnectReason>();
 
                 disconnectInfo.titleTranslated =
                     netReason == DisconnectReason.ConnectionFailed ?
@@ -150,7 +150,7 @@ namespace Multiplayer.Client
 
             if (reason == MpDisconnectReason.NetFailed)
             {
-                var netReason = (DisconnectReason)reader.ReadByte();
+                var netReason = reader.ReadEnum<DisconnectReason>();
 
                 disconnectInfo.titleTranslated =
                     "MpDisconnectedWithInfo".Translate(netReason.ToString().CamelSpace().ToLowerInvariant());

--- a/Source/Client/Session/PlayerInfo.cs
+++ b/Source/Client/Session/PlayerInfo.cs
@@ -65,8 +65,8 @@ public class PlayerInfo : IPlayerInfo
         int id = data.ReadInt32();
         string username = data.ReadString();
         int latency = data.ReadInt32();
-        var type = (PlayerType)data.ReadByte();
-        var status = (PlayerStatus)data.ReadByte();
+        var type = data.ReadEnum<PlayerType>();
+        var status = data.ReadEnum<PlayerStatus>();
 
         var steamId = data.ReadULong();
         var steamName = data.ReadString();

--- a/Source/Client/Util/Extensions.cs
+++ b/Source/Client/Util/Extensions.cs
@@ -84,7 +84,7 @@ namespace Multiplayer.Client
         public static void SendCommand(this ConnectionBase conn, CommandType type, int mapId, byte[] data)
         {
             ByteWriter writer = new ByteWriter();
-            writer.WriteInt32(Convert.ToInt32(type));
+            writer.WriteEnum(type);
             writer.WriteInt32(mapId);
             writer.WritePrefixedBytes(data);
 

--- a/Source/Common/ByteReader.cs
+++ b/Source/Common/ByteReader.cs
@@ -140,7 +140,7 @@ namespace Multiplayer.Common
 
         public virtual T ReadEnum<T>() where T : Enum
         {
-            var values = EnumCache.GetValues(typeof(T));
+            var values = EnumCache<T>.Values;
             ushort enumIndex = values.Length switch
             {
                 <= byte.MaxValue => ReadByte(),

--- a/Source/Common/ByteReader.cs
+++ b/Source/Common/ByteReader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using Multiplayer.Common.Util;
 
 namespace Multiplayer.Common
 {
@@ -139,7 +140,7 @@ namespace Multiplayer.Common
 
         public virtual T ReadEnum<T>() where T : Enum
         {
-            var values = Enum.GetValues(typeof(T));
+            var values = EnumCache.GetValues(typeof(T));
             ushort enumIndex = values.Length switch
             {
                 <= byte.MaxValue => ReadByte(),

--- a/Source/Common/ByteReader.cs
+++ b/Source/Common/ByteReader.cs
@@ -137,6 +137,18 @@ namespace Multiplayer.Common
             return result;
         }
 
+        public virtual T ReadEnum<T>() where T : Enum
+        {
+            var values = Enum.GetValues(typeof(T));
+            ushort enumIndex = values.Length switch
+            {
+                <= byte.MaxValue => ReadByte(),
+                <= ushort.MaxValue => ReadUShort(),
+                _ => throw new Exception($"Enum {typeof(T).FullName} has more than {ushort.MaxValue} values!")
+            };
+            return (T)values.GetValue(enumIndex);
+        }
+
         private int IncrementIndex(int size)
         {
             int i = index;

--- a/Source/Common/ByteWriter.cs
+++ b/Source/Common/ByteWriter.cs
@@ -83,6 +83,22 @@ namespace Multiplayer.Common
             return this;
         }
 
+        public virtual void WriteEnum<T>(T value) where T : Enum
+        {
+            var values = Enum.GetValues(value.GetType());
+            var index = Array.IndexOf(values, value);
+            switch (values.Length)
+            {
+                case <= byte.MaxValue:
+                    WriteByte((byte)index);
+                    break;
+                case <= ushort.MaxValue:
+                    WriteUShort((ushort)index);
+                    break;
+                default:
+                    throw new Exception($"Enum {value.GetType().FullName} has more than {ushort.MaxValue} values!");
+            }
+        }
         private void Write(object obj)
         {
             if (obj is int @int)
@@ -125,9 +141,9 @@ namespace Multiplayer.Common
             {
                 WritePrefixedBytes(bytes);
             }
-            else if (obj is Enum)
+            else if (obj is Enum enumObj)
             {
-                Write(Convert.ToInt32(obj));
+                WriteEnum(enumObj);
             }
             else if (obj is string @string)
             {

--- a/Source/Common/ByteWriter.cs
+++ b/Source/Common/ByteWriter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Multiplayer.Common.Util;
 
 namespace Multiplayer.Common
 {
@@ -85,7 +86,7 @@ namespace Multiplayer.Common
 
         public virtual void WriteEnum<T>(T value) where T : Enum
         {
-            var values = Enum.GetValues(value.GetType());
+            var values = EnumCache.GetValues(value.GetType());
             var index = Array.IndexOf(values, value);
             switch (values.Length)
             {

--- a/Source/Common/ByteWriter.cs
+++ b/Source/Common/ByteWriter.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Multiplayer.Common.Util;
+using Verse;
 
 namespace Multiplayer.Common
 {
@@ -86,7 +87,7 @@ namespace Multiplayer.Common
 
         public virtual void WriteEnum<T>(T value) where T : Enum
         {
-            var values = EnumCache.GetValues(value.GetType());
+            var values = typeof(T) == typeof(Enum) ? EnumCache.Values(value.GetType()) : EnumCache<T>.Values;
             var index = Array.IndexOf(values, value);
             switch (values.Length)
             {

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -172,7 +172,7 @@ namespace Multiplayer.Common
         public static byte[] GetDisconnectBytes(MpDisconnectReason reason, byte[]? data = null)
         {
             var writer = new ByteWriter();
-            writer.WriteByte((byte)reason);
+            writer.WriteEnum(reason);
             writer.WritePrefixedBytes(data ?? Array.Empty<byte>());
             return writer.ToArray();
         }

--- a/Source/Common/Networking/State/ServerJoiningState.cs
+++ b/Source/Common/Networking/State/ServerJoiningState.cs
@@ -105,8 +105,8 @@ public class ServerJoiningState : AsyncConnectionState
 
     private bool HandleClientJoinData(ByteReader data)
     {
-        var modCtorRoundMode = (RoundModeEnum)data.ReadInt32();
-        var staticCtorRoundMode = (RoundModeEnum)data.ReadInt32();
+        var modCtorRoundMode = data.ReadEnum<RoundModeEnum>();
+        var staticCtorRoundMode = data.ReadEnum<RoundModeEnum>();
 
         if ((modCtorRoundMode, staticCtorRoundMode) != Server.initData!.RoundModes)
         {
@@ -142,7 +142,7 @@ public class ServerJoiningState : AsyncConnectionState
             if (status != DefCheckStatus.Ok)
                 defsMatch = false;
 
-            defsResponse.WriteByte((byte)status);
+            defsResponse.WriteEnum(status);
         }
 
         connection.SendFragmented(

--- a/Source/Common/Networking/State/ServerPlayingState.cs
+++ b/Source/Common/Networking/State/ServerPlayingState.cs
@@ -49,7 +49,7 @@ namespace Multiplayer.Common
         [PacketHandler(Packets.Client_Command)]
         public void HandleClientCommand(ByteReader data)
         {
-            CommandType cmd = (CommandType)data.ReadInt32();
+            CommandType cmd = data.ReadEnum<CommandType>();
             int mapId = data.ReadInt32();
             byte[]? extra = data.ReadPrefixedBytes(65535);
             if (extra == null) return;

--- a/Source/Common/PlayerManager.cs
+++ b/Source/Common/PlayerManager.cs
@@ -25,7 +25,7 @@ namespace Multiplayer.Common
         public void SendLatencies()
         {
             var writer = new ByteWriter();
-            writer.WriteByte((byte)PlayerListAction.Latencies);
+            writer.WriteEnum(PlayerListAction.Latencies);
 
             writer.WriteInt32(JoinedPlayers.Count());
             foreach (var player in JoinedPlayers)
@@ -91,7 +91,7 @@ namespace Multiplayer.Common
                 server.SendNotification("MpPlayerDisconnected", conn.username);
                 server.SendChat($"{conn.username} has left.");
 
-                server.SendToPlaying(Packets.Server_PlayerList, new object[] { (byte)PlayerListAction.Remove, player.id });
+                server.SendToPlaying(Packets.Server_PlayerList, new object[] { PlayerListAction.Remove, player.id });
 
                 player.ResetTimeVotes();
             }
@@ -146,7 +146,7 @@ namespace Multiplayer.Common
             }
 
             var writer = new ByteWriter();
-            writer.WriteByte((byte)PlayerListAction.Add);
+            writer.WriteEnum(PlayerListAction.Add);
             writer.WriteRaw(player.SerializePlayerInfo());
 
             server.SendToPlaying(Packets.Server_PlayerList, writer.ToArray());

--- a/Source/Common/ScheduledCommand.cs
+++ b/Source/Common/ScheduledCommand.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Multiplayer.Common
 {
@@ -32,7 +31,8 @@ namespace Multiplayer.Common
         public static byte[] Serialize(ScheduledCommand cmd)
         {
             ByteWriter writer = new ByteWriter();
-            writer.WriteEnum(cmd.type);
+            // Use WriteByte directly instead of WriteEnum for better performance, as this is frequently used.
+            writer.WriteByte((byte)cmd.type);
             writer.WriteInt32(cmd.ticks);
             writer.WriteInt32(cmd.factionId);
             writer.WriteInt32(cmd.mapId);
@@ -44,7 +44,8 @@ namespace Multiplayer.Common
 
         public static ScheduledCommand Deserialize(ByteReader data)
         {
-            CommandType cmd = data.ReadEnum<CommandType>();
+            // Use ReadByte directly instead of ReadEnum for better performance, as this is frequently used.
+            CommandType cmd = (CommandType)data.ReadByte();
             int ticks = data.ReadInt32();
             int factionId = data.ReadInt32();
             int mapId = data.ReadInt32();

--- a/Source/Common/ScheduledCommand.cs
+++ b/Source/Common/ScheduledCommand.cs
@@ -32,7 +32,7 @@ namespace Multiplayer.Common
         public static byte[] Serialize(ScheduledCommand cmd)
         {
             ByteWriter writer = new ByteWriter();
-            writer.WriteInt32(Convert.ToInt32(cmd.type));
+            writer.WriteEnum(cmd.type);
             writer.WriteInt32(cmd.ticks);
             writer.WriteInt32(cmd.factionId);
             writer.WriteInt32(cmd.mapId);
@@ -44,7 +44,7 @@ namespace Multiplayer.Common
 
         public static ScheduledCommand Deserialize(ByteReader data)
         {
-            CommandType cmd = (CommandType)data.ReadInt32();
+            CommandType cmd = data.ReadEnum<CommandType>();
             int ticks = data.ReadInt32();
             int factionId = data.ReadInt32();
             int mapId = data.ReadInt32();

--- a/Source/Common/ServerInitData.cs
+++ b/Source/Common/ServerInitData.cs
@@ -32,7 +32,7 @@ public record ServerInitData(
             data.ReadString(),
             data.ReadPrefixedInts().ToHashSet(),
             data.ReadPrefixedInts().ToHashSet(),
-            ((RoundModeEnum)data.ReadInt32(), (RoundModeEnum)data.ReadInt32()),
+            (data.ReadEnum<RoundModeEnum>(), data.ReadEnum<RoundModeEnum>()),
             new Dictionary<string, DefInfo>()
         );
 

--- a/Source/Common/ServerPlayer.cs
+++ b/Source/Common/ServerPlayer.cs
@@ -90,7 +90,7 @@ namespace Multiplayer.Common
         {
             var writer = new ByteWriter();
 
-            writer.WriteByte((byte)PlayerListAction.List);
+            writer.WriteEnum(PlayerListAction.List);
             writer.WriteInt32(Server.JoinedPlayers.Count());
 
             foreach (var player in Server.JoinedPlayers)
@@ -106,8 +106,8 @@ namespace Multiplayer.Common
             writer.WriteInt32(id);
             writer.WriteString(Username);
             writer.WriteInt32(Latency);
-            writer.WriteByte((byte)type);
-            writer.WriteByte((byte)status);
+            writer.WriteEnum(type);
+            writer.WriteEnum(status);
             writer.WriteULong(steamId);
             writer.WriteString(steamPersonaName);
             writer.WriteInt32(ticksBehind);
@@ -132,7 +132,7 @@ namespace Multiplayer.Common
         {
             if (status == newStatus) return;
             status = newStatus;
-            Server.SendToPlaying(Packets.Server_PlayerList, new object[] { (byte)PlayerListAction.Status, id, (byte)newStatus });
+            Server.SendToPlaying(Packets.Server_PlayerList, new object[] { PlayerListAction.Status, id, newStatus });
         }
 
         public void ResetTimeVotes()

--- a/Source/Common/Syncing/Logger/LoggingByteReader.cs
+++ b/Source/Common/Syncing/Logger/LoggingByteReader.cs
@@ -83,6 +83,11 @@ namespace Multiplayer.Client
             Log.Node($"byte[{array?.Length}]");
             return array;
         }
+
+        public override T ReadEnum<T>()
+        {
+            return Log.NodePassthrough($"enum {typeof(T).FullName}: ", base.ReadEnum<T>());
+        }
     }
 
 }

--- a/Source/Common/Syncing/Logger/LoggingByteWriter.cs
+++ b/Source/Common/Syncing/Logger/LoggingByteWriter.cs
@@ -62,6 +62,13 @@ namespace Multiplayer.Client
 			Log.Exit();
 			return this;
 		}
+
+        public override void WriteEnum<T>(T value)
+        {
+            Log.Enter($"enum {value.GetType().FullName}: {value}");
+            base.WriteEnum(value);
+            Log.Exit();
+        }
     }
 
 }

--- a/Source/Common/Util/EnumCache.cs
+++ b/Source/Common/Util/EnumCache.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Multiplayer.Common.Util;
+
+internal static class EnumCache
+{
+    private static readonly ConcurrentDictionary<Type, Array> Cache = new();
+
+    public static Array GetValues(Type enumType) => Cache.GetOrAdd(enumType, Enum.GetValues);
+}

--- a/Source/Common/Util/EnumCache.cs
+++ b/Source/Common/Util/EnumCache.cs
@@ -1,11 +1,17 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Linq;
 
 namespace Multiplayer.Common.Util;
+
+internal static class EnumCache<T> where T: Enum
+{
+    public static readonly T[] Values = Enum.GetValues(typeof(T)).Cast<T>().ToArray();
+}
 
 internal static class EnumCache
 {
     private static readonly ConcurrentDictionary<Type, Array> Cache = new();
 
-    public static Array GetValues(Type enumType) => Cache.GetOrAdd(enumType, Enum.GetValues);
+    public static Array Values(Type enumType) => Cache.GetOrAdd(enumType, Enum.GetValues);
 }

--- a/Source/Common/Version.cs
+++ b/Source/Common/Version.cs
@@ -3,7 +3,7 @@ namespace Multiplayer.Common
     public static class MpVersion
     {
         public const string Version = "0.10.5";
-        public const int Protocol = 47;
+        public const int Protocol = 48;
 
         public const string ApiAssemblyName = "0MultiplayerAPI";
 


### PR DESCRIPTION
This makes the code clearer, it's more convenient than casting to number-types, and is smaller on the wire (as some enums were needlessly sent as an int).