### PR TITLE
RBP on demand

### DIFF
--- a/Source/Common/DeferredStackTracingImpl.cs
+++ b/Source/Common/DeferredStackTracingImpl.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Runtime.CompilerServices;
-using UnityEngine;
-using Verse;
 
 namespace Multiplayer.Client.Desyncs;
 
@@ -261,7 +259,6 @@ public static class DeferredStackTracingImpl
             if (Native.mono_jit_info_table_find(Native.DomainPtr, *(IntPtr*)(cand + 8)) == IntPtr.Zero)
                 continue;
 
-            Verse.Log.Message($"[rbp] saved [{i}] RBP 0x{*(&local + i):X}");
             return cand;                              // looks like a real frame ptr
         }
 


### PR DESCRIPTION
- now probe for the correct rbp when required.
- This is required as newer version of mono are less static than previously