### PR TITLE
Deterministic HashCombines

### DIFF
--- a/Source/Client/Patches/HashCodes.cs
+++ b/Source/Client/Patches/HashCodes.cs
@@ -1,7 +1,10 @@
 using HarmonyLib;
+using Multiplayer.Client.Util;
 using RimWorld;
 using RimWorld.Planet;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Verse;
@@ -60,6 +63,152 @@ namespace Multiplayer.Client.Patches
         static void Postfix(Tradeable __instance, ref int __result)
         {
             __result = RuntimeHelpers.GetHashCode(__instance);
+        }
+    }
+
+    // Have created a patch that will handle 2-8 System.HashCode.Combine functions.
+    // TODO: Check the following:
+    // TileQueryParams.GetHashCode
+    // UnmanagedGridTraverseParams.GetHashCode
+    // MapGridRequest.GetHashCode
+    // SimplifiedPastureNutritionSimulator.GetHashCode
+    // FieldAliasCache.GetHashCode
+    static class HashCodeDetours
+    {
+        private static readonly Type HashCodeType = typeof(string).Assembly.GetType("System.HashCode");
+
+        internal static MethodBase GetCombineIntMethod(int numOfInts)
+        {
+            Type[] intTypes = Enumerable.Repeat(typeof(int), numOfInts).ToArray();
+
+            // Look for a pre-compiled int,int,… overload (only exists on some runtimes)
+            MethodInfo method = HashCodeType.GetMethod("Combine", BindingFlags.Public | BindingFlags.Static, binder: null, types: intTypes, modifiers: null);
+            if (method != null)
+                return method;   // good – no generics involved
+
+            // Fall back to the generic definition and close it for <int,…,int>
+            MethodInfo genericMethod = HashCodeType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                                 .First(x =>
+                                    x.Name == "Combine" &&
+                                    x.IsGenericMethodDefinition &&
+                                    x.GetGenericArguments().Length == numOfInts);
+
+            return genericMethod.MakeGenericMethod(intTypes);
+        }
+    }
+
+    //  ─── PATCH 2 ints ─────────────────────────────────────────
+    [HarmonyPatch]
+    static class Combine2Patch
+    {
+        static MethodBase TargetMethod() => HashCodeDetours.GetCombineIntMethod(2);
+
+        static bool Prefix(int value1, int value2, ref int __result)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = Gen.HashCombineInt(value1, value2);
+            return false;
+        }
+    }
+
+    //  ─── PATCH 3 ints ─────────────────────────────────────────
+    [HarmonyPatch]
+    static class Combine3Patch
+    {
+        static MethodBase TargetMethod() => HashCodeDetours.GetCombineIntMethod(3);
+
+        static bool Prefix(int value1, int value2, int value3, ref int __result)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = DeterministicHash.HashCombineInt(value1, value2, value3);
+            return false;
+        }
+    }
+
+    //  ─── PATCH 4 ints ─────────────────────────────────────────
+    [HarmonyPatch]
+    static class Combine4Patch
+    {
+        static MethodBase TargetMethod() => HashCodeDetours.GetCombineIntMethod(4);
+
+        static bool Prefix(int value1, int value2, int value3, int value4, ref int __result)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = Gen.HashCombineInt(value1, value2, value3, value4);
+            return false;
+        }
+    }
+
+    //  ─── PATCH 5 ints ─────────────────────────────────────────
+    [HarmonyPatch]
+    static class Combine5Patch
+    {
+        static MethodBase TargetMethod() => HashCodeDetours.GetCombineIntMethod(5);
+
+        static bool Prefix(int value1, int value2, int value3, int value4, int value5, ref int __result)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = DeterministicHash.HashCombineInt(value1, value2, value3, value4, value5);
+            return false;
+        }
+    }
+
+    //  ─── PATCH 6 ints ─────────────────────────────────────────
+    [HarmonyPatch]
+    static class Combine6Patch
+    {
+        static MethodBase TargetMethod() => HashCodeDetours.GetCombineIntMethod(6);
+
+        static bool Prefix(int value1, int value2, int value3, int value4, int value5, int value6, ref int __result)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = DeterministicHash.HashCombineInt(value1, value2, value3,
+                                                  value4, value5, value6);
+            return false;
+        }
+    }
+
+    //  ─── PATCH 7 ints ─────────────────────────────────────────
+    [HarmonyPatch]
+    static class Combine7Patch
+    {
+        static MethodBase TargetMethod() => HashCodeDetours.GetCombineIntMethod(7);
+
+        static bool Prefix(int value1, int value2, int value3, int value4, int value5, int value6, int value7, ref int __result)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = DeterministicHash.HashCombineInt(value1, value2, value3, value4,
+                                                  value5, value6, value7);
+            return false;
+        }
+    }
+
+    //  ─── PATCH 8 ints ─────────────────────────────────────────
+    [HarmonyPatch]
+    static class Combine8Patch
+    {
+        static MethodBase TargetMethod() => HashCodeDetours.GetCombineIntMethod(8);
+
+        static bool Prefix(int value1, int value2, int value3, int value4, int value5, int value6, int value7, int value8, ref int __result)
+        {
+            if (Multiplayer.Client == null)
+                return true;
+
+            __result = DeterministicHash.HashCombineInt(value1, value2, value3, value4,
+                                                  value5, value6, value7, value8);
+            return false;
         }
     }
 }

--- a/Source/Client/Util/DeterministicHash.cs
+++ b/Source/Client/Util/DeterministicHash.cs
@@ -1,0 +1,99 @@
+namespace Multiplayer.Client.Util
+{
+    public static class DeterministicHash
+    {
+        public const int DefaultSeed = 352654597;
+        public const int DefaultSeed2 = 1566083941;
+
+        // 3-value combiner  ──────────────────────────────────────
+        public static int HashCombineInt(int v1, int v2, int v3)
+        {
+            unchecked
+            {
+                int h = DefaultSeed;
+                h = ((h << 5) + h + (h >> 27)) ^ v1;
+                h = ((h << 5) + h + (h >> 27)) ^ v2;
+                h = ((h << 5) + h + (h >> 27)) ^ v3;
+                return h;
+            }
+        }
+
+        // 5-value combiner  ──────────────────────────────────────
+        public static int HashCombineInt(int v1, int v2, int v3, int v4, int v5)
+        {
+            unchecked
+            {
+                int h1 = DefaultSeed;
+                int h2 = h1;
+
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v1;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v2;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v3;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v4;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v5;
+
+                return h1 + h2 * DefaultSeed2;
+            }
+        }
+
+        // 6-value combiner  ──────────────────────────────────────
+        public static int HashCombineInt(int v1, int v2, int v3, int v4, int v5, int v6)
+        {
+            unchecked
+            {
+                int h1 = DefaultSeed;
+                int h2 = h1;
+
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v1;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v2;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v3;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v4;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v5;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v6;
+
+                return h1 + h2 * DefaultSeed2;
+            }
+        }
+
+        // 7-value combiner ─────────────────────────────────────────
+        public static int HashCombineInt(int v1, int v2, int v3, int v4, int v5, int v6, int v7)
+        {
+            unchecked
+            {
+                int h1 = DefaultSeed;
+                int h2 = h1;
+
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v1;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v2;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v3;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v4;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v5;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v6;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v7;
+
+                return h1 + h2 * DefaultSeed2;
+            }
+        }
+
+        // 8-value combiner ─────────────────────────────────────────
+        public static int HashCombineInt(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8)
+        {
+            unchecked
+            {
+                int h1 = DefaultSeed;
+                int h2 = h1;
+
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v1;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v2;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v3;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v4;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v5;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v6;
+                h1 = ((h1 << 5) + h1 + (h1 >> 27)) ^ v7;
+                h2 = ((h2 << 5) + h2 + (h2 >> 27)) ^ v8;
+
+                return h1 + h2 * DefaultSeed2;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added Deterministic HashCombineInt for 3,5,6,7 and 8 combinations. (2 and 4 are already included in RimWorld)
- Patched all version of System.HashCode.Combine which will cover all future functions of this to.