### PR TITLE
Encapsulate MpConnectionState.packetHandlers via GetPacketHandler

### DIFF
--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -128,7 +128,7 @@ namespace Multiplayer.Common
             Packets packetType = (Packets)msgId;
             ServerLog.Verbose($"Received packet {this}: {packetType}");
 
-            var handler = StateObj?.GetPacketHandler(packetType) ?? MpConnectionState.packetHandlers[(int)State, (int)packetType];
+            var handler = StateObj?.GetPacketHandler(packetType);
             if (handler == null)
             {
                 if (reliable && !Lenient)


### PR DESCRIPTION
The packetHandlers field does not need to be publicly accessible. This change encapsulates it and utilizes the existing GetPacketHandler method to provide controlled access.