### PR TITLE
Fix for #547

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimePatches.cs
+++ b/Source/Client/AsyncTime/AsyncTimePatches.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using Multiplayer.Client.Factions;
 using RimWorld;
 using RimWorld.Planet;
 using System.Collections.Generic;
@@ -147,6 +148,7 @@ namespace Multiplayer.Client.AsyncTime
         {
             if (Multiplayer.Client == null) return;
             if (WorldRendererUtility.WorldRenderedNow) return;
+            if (FactionCreator.generatingMap) return;
 
             var asyncTime = Find.CurrentMap.AsyncTime();
             var timeSpeed = Multiplayer.IsReplay ? TickPatch.replayTimeSpeed : asyncTime.DesiredTimeSpeed;


### PR DESCRIPTION
Fixes issue: #547

> A guard for currentMap == null was added in https://github.com/rwmt/Multiplayer/pull/508 but later reverted (https://github.com/rwmt/Multiplayer/commit/adc9d8b14ae91735b8f7c72b4b80b41acc06fa14#diff-e2d1935affa8fc6df58e22fb262dd657d4774930103d508fd4b70e1f446868b9L150) due to uncertainty about its purpose - both in code review and because I had forgotten the reason myself after writing it 6 months earlier. The fix should be more explicit and self-explanatory, rather than relying on a simple guard clause without clear context.

To make the solution more targeted, the TickManager.Paused patch is now explicitly disabled while a new map is being generated. Instead of a generic `currentMap == null` check, this uses `FactionCreator.generatingMap` to indicate the reason the patch is being skipped.

This makes it more obvious why the guard exists and helps prevent future confusion or accidental removal.