### PR TITLE
Add SyncWorker for ThingDefCount serialization

### DIFF
--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -810,6 +810,23 @@ namespace Multiplayer.Client
                     }
                 }, true // implicit
             },
+            {
+                (SyncWorker sync, ref ThingDefCount thingDefCount) =>
+                {
+                    if (sync.isWriting)
+                    {
+                        sync.Write(thingDefCount.ThingDef);
+                        sync.Write(thingDefCount.Count);
+                    }
+                    else
+                    {
+                        var def = sync.Read<ThingDef>();
+                        var count = sync.Read<int>();
+
+                        thingDefCount = new ThingDefCount(def, count);
+                    }
+                }
+            },
             #endregion
 
             #region Databases


### PR DESCRIPTION
Introduces a SyncWorker delegate for handling ThingDefCount synchronization.

This is needed for #508 to sync pawns starting possessions and ensure they are generated correctly on the map after pawn creation.

Per Sokyran's suggestion, this functionality is split into its own PR, as it could be useful for other cases as well.