### PR TITLE
Integrate IsFragmented into PacketHandler

### DIFF
--- a/Source/Client/Networking/State/ClientJoiningState.cs
+++ b/Source/Client/Networking/State/ClientJoiningState.cs
@@ -77,8 +77,7 @@ namespace Multiplayer.Client
             connection.SendFragmented(Packets.Client_JoinData, writer.ToArray());
         }
 
-        [PacketHandler(Packets.Server_JoinData)]
-        [IsFragmented]
+        [PacketHandler(Packets.Server_JoinData, allowFragmented: true)]
         public void HandleJoinData(ByteReader data)
         {
             Multiplayer.session.gameName = data.ReadString();

--- a/Source/Client/Networking/State/ClientLoadingState.cs
+++ b/Source/Client/Networking/State/ClientLoadingState.cs
@@ -28,8 +28,7 @@ public class ClientLoadingState : ClientBaseState
         connection.Lenient = false; // Lenient is set while rejoining
     }
 
-    [PacketHandler(Packets.Server_WorldData)]
-    [IsFragmented]
+    [PacketHandler(Packets.Server_WorldData, allowFragmented: true)]
     public void HandleWorldData(ByteReader data)
     {
         Log.Message("Game data size: " + data.Length);

--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -208,8 +208,7 @@ namespace Multiplayer.Client
             Messages.Message(key.Translate(Array.ConvertAll(args, s => (NamedArgument)s)), MessageTypeDefOf.SilentInput, false);
         }
 
-        [PacketHandler(Packets.Server_SyncInfo)]
-        [IsFragmented]
+        [PacketHandler(Packets.Server_SyncInfo, allowFragmented: true)]
         public void HandleDesyncCheck(ByteReader data)
         {
             Multiplayer.game?.sync.AddClientOpinionAndCheckDesync(ClientSyncOpinion.Deserialize(data));
@@ -225,8 +224,7 @@ namespace Multiplayer.Client
             TickPatch.frozenAt = frozenAt;
         }
 
-        [PacketHandler(Packets.Server_Traces)]
-        [IsFragmented]
+        [PacketHandler(Packets.Server_Traces, allowFragmented: true)]
         public void HandleTraces(ByteReader data)
         {
             var type = (TracesPacket)data.ReadInt32();

--- a/Source/Common/Networking/MpConnectionState.cs
+++ b/Source/Common/Networking/MpConnectionState.cs
@@ -48,12 +48,11 @@ namespace Multiplayer.Common
                 if (method.GetParameters().Length != 1 || method.GetParameters()[0].ParameterType != typeof(ByteReader))
                     throw new Exception($"Bad packet handler signature for {method}");
 
-                bool fragment = method.GetAttribute<IsFragmentedAttribute>() != null;
-
                 if (packetHandlers[(int)state, (int)attr.packet] != null)
                     throw new Exception($"Packet {state}:{type} already has a handler");
 
-                packetHandlers[(int)state, (int)attr.packet] = new PacketHandlerInfo(MethodInvoker.GetHandler(method), fragment);
+                packetHandlers[(int)state, (int)attr.packet] =
+                    new PacketHandlerInfo(MethodInvoker.GetHandler(method), attr.allowFragmented);
             }
         }
     }

--- a/Source/Common/Networking/PacketHandlerAttribute.cs
+++ b/Source/Common/Networking/PacketHandlerAttribute.cs
@@ -5,18 +5,10 @@ using JetBrains.Annotations;
 namespace Multiplayer.Common
 {
     [MeansImplicitUse]
-    public class PacketHandlerAttribute : Attribute
+    public class PacketHandlerAttribute(Packets packet, bool allowFragmented = false) : Attribute
     {
-        public readonly Packets packet;
-
-        public PacketHandlerAttribute(Packets packet)
-        {
-            this.packet = packet;
-        }
-    }
-
-    public class IsFragmentedAttribute : Attribute
-    {
+        public readonly Packets packet = packet;
+        public readonly bool allowFragmented = allowFragmented;
     }
 
     public record PacketHandlerInfo(FastInvokeHandler Method, bool Fragment);

--- a/Source/Common/Networking/State/ServerPlayingState.cs
+++ b/Source/Common/Networking/State/ServerPlayingState.cs
@@ -32,8 +32,7 @@ namespace Multiplayer.Common
             Server.playerManager.OnDesync(Player, tick, diffAt);
         }
 
-        [PacketHandler(Packets.Client_Traces)]
-        [IsFragmented]
+        [PacketHandler(Packets.Client_Traces, allowFragmented: true)]
         public void HandleTraces(ByteReader data)
         {
             var type = (TracesPacket)data.ReadInt32();
@@ -81,8 +80,7 @@ namespace Multiplayer.Common
             }
         }
 
-        [PacketHandler(Packets.Client_WorldDataUpload)]
-        [IsFragmented]
+        [PacketHandler(Packets.Client_WorldDataUpload, allowFragmented: true)]
         public void HandleWorldDataUpload(ByteReader data)
         {
             if (Server.ArbiterPlaying ? !Player.IsArbiter : !Player.IsHost) // policy
@@ -204,8 +202,7 @@ namespace Multiplayer.Common
             }
         }
 
-        [PacketHandler(Packets.Client_SyncInfo)]
-        [IsFragmented]
+        [PacketHandler(Packets.Client_SyncInfo, allowFragmented: true)]
         public void HandleDesyncCheck(ByteReader data)
         {
             var arbiter = Server.ArbiterPlaying;


### PR DESCRIPTION
`IsFragmented` doesn't mean anything on its own, i.e. it's almost certainly a mistake to use it without an accompanying `PacketHandler` attribute. It makes more sense to just add it as a field to `PacketHandler`.