### PR TITLE
Prevent duplicate monolith generation in multifaction

### DIFF
--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -673,6 +673,22 @@ static class ApparelWornGraphicPathGetterPatch
     }
 }
 
+#region Map generation
+
+[HarmonyPatch(typeof(GenStep_Monolith), nameof(GenStep_Monolith.GenerateMonolith))]
+public static class GenStepMonolithPatch
+{
+    static bool Prefix()
+    {
+        if (Multiplayer.Client == null)
+            return true;
+
+        var anomalyComp = Current.Game.components.OfType<GameComponent_Anomaly>().FirstOrDefault();
+
+        return anomalyComp?.monolith == null;
+    }
+}
+
 [HarmonyPatch(typeof(ScenPart_ScatterThings), nameof(ScenPart_ScatterThings.GenerateIntoMap))]
 static class ScenPartScatterThingsPatch
 {
@@ -690,6 +706,8 @@ static class ScenPartPlayerPawnsArriveMethodPatch
         return Multiplayer.Client == null || FactionCreator.generatingMap;
     }
 }
+
+#endregion
 
 [HarmonyPatch(typeof(CharacterCardUtility), nameof(CharacterCardUtility.DoTopStack))]
 static class CharacterCardUtilityDontDrawIdeoPlate


### PR DESCRIPTION
Label 1.5, Multifaction, Bug, Anomaly

Due to changes in #508, an exostrider is now spawned on every newly generated multifaction map. However, this also caused a monolith to be generated each time, resulting in multiple monoliths appearing and causing issues.

This update adds a Harmony patch to GenStep_Monolith.GenerateMonolith to skip monolith generation if one already exists.