### PR TITLE
`SyncField` buffering: expanded docs, simplified code flow, and improved UX

### DIFF
--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -152,7 +152,7 @@ namespace Multiplayer.Client
                 nameof(Bill_Production.targetCount),
                 nameof(Bill_Production.pauseWhenSatisfied),
                 nameof(Bill_Production.unpauseWhenYouHave)
-            );
+            ).SetBufferChanges();
 
             SyncBillIncludeCriteria = Sync.Fields(
                 typeof(Bill_Production),

--- a/Source/Client/Syncing/Handler/SyncField.cs
+++ b/Source/Client/Syncing/Handler/SyncField.cs
@@ -141,21 +141,16 @@ namespace Multiplayer.Client
             return this;
         }
 
-        /// Throttles network updates for this field to reduce network chatter. An update
-        /// is sent immediately unless another was already sent within the last 200ms. If
-        /// additional updates occur during that cooldown period, they are not sent
-        /// immediately; only the most recent update is queued and will be sent once the
-        /// 200ms interval has passed. All intermediate updates are discarded.
+        /// Throttles network updates for this field to reduce network chatter.
+        /// An update is sent only after the field has remained unchanged for 200ms.
+        /// If changes continue occurring within that window, the timer resets, and only
+        /// the latest value is eventually sent. All intermediate updates are discarded.
         ///
-        /// The UI reflects the latest value instantly, without waiting for server
-        /// confirmation — avoiding rollback, and re-apply behavior when the server
-        /// responds. However, in some cases the UI may briefly display stale information:
-        /// this can occur when the client sends an update to the host, which then sends a
-        /// confirmation back that overwrites the current client-side value, potentially
-        /// during an ongoing user interaction.
+        /// The UI reflects the latest value immediately, without waiting for server
+        /// confirmation — avoiding rollback, and reapply behavior on server response.
         ///
-        /// This mechanism is typically used for rapidly changing values (e.g., sliders),
-        /// where sending every intermediate update would be inefficient and unnecessary.
+        /// Ideal for rapidly changing fields (e.g., sliders) where sending every
+        /// intermediate value would be inefficient and unnecessary.
         public ISyncField SetBufferChanges()
         {
             SyncFieldUtil.bufferedChanges[this] = new();

--- a/Source/Client/Syncing/Handler/SyncField.cs
+++ b/Source/Client/Syncing/Handler/SyncField.cs
@@ -141,6 +141,21 @@ namespace Multiplayer.Client
             return this;
         }
 
+        /// Throttles network updates for this field to reduce network chatter. An update
+        /// is sent immediately unless another was already sent within the last 200ms. If
+        /// additional updates occur during that cooldown period, they are not sent
+        /// immediately; only the most recent update is queued and will be sent once the
+        /// 200ms interval has passed. All intermediate updates are discarded.
+        ///
+        /// The UI reflects the latest value instantly, without waiting for server
+        /// confirmation — avoiding rollback, and re-apply behavior when the server
+        /// responds. However, in some cases the UI may briefly display stale information:
+        /// this can occur when the client sends an update to the host, which then sends a
+        /// confirmation back that overwrites the current client-side value, potentially
+        /// during an ongoing user interaction.
+        ///
+        /// This mechanism is typically used for rapidly changing values (e.g., sliders),
+        /// where sending every intermediate update would be inefficient and unnecessary.
         public ISyncField SetBufferChanges()
         {
             SyncFieldUtil.bufferedChanges[this] = new();

--- a/Source/Client/Syncing/Handler/SyncField.cs
+++ b/Source/Client/Syncing/Handler/SyncField.cs
@@ -159,7 +159,6 @@ namespace Multiplayer.Client
         public ISyncField SetBufferChanges()
         {
             SyncFieldUtil.bufferedChanges[this] = new();
-            Sync.bufferedFields.Add(this);
             bufferChanges = true;
             return this;
         }

--- a/Source/Client/Syncing/Sync.cs
+++ b/Source/Client/Syncing/Sync.cs
@@ -13,7 +13,6 @@ namespace Multiplayer.Client
     public static class Sync
     {
         public static List<SyncHandler> handlers = new();
-        public static List<SyncField> bufferedFields = new();
 
         // Internal maps for Harmony patches
         public static Dictionary<MethodBase, int> methodBaseToInternalId = new();

--- a/Source/Client/Syncing/SyncFieldUtil.cs
+++ b/Source/Client/Syncing/SyncFieldUtil.cs
@@ -181,6 +181,10 @@ namespace Multiplayer.Client
     {
         public readonly SyncField handler;
         public readonly object target;
+        /// Reflects the value the field had before the most recent GUI update.
+        /// For unbuffered fields, this is also the current simulation value.
+        /// For buffered fields, which may modify the field across multiple `Watch` calls,
+        /// this represents the value at the start of the latest `Watch` invocation.
         public readonly object oldValue;
         public readonly object index;
 
@@ -218,6 +222,9 @@ namespace Multiplayer.Client
     public class BufferData
     {
         public SyncField field;
+        /// This is the real field's value. If this were an unbuffered field, it'd be equivalent to `FieldData.oldValue`,
+        /// however for buffered fields `oldValue` reflects the value prior to the last GUI update. Use this field to
+        /// access the original value before any user interaction occurred.
         public object actualValue;
         public object toSend;
         public long timestamp;

--- a/Source/Client/Syncing/SyncFieldUtil.cs
+++ b/Source/Client/Syncing/SyncFieldUtil.cs
@@ -28,45 +28,54 @@ namespace Multiplayer.Client
         {
             if (Multiplayer.Client == null) return;
 
-            while (watchedStack.Count > 0)
+            // Iterate until we hit the marker (`null`).
+            while (watchedStack.TryPop(out var dataOrNull) && dataOrNull is { } data)
             {
-                var dataOrNull = watchedStack.Pop();
-
-                if (dataOrNull is not { } data)
-                    break; // The marker
-
                 SyncField handler = data.handler;
-
                 object newValue = MpReflection.GetValue(data.target, handler.memberPath, data.index);
                 bool changed = !ValuesEqual(handler, newValue, data.oldValue);
                 var cache =
-                    handler.bufferChanges && !Multiplayer.IsReplay && !Multiplayer.GhostMode ?
-                        bufferedChanges.GetValueSafe(handler) :
-                        null;
+                    handler.bufferChanges && !Multiplayer.IsReplay && !Multiplayer.GhostMode
+                        ? bufferedChanges.GetValueSafe(handler)
+                        : null;
+                var bufferTarget = new BufferTarget(data.target, data.index);
+                var cachedData = cache?.GetValueSafe(bufferTarget);
 
-                if (cache != null && cache.TryGetValue(new(data.target, data.index), out BufferData cached))
+                // Revert the local field's value for simulation purposes.
+                // For unbuffered fields, this rollback is only necessary if the value actually changed.
+                // For buffered fields, however, we always perform the restore, since the value is overwritten
+                // whenever watching it begins — assuming the value was previously changed and thus the buffer was
+                // initialized.
+                // If any change has happened, we record it and either send it immediately (unbuffered field) or queue
+                // it (buffered field). The server will eventually acknowledge the change and send it back, at which
+                // point the field is updated.
+                if (changed || cachedData != null)
                 {
-                    if (changed && cached.sent)
-                        cached.sent = false;
+                    var simulationValue = cachedData?.actualValue ?? data.oldValue;
+                    MpReflection.SetValue(data.target, handler.memberPath, simulationValue, data.index);
+                }
 
-                    cached.toSend = SnapshotValueIfNeeded(handler, newValue);
-                    MpReflection.SetValue(data.target, handler.memberPath, cached.actualValue, data.index);
+                // No changes happened means no syncing needed either - we are done.
+                if (!changed)
+                    continue;
+
+                // For unbuffered fields, just immediately sync any changes.
+                if (cache == null)
+                {
+                    handler.DoSyncCatch(data.target, newValue, data.index);
                     continue;
                 }
 
-                if (!changed) continue;
-
-                if (cache != null)
+                // For buffered fields, update the value to be sent.
+                if (cachedData != null)
                 {
-                    BufferData bufferData = new BufferData(handler, data.oldValue, SnapshotValueIfNeeded(handler, newValue));
-                    cache[new(data.target, data.index)] = bufferData;
-                }
-                else
-                {
-                    handler.DoSyncCatch(data.target, newValue, data.index);
+                    cachedData.sent = false;
+                    cachedData.toSend = SnapshotValueIfNeeded(handler, newValue);
+                    continue;
                 }
 
-                MpReflection.SetValue(data.target, handler.memberPath, data.oldValue, data.index);
+                // The field is buffered but had no prior changes; initialize the cache entry now that a change has occurred.
+                cache[bufferTarget] = new BufferData(handler, data.oldValue, SnapshotValueIfNeeded(handler, newValue));
             }
         }
 

--- a/Source/Client/Syncing/SyncFieldUtil.cs
+++ b/Source/Client/Syncing/SyncFieldUtil.cs
@@ -70,52 +70,51 @@ namespace Multiplayer.Client
             watchedStack.Push(new FieldData(field, target, value, index));
         }
 
-        public static Func<BufferTarget, BufferData, bool> BufferedChangesPruner(Func<long> timeGetter)
+        private static bool SyncPendingAndPruneFinished(BufferTarget target, BufferData data)
         {
-            return (target, data) =>
+            if (data.IsAlreadySynced(target))
+                return true;
+
+            var millisNow = Utils.MillisNow;
+            if (!data.sent && millisNow - data.timestamp > 200)
             {
-                if (CheckShouldRemove(data.field, target, data))
+                // If syncing fails with an exception don't try to reattempt and just give up.
+                if (data.field.DoSyncCatch(target.target, data.toSend, target.index) is false)
                     return true;
 
-                if (!data.sent && timeGetter() - data.timestamp > 200)
-                {
-                    if (data.field.DoSyncCatch(target.target, data.toSend, target.index) is false)
-                        return true;
+                data.sent = true;
+                data.timestamp = millisNow;
+            }
 
-                    data.sent = true;
-                    data.timestamp = timeGetter();
-                }
-
-                return false;
-            };
+            return false;
         }
-
-        private static Func<BufferTarget, BufferData, bool> bufferPredicate =
-            BufferedChangesPruner(() => Utils.MillisNow);
 
         public static void UpdateSync()
         {
             foreach (var (field, fieldBufferedChanges) in bufferedChanges)
             {
                 if (field.inGameLoop) continue;
-                fieldBufferedChanges.RemoveAll(bufferPredicate);
+                fieldBufferedChanges.RemoveAll(SyncPendingAndPruneFinished);
             }
         }
 
-        public static bool CheckShouldRemove(SyncField field, BufferTarget target, BufferData data)
+        private static bool IsAlreadySynced(this BufferData data, BufferTarget target)
         {
-            if (data.sent && ValuesEqual(field, data.toSend, data.actualValue))
-                return true;
+            var field = data.field;
+            if (data.sent && ValuesEqual(field, data.toSend, data.actualValue)) return true;
 
             object currentValue = target.target.GetPropertyOrField(field.memberPath, target.index);
 
-            if (!ValuesEqual(field, currentValue, data.actualValue))
-            {
-                if (data.sent)
-                    return true;
-                data.actualValue = SnapshotValueIfNeeded(field, currentValue);
-            }
+            // Data hasn't been sent yet, or we are waiting for the server to acknowledge it and send it back.
+            if (ValuesEqual(field, currentValue, data.actualValue)) return false;
 
+            // The last seen value differs from the current field value — likely because a sync command from the server
+            // has overwritten it (possibly even with the desired value). If we've already sent our update, we assume it's fine;
+            // once the server processes it, it will likely acknowledge and send back the update via another sync command,
+            // restoring the field to the intended value.
+            if (data.sent) return true;
+
+            data.actualValue = SnapshotValueIfNeeded(field, currentValue);
             return false;
         }
 

--- a/Source/Client/Syncing/SyncFieldUtil.cs
+++ b/Source/Client/Syncing/SyncFieldUtil.cs
@@ -95,10 +95,10 @@ namespace Multiplayer.Client
 
         public static void UpdateSync()
         {
-            foreach (SyncField f in Sync.bufferedFields)
+            foreach (var (field, fieldBufferedChanges) in bufferedChanges)
             {
-                if (f.inGameLoop) continue;
-                bufferedChanges[f].RemoveAll(bufferPredicate);
+                if (field.inGameLoop) continue;
+                fieldBufferedChanges.RemoveAll(bufferPredicate);
             }
         }
 

--- a/Source/Client/Syncing/SyncFieldUtil.cs
+++ b/Source/Client/Syncing/SyncFieldUtil.cs
@@ -12,6 +12,11 @@ namespace Multiplayer.Client
         public static Dictionary<SyncField, Dictionary<BufferTarget, BufferData>> bufferedChanges = new();
         private static Stack<FieldData?> watchedStack = new();
 
+        public static void StackPush(SyncField field, object target, object value, object index)
+        {
+            watchedStack.Push(new FieldData(field, target, value, index));
+        }
+
         public static void FieldWatchPrefix()
         {
             if (Multiplayer.Client == null) return;
@@ -65,9 +70,13 @@ namespace Multiplayer.Client
             }
         }
 
-        public static void StackPush(SyncField field, object target, object value, object index)
+        public static void UpdateSync()
         {
-            watchedStack.Push(new FieldData(field, target, value, index));
+            foreach (var (field, fieldBufferedChanges) in bufferedChanges)
+            {
+                if (field.inGameLoop) continue;
+                fieldBufferedChanges.RemoveAll(SyncPendingAndPruneFinished);
+            }
         }
 
         private static bool SyncPendingAndPruneFinished(BufferTarget target, BufferData data)
@@ -87,15 +96,6 @@ namespace Multiplayer.Client
             }
 
             return false;
-        }
-
-        public static void UpdateSync()
-        {
-            foreach (var (field, fieldBufferedChanges) in bufferedChanges)
-            {
-                if (field.inGameLoop) continue;
-                fieldBufferedChanges.RemoveAll(SyncPendingAndPruneFinished);
-            }
         }
 
         private static bool IsAlreadySynced(this BufferData data, BufferTarget target)

--- a/Source/Client/Syncing/SyncFieldUtil.cs
+++ b/Source/Client/Syncing/SyncFieldUtil.cs
@@ -70,6 +70,7 @@ namespace Multiplayer.Client
                 if (cachedData != null)
                 {
                     cachedData.sent = false;
+                    cachedData.lastChangedAtMillis = Utils.MillisNow;
                     cachedData.toSend = SnapshotValueIfNeeded(handler, newValue);
                     continue;
                 }
@@ -94,14 +95,13 @@ namespace Multiplayer.Client
                 return true;
 
             var millisNow = Utils.MillisNow;
-            if (!data.sent && millisNow - data.timestamp > 200)
+            if (!data.sent && millisNow - data.lastChangedAtMillis > 200)
             {
                 // If syncing fails with an exception don't try to reattempt and just give up.
                 if (data.field.DoSyncCatch(target.target, data.toSend, target.index) is false)
                     return true;
 
                 data.sent = true;
-                data.timestamp = millisNow;
             }
 
             return false;
@@ -219,22 +219,15 @@ namespace Multiplayer.Client
         }
     }
 
-    public class BufferData
+    public class BufferData(SyncField field, object actualValue, object toSend)
     {
-        public SyncField field;
+        public SyncField field = field;
         /// This is the real field's value. If this were an unbuffered field, it'd be equivalent to `FieldData.oldValue`,
         /// however for buffered fields `oldValue` reflects the value prior to the last GUI update. Use this field to
         /// access the original value before any user interaction occurred.
-        public object actualValue;
-        public object toSend;
-        public long timestamp;
+        public object actualValue = actualValue;
+        public object toSend = toSend;
+        public long lastChangedAtMillis = Utils.MillisNow;
         public bool sent;
-
-        public BufferData(SyncField field, object actualValue, object toSend)
-        {
-            this.field = field;
-            this.actualValue = actualValue;
-            this.toSend = toSend;
-        }
     }
 }

--- a/Source/Client/Util/CollectionExtensions.cs
+++ b/Source/Client/Util/CollectionExtensions.cs
@@ -53,8 +53,6 @@ namespace Multiplayer.Client
         public static int RemoveAll<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, Func<TKey, TValue, bool> predicate)
         {
             List<TKey> list = null;
-            int result;
-
             try
             {
                 foreach (var (key, value) in dictionary)
@@ -66,21 +64,12 @@ namespace Multiplayer.Client
                     }
                 }
 
-                if (list != null)
+                if (list == null) return 0;
+                foreach (var key in list)
                 {
-                    int i = 0;
-                    int count = list.Count;
-                    while (i < count)
-                    {
-                        dictionary.Remove(list[i]);
-                        i++;
-                    }
-                    result = list.Count;
+                    dictionary.Remove(key);
                 }
-                else
-                {
-                    result = 0;
-                }
+                return list.Count;
             }
             finally
             {
@@ -90,8 +79,6 @@ namespace Multiplayer.Client
                     SimplePool<List<TKey>>.Return(list);
                 }
             }
-
-            return result;
         }
 
         public static bool EqualAsSets<T>(this IEnumerable<T> enum1, IEnumerable<T> enum2)


### PR DESCRIPTION
Best reviewed commit-by-commit. Only the last two commits introduce functional changes. All previous commits are non-functional - they focus on improving documentation, renaming for clarity, and simplifying the code flow.

As for the functional changes they are meant to improve user UX and avoid input jerkiness. See below videos for comparison of the actual effect (host is on the left side; a 50ms artificial latency is applied between host and client).  At the beginning of each video I demonstrate the effects of delaying syncing until 200ms have passed without any further user input using the ingredient radius slider. In the second part I show the effect of buffering `SyncBillProduction`. In both videos, the click speed was approximately the same. However, in the "before" video, some of the clicks were lost, whereas the "after" behavior ensures the user input is correctly handled.

Before:

https://github.com/user-attachments/assets/555214d8-d127-4464-9a83-70413a7f8e6c

After:

https://github.com/user-attachments/assets/9dcd3f5c-b430-4579-a1b1-749e2ae5b321

