### PR TITLE
Variable Tick Rate

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncTimeComp.cs
@@ -10,6 +10,7 @@ using Multiplayer.Client.Factions;
 using Multiplayer.Client.Patches;
 using Multiplayer.Client.Saving;
 using Multiplayer.Client.Util;
+using System.Linq;
 
 namespace Multiplayer.Client
 {
@@ -97,6 +98,9 @@ namespace Multiplayer.Client
         public ulong randState;
 
         public Queue<ScheduledCommand> cmds = new();
+
+        public int CurrentPlayerCount { get; private set; } = 0;
+        public int VTR => CurrentPlayerCount > 0 ? 1 : 15;
 
         public AsyncTimeComp(Map map, int gameStartAbsTick = 0)
         {
@@ -227,6 +231,9 @@ namespace Multiplayer.Client
 
             Scribe_Custom.LookULong(ref randState, "randState", 1);
         }
+
+        public void IncreasePlayerCount() => CurrentPlayerCount++;
+        public void DecreasePlayerCount() => CurrentPlayerCount = Math.Max(0, CurrentPlayerCount - 1);
 
         public void FinalizeInit()
         {

--- a/Source/Client/AsyncTime/AsyncTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncTimeComp.cs
@@ -100,7 +100,7 @@ namespace Multiplayer.Client
         public Queue<ScheduledCommand> cmds = new();
 
         public int CurrentPlayerCount { get; private set; } = 0;
-        public int VTR => CurrentPlayerCount > 0 ? 1 : 15;
+        public int VTR => CurrentPlayerCount > 0 ? VTRSync.MinimumVtr : VTRSync.MaximumVtr;
 
         public AsyncTimeComp(Map map, int gameStartAbsTick = 0)
         {

--- a/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
@@ -223,6 +223,19 @@ public class AsyncWorldTimeComp : IExposable, ITickable
                 var canUseDevMode = data.ReadBool();
                 Multiplayer.GameComp.playerData[playerId] = new PlayerData { canUseDevMode = canUseDevMode };
             }
+
+            if (cmdType == CommandType.PlayerCount)
+            {
+                int previousMapId = data.ReadInt32();
+                int newMapId = data.ReadInt32();
+                int mapCount = Find.Maps.Count;
+
+                if (0 <= previousMapId && previousMapId < mapCount)
+                    Find.Maps[previousMapId]?.AsyncTime()?.DecreasePlayerCount();
+
+                if (0 <= newMapId && newMapId < mapCount)
+                    Find.Maps[newMapId]?.AsyncTime()?.IncreasePlayerCount();
+            }
         }
         catch (Exception e)
         {

--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -16,20 +16,49 @@ namespace Multiplayer.Client.Patches
             if (Multiplayer.Client == null)
                 return true;
 
-            __result = GetSynchronizedUpdateRate(thing);
+            __result = VTRSync.GetSynchronizedUpdateRate(thing);
             return false;
         }
+    }
 
-        private static int GetSynchronizedUpdateRate(Thing thing) => thing?.MapHeld?.AsyncTime()?.VTR ?? 15;
+    [HarmonyPatch(typeof(Projectile), nameof(Projectile.UpdateRateTicks), MethodType.Getter)]
+    public static class VtrSyncProjectilePatch
+    {
+        static bool Prefix(ref int __result, Projectile __instance)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = __instance.Spawned ? VTRSync.GetSynchronizedUpdateRate(__instance) : VTRSync.MaximumVtr;
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(WorldObject), nameof(WorldObject.UpdateRateTicks), MethodType.Getter)]
+    public static class VtrSyncWorldObjectPatch
+    {
+        static bool Prefix(ref int __result, WorldObject __instance)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = VTRSync.MaximumVtr;
+            return false;
+        }
     }
 
     static class VTRSync
     {
-        public static int lastMovedToMap = -1;
-        public static int lastSentTick = -1;
-        
         // Special identifier for world map (since it doesn't have a uniqueID like regular maps)
         public const int WorldMapId = -2;
+        public static int lastMovedToMap = -1;
+        public static int lastSentTick = -1;
+
+        // Vtr rates
+        public const int MaximumVtr = 15;
+        public const int MinimumVtr = 1;
+
+        public static int GetSynchronizedUpdateRate(Thing thing) => thing?.MapHeld?.AsyncTime()?.VTR ?? VTRSync.MaximumVtr;
     }
 
     [HarmonyPatch(typeof(Game), nameof(Game.CurrentMap), MethodType.Setter)]

--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using Multiplayer.Client.Util;
+using Multiplayer.Common;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace Multiplayer.Client.Patches
+{
+    [HarmonyPatch(typeof(GenTicks), nameof(GenTicks.GetCameraUpdateRate))]
+    public static class VTRSyncPatch
+    {
+        static bool Prefix(Thing thing, ref int __result)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = GetSynchronizedUpdateRate(thing);
+            return false;
+        }
+
+        private static int GetSynchronizedUpdateRate(Thing thing) => thing?.MapHeld?.AsyncTime()?.VTR ?? 15;
+    }
+
+    [HarmonyPatch(typeof(Game), nameof(Game.CurrentMap), MethodType.Setter)]
+    static class MapSwitchPatch
+    {
+        private static int lastSentFromMap = int.MaxValue;
+        private static int lastSentTick = -1;
+
+        static void Prefix(Map value)
+        {
+            if (Multiplayer.Client == null) return;
+
+            try
+            {
+                int previousMap = Find.CurrentMap?.uniqueID ?? -1;
+                int newMap = value?.uniqueID ?? -1;
+                int currentTick = Find.TickManager?.TicksGame ?? 0;
+
+                // Only send when multiplayer is ready
+                if (Multiplayer.Client == null || Client.Multiplayer.session == null)
+                    return;
+
+                // If no change in map, do nothing
+                if (previousMap == newMap)
+                    return;
+
+                // Prevent duplicate commands for the same transition, but allow retry after a tick
+                if (lastSentFromMap == previousMap && currentTick == lastSentTick)
+                    return;
+
+                // Send map change command to server
+                // Send as global command since it affects multiple maps
+                Multiplayer.Client.SendCommand(CommandType.PlayerCount, ScheduledCommand.Global, ByteWriter.GetBytes(previousMap, newMap));
+
+                // Track this command to prevent duplicates
+                lastSentFromMap = previousMap;
+                lastSentTick = currentTick;
+            }
+            catch (Exception ex)
+            {
+                MpLog.Error($"VTR MapSwitchPatch error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -1,11 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using HarmonyLib;
+using Multiplayer.Client.Patches;
 using Multiplayer.Client.Util;
 using Multiplayer.Common;
-using RimWorld;
-using UnityEngine;
+using RimWorld.Planet;
+using System;
 using Verse;
 
 namespace Multiplayer.Client.Patches
@@ -25,15 +23,21 @@ namespace Multiplayer.Client.Patches
         private static int GetSynchronizedUpdateRate(Thing thing) => thing?.MapHeld?.AsyncTime()?.VTR ?? 15;
     }
 
+    static class VTRSync
+    {
+        public static int lastMovedToMap = -1;
+        public static int lastSentTick = -1;
+        
+        // Special identifier for world map (since it doesn't have a uniqueID like regular maps)
+        public const int WorldMapId = -2;
+    }
+
     [HarmonyPatch(typeof(Game), nameof(Game.CurrentMap), MethodType.Setter)]
     static class MapSwitchPatch
     {
-        private static int lastSentFromMap = int.MaxValue;
-        private static int lastSentTick = -1;
-
         static void Prefix(Map value)
         {
-            if (Multiplayer.Client == null) return;
+            if (Multiplayer.Client == null || Client.Multiplayer.session == null) return;
 
             try
             {
@@ -41,16 +45,12 @@ namespace Multiplayer.Client.Patches
                 int newMap = value?.uniqueID ?? -1;
                 int currentTick = Find.TickManager?.TicksGame ?? 0;
 
-                // Only send when multiplayer is ready
-                if (Multiplayer.Client == null || Client.Multiplayer.session == null)
-                    return;
-
                 // If no change in map, do nothing
                 if (previousMap == newMap)
                     return;
 
                 // Prevent duplicate commands for the same transition, but allow retry after a tick
-                if (lastSentFromMap == previousMap && currentTick == lastSentTick)
+                if (VTRSync.lastMovedToMap == previousMap && currentTick == VTRSync.lastSentTick)
                     return;
 
                 // Send map change command to server
@@ -58,12 +58,47 @@ namespace Multiplayer.Client.Patches
                 Multiplayer.Client.SendCommand(CommandType.PlayerCount, ScheduledCommand.Global, ByteWriter.GetBytes(previousMap, newMap));
 
                 // Track this command to prevent duplicates
-                lastSentFromMap = previousMap;
-                lastSentTick = currentTick;
+                VTRSync.lastMovedToMap = newMap;
+                VTRSync.lastSentTick = currentTick;
             }
             catch (Exception ex)
             {
                 MpLog.Error($"VTR MapSwitchPatch error: {ex.Message}");
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(WorldRendererUtility), nameof(WorldRendererUtility.CurrentWorldRenderMode), MethodType.Getter)]
+    static class WorldRenderModePatch
+    {
+        private static WorldRenderMode lastRenderMode = WorldRenderMode.None;
+
+        static void Postfix(WorldRenderMode __result)
+        {
+            if (Multiplayer.Client == null) return;
+
+            try
+            {
+                // Detect transition to world map (Planet mode)
+                if (__result == WorldRenderMode.Planet && lastRenderMode != WorldRenderMode.Planet)
+                {
+                    if (VTRSync.lastMovedToMap != -1)
+                    {
+                        Multiplayer.Client.SendCommand(CommandType.PlayerCount, ScheduledCommand.Global, ByteWriter.GetBytes(VTRSync.lastMovedToMap, VTRSync.WorldMapId));
+                    }
+                }
+                // Detect transition away from world map
+                else if (__result != WorldRenderMode.Planet && lastRenderMode == WorldRenderMode.Planet)
+                {
+                    int currentMapId = Find.CurrentMap?.uniqueID ?? -1;
+                    Multiplayer.Client.SendCommand(CommandType.PlayerCount, ScheduledCommand.Global, ByteWriter.GetBytes(VTRSync.WorldMapId, currentMapId));
+                }
+
+                lastRenderMode = __result;
+            }
+            catch (Exception ex)
+            {
+                MpLog.Error($"WorldRenderModePatch error: {ex.Message}");
             }
         }
     }

--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -79,7 +79,7 @@ namespace Multiplayer.Client.Patches
                     return;
 
                 // Prevent duplicate commands for the same transition, but allow retry after a tick
-                if (VTRSync.lastMovedToMap == previousMap && currentTick == VTRSync.lastSentTick)
+                if (VTRSync.lastMovedToMap == newMap && currentTick == VTRSync.lastSentTick)
                     return;
 
                 // Send map change command to server
@@ -115,12 +115,6 @@ namespace Multiplayer.Client.Patches
                     {
                         Multiplayer.Client.SendCommand(CommandType.PlayerCount, ScheduledCommand.Global, ByteWriter.GetBytes(VTRSync.lastMovedToMap, VTRSync.WorldMapId));
                     }
-                }
-                // Detect transition away from world map
-                else if (__result != WorldRenderMode.Planet && lastRenderMode == WorldRenderMode.Planet)
-                {
-                    int currentMapId = Find.CurrentMap?.uniqueID ?? -1;
-                    Multiplayer.Client.SendCommand(CommandType.PlayerCount, ScheduledCommand.Global, ByteWriter.GetBytes(VTRSync.WorldMapId, currentMapId));
                 }
 
                 lastRenderMode = __result;

--- a/Source/Common/CommandType.cs
+++ b/Source/Common/CommandType.cs
@@ -16,4 +16,5 @@ public enum CommandType : byte
     // Map scope
     MapTimeSpeed,
     Designator,
+    PlayerCount,
 }

--- a/Source/Common/Networking/State/ServerPlayingState.cs
+++ b/Source/Common/Networking/State/ServerPlayingState.cs
@@ -109,6 +109,9 @@ namespace Multiplayer.Common
 
             byte seq = data.ReadByte();
             byte map = data.ReadByte();
+            
+            // Track the player's current map from cursor updates
+            Player.currentMap = map;
 
             writer.WriteInt32(Player.id);
             writer.WriteByte(seq);

--- a/Source/Common/PlayerManager.cs
+++ b/Source/Common/PlayerManager.cs
@@ -80,6 +80,16 @@ namespace Multiplayer.Common
 
             if (player.hasJoined)
             {
+                // Handle unexpected disconnections by sending PlayerCount command
+                if (reason == MpDisconnectReason.ClientLeft || reason == MpDisconnectReason.NetFailed)
+                {
+                    // Send PlayerCount command to remove player from their last known map
+                    if (player.currentMap != -1)
+                    {
+                        byte[] playerCountData = ByteWriter.GetBytes(player.currentMap, -1); // previousMap: player's map, newMap: -1 (disconnected)
+                        server.commands.Send(CommandType.PlayerCount, ScheduledCommand.NoFaction, ScheduledCommand.Global, playerCountData);
+                    }
+                }
                 // todo check player.IsPlaying?
                 // todo FactionId might throw when called for not fully initialized players
                 // if (Players.All(p => p.FactionId != player.FactionId))

--- a/Source/Common/ServerPlayer.cs
+++ b/Source/Common/ServerPlayer.cs
@@ -30,6 +30,9 @@ namespace Multiplayer.Common
 
         public bool frozen;
         public int unfrozenAt;
+        
+        // Track which map the player is currently on (from cursor updates)
+        public int currentMap = -1;
 
         public string Username => conn.username;
         public int Latency => conn.Latency;


### PR DESCRIPTION
Variable tick rate implementation
- Standard VTR of 1 on any map that has any players
- Any other maps run at 15 (ticks every 15 ticks instead of every 1)
- Keeps track of player count on each map now via a new command

Updates:
- Now correctly update map player counts on unexpected disconnects
- Handled Projectile and WorldItem VTR
- No longer counts a player as on a map if they have the world map open (Need to test Odyssey scenarios)

NOTE: This will not work by itself, it needs other general 1.6 updates as found in my other PR
I separated this one as I think it could have some discussion around the best way to implement it.