### PR TITLE
Resolve reference comparison warnings (CS0252)

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimePatches.cs
+++ b/Source/Client/AsyncTime/AsyncTimePatches.cs
@@ -178,9 +178,9 @@ namespace Multiplayer.Client.AsyncTime
         {
             foreach (var inst in insts)
             {
-                if (inst.operand == AccessTools.PropertyGetter(typeof(Prefs), nameof(Prefs.AutomaticPauseMode)))
+                if (AccessTools.PropertyGetter(typeof(Prefs), nameof(Prefs.AutomaticPauseMode)).Equals(inst.operand))
                     inst.operand = AccessTools.Method(typeof(ReceiveLetterPause), nameof(AutomaticPauseMode));
-                else if (inst.operand == AccessTools.Method(typeof(TickManager), nameof(TickManager.Pause)))
+                else if (AccessTools.Method(typeof(TickManager), nameof(TickManager.Pause)).Equals(inst.operand))
                     inst.operand = AccessTools.Method(typeof(ReceiveLetterPause), nameof(PauseOnLetter));
 
                 yield return inst;
@@ -190,7 +190,7 @@ namespace Multiplayer.Client.AsyncTime
         private static AutomaticPauseMode AutomaticPauseMode()
         {
             return Multiplayer.Client != null
-                ? (AutomaticPauseMode) Multiplayer.GameComp.pauseOnLetter
+                ? (AutomaticPauseMode)Multiplayer.GameComp.pauseOnLetter
                 : Prefs.AutomaticPauseMode;
         }
 

--- a/Source/Client/AsyncTime/AsyncTimePatches.cs
+++ b/Source/Client/AsyncTime/AsyncTimePatches.cs
@@ -178,9 +178,9 @@ namespace Multiplayer.Client.AsyncTime
         {
             foreach (var inst in insts)
             {
-                if (AccessTools.PropertyGetter(typeof(Prefs), nameof(Prefs.AutomaticPauseMode)).Equals(inst.operand))
+                if (inst.operand as MethodInfo == AccessTools.PropertyGetter(typeof(Prefs), nameof(Prefs.AutomaticPauseMode)))
                     inst.operand = AccessTools.Method(typeof(ReceiveLetterPause), nameof(AutomaticPauseMode));
-                else if (AccessTools.Method(typeof(TickManager), nameof(TickManager.Pause)).Equals(inst.operand))
+                else if (inst.operand as MethodInfo == AccessTools.Method(typeof(TickManager), nameof(TickManager.Pause)))
                     inst.operand = AccessTools.Method(typeof(ReceiveLetterPause), nameof(PauseOnLetter));
 
                 yield return inst;

--- a/Source/Client/AsyncTime/TimeControlUI.cs
+++ b/Source/Client/AsyncTime/TimeControlUI.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Multiplayer.Client.Util;
@@ -36,13 +37,13 @@ public static class TimeControlPatch
     {
         foreach (var inst in insts)
         {
-            if (AccessTools.Method(typeof(TimeControls), nameof(TimeControls.DoTimeControlsGUI)).Equals(inst.operand))
+            if (inst.operand as MethodInfo == AccessTools.Method(typeof(TimeControls), nameof(TimeControls.DoTimeControlsGUI)))
                 inst.operand = AccessTools.Method(typeof(TimeControlPatch), nameof(DoTimeControlsGUI));
 
             yield return inst;
 
-            if (AccessTools.Constructor(typeof(Rect),
-                new[] { typeof(float), typeof(float), typeof(float), typeof(float) }).Equals(inst.operand))
+            if (inst.operand as MethodInfo == AccessTools.Constructor(typeof(Rect),
+                    new[] { typeof(float), typeof(float), typeof(float), typeof(float) }))
             {
                 yield return new CodeInstruction(OpCodes.Ldloca_S, 1);
                 yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(TimeControlPatch), nameof(ModifyRect)));

--- a/Source/Client/AsyncTime/TimeControlUI.cs
+++ b/Source/Client/AsyncTime/TimeControlUI.cs
@@ -36,13 +36,13 @@ public static class TimeControlPatch
     {
         foreach (var inst in insts)
         {
-            if (inst.operand == AccessTools.Method(typeof(TimeControls), nameof(TimeControls.DoTimeControlsGUI)))
+            if (AccessTools.Method(typeof(TimeControls), nameof(TimeControls.DoTimeControlsGUI)).Equals(inst.operand))
                 inst.operand = AccessTools.Method(typeof(TimeControlPatch), nameof(DoTimeControlsGUI));
 
             yield return inst;
 
-            if (inst.operand == AccessTools.Constructor(typeof(Rect),
-                    new[] { typeof(float), typeof(float), typeof(float), typeof(float) }))
+            if (AccessTools.Constructor(typeof(Rect),
+                new[] { typeof(float), typeof(float), typeof(float), typeof(float) }).Equals(inst.operand))
             {
                 yield return new CodeInstruction(OpCodes.Ldloca_S, 1);
                 yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(TimeControlPatch), nameof(ModifyRect)));
@@ -360,7 +360,7 @@ public static class ColonistBarTimeControl
                 }
                 else
                 {
-                    // There is a new blocking pause 
+                    // There is a new blocking pause
                     flashDict.Add(flashPos, Time.time);
                 }
             }
@@ -416,7 +416,7 @@ public static class ColonistBarTimeControl
         // Only flash at flashInterval from the time the blocking pause began
         if (pauseDuration > 0f && pauseDuration % flashInterval < 1f)
         {
-             GenUI.DrawFlash(pos.x, pos.y, UI.screenWidth * 0.6f, Pulser.PulseBrightness(1f, 1f, pauseDuration) * 0.4f, flashColor);
+            GenUI.DrawFlash(pos.x, pos.y, UI.screenWidth * 0.6f, Pulser.PulseBrightness(1f, 1f, pauseDuration) * 0.4f, flashColor);
         }
     }
 }

--- a/Source/Client/Debug/DebugPatches.cs
+++ b/Source/Client/Debug/DebugPatches.cs
@@ -90,10 +90,10 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (inst.operand == GizmoOnGUI)
+                if (GizmoOnGUI.Equals(inst.operand))
                     yield return new CodeInstruction(OpCodes.Call,
                         AccessTools.Method(typeof(GizmoDrawDebugInfo), nameof(GizmoOnGUIProxy)));
-                else if (inst.operand == GizmoOnGUIShrunk)
+                else if (GizmoOnGUIShrunk.Equals(inst.operand))
                     yield return new CodeInstruction(OpCodes.Call,
                         AccessTools.Method(typeof(GizmoDrawDebugInfo), nameof(GizmoOnGUIShrunkProxy)));
                 else

--- a/Source/Client/Debug/DebugPatches.cs
+++ b/Source/Client/Debug/DebugPatches.cs
@@ -90,10 +90,10 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (GizmoOnGUI.Equals(inst.operand))
+                if (inst.operand as MethodInfo == GizmoOnGUI)
                     yield return new CodeInstruction(OpCodes.Call,
                         AccessTools.Method(typeof(GizmoDrawDebugInfo), nameof(GizmoOnGUIProxy)));
-                else if (GizmoOnGUIShrunk.Equals(inst.operand))
+                else if (inst.operand as MethodInfo == GizmoOnGUIShrunk)
                     yield return new CodeInstruction(OpCodes.Call,
                         AccessTools.Method(typeof(GizmoDrawDebugInfo), nameof(GizmoOnGUIShrunkProxy)));
                 else

--- a/Source/Client/Factions/Blueprints.cs
+++ b/Source/Client/Factions/Blueprints.cs
@@ -30,7 +30,7 @@ namespace Multiplayer.Client
 
                 yield return cur;
 
-                if (cur.opcode == OpCodes.Call && CanPlaceBlueprintOver.Equals(cur.operand))
+                if (cur.opcode == OpCodes.Call && cur.operand as MethodInfo == CanPlaceBlueprintOver)
                 {
                     var thingToIgnoreIndex = insts[i - 2].operand;
 
@@ -173,7 +173,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Call && SpawningWipes.Equals(inst.operand))
+                if (inst.opcode == OpCodes.Call && inst.operand as MethodInfo == SpawningWipes)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_2);
                     yield return new CodeInstruction(OpCodes.Ldloc_3);
@@ -196,7 +196,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Call && SpawningWipes.Equals(inst.operand))
+                if (inst.opcode == OpCodes.Call && inst.operand as MethodInfo == SpawningWipes)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_2);
                     yield return new CodeInstruction(OpCodes.Ldloc_S, 4);
@@ -221,7 +221,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Call && SpawningWipes.Equals(inst.operand))
+                if (inst.opcode == OpCodes.Call && inst.operand as MethodInfo == SpawningWipes)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, ThingDefField);
@@ -335,7 +335,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Isinst && typeof(Blueprint).Equals(inst.operand))
+                if (inst.opcode == OpCodes.Isinst && inst.operand as MethodInfo == typeof(Blueprint))
                 {
                     yield return new CodeInstruction(OpCodes.Ldnull);
                     yield return new CodeInstruction(OpCodes.Cgt_Un);

--- a/Source/Client/Factions/Blueprints.cs
+++ b/Source/Client/Factions/Blueprints.cs
@@ -30,7 +30,7 @@ namespace Multiplayer.Client
 
                 yield return cur;
 
-                if (cur.opcode == OpCodes.Call && cur.operand == CanPlaceBlueprintOver)
+                if (cur.opcode == OpCodes.Call && CanPlaceBlueprintOver.Equals(cur.operand))
                 {
                     var thingToIgnoreIndex = insts[i - 2].operand;
 
@@ -103,7 +103,7 @@ namespace Multiplayer.Client
                 new CodeInstruction(OpCodes.Call, CanPlaceBlueprintAtPatch.ShouldIgnore1Method),
                 new CodeInstruction(OpCodes.Brtrue, insts[loop + 1].operand)
             );
-            
+
             return insts;
         }
     }
@@ -173,7 +173,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Call && inst.operand == SpawningWipes)
+                if (inst.opcode == OpCodes.Call && SpawningWipes.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_2);
                     yield return new CodeInstruction(OpCodes.Ldloc_3);
@@ -196,7 +196,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Call && inst.operand == SpawningWipes)
+                if (inst.opcode == OpCodes.Call && SpawningWipes.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_2);
                     yield return new CodeInstruction(OpCodes.Ldloc_S, 4);
@@ -221,7 +221,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Call && inst.operand == SpawningWipes)
+                if (inst.opcode == OpCodes.Call && SpawningWipes.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, ThingDefField);
@@ -335,7 +335,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Isinst && inst.operand == typeof(Blueprint))
+                if (inst.opcode == OpCodes.Isinst && typeof(Blueprint).Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldnull);
                     yield return new CodeInstruction(OpCodes.Cgt_Un);

--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -50,7 +50,7 @@ public static class MainTabWindow_QuestsShouldListNowPatch
             if (quest.TryGetPlayerFaction(out playerFaction) && playerFaction != Faction.OfPlayer)
             {
                 __result = false;
-                return false; 
+                return false;
             }
         }
         return true;
@@ -82,8 +82,8 @@ static class WorldInspectPanePaneTopYPatch
 {
     static void Postfix(ref float __result)
     {
-        if (Multiplayer.Client != null && Multiplayer.RealPlayerFaction == Multiplayer.WorldComp.spectatorFaction)       
-            __result += 35f;      
+        if (Multiplayer.Client != null && Multiplayer.RealPlayerFaction == Multiplayer.WorldComp.spectatorFaction)
+            __result += 35f;
     }
 }
 
@@ -198,13 +198,13 @@ static class MainButtonsRootDoButtonsPatch
     private static bool ReplaceOriginalDrawing(MainButtonsRoot __instance)
     {
         if (!IsSpectator)
-            return true; 
+            return true;
 
         try
         {
             var allButtons = AllButtonsRef(__instance);
             if (allButtons == null)
-                return true; 
+                return true;
 
             var toDraw = SpectatorButtons
                 .Select(name => allButtons.Find(b => b.defName == name))
@@ -212,7 +212,7 @@ static class MainButtonsRootDoButtonsPatch
                 .ToList();
 
             DrawCornerButtons(toDraw);
-            return false; 
+            return false;
         }
         catch (Exception ex)
         {
@@ -421,7 +421,7 @@ static class StartingAnimalPatch
         {
             yield return inst;
 
-            if (inst.operand == playerFactionField)
+            if (playerFactionField.Equals(inst.operand))
                 yield return new CodeInstruction(OpCodes.Call, factionOfPlayer.Method);
         }
     }
@@ -442,7 +442,7 @@ static class PawnIsColonistPatch
 
         foreach (var inst in insts)
         {
-            if (inst.operand == isPlayerMethodGetter)
+            if (isPlayerMethodGetter.Equals(inst.operand))
                 inst.operand = factionIsPlayer.Method;
 
             yield return inst;
@@ -464,7 +464,7 @@ static class RecacheColonistBelieverCountPatch
     {
         foreach (var inst in insts)
         {
-            if (inst.operand == allColonists)
+            if (allColonists.Equals(inst.operand))
                 inst.operand = AccessTools.Method(typeof(RecacheColonistBelieverCountPatch), nameof(ColonistsAllPlayerFactions));
             yield return inst;
         }
@@ -516,7 +516,7 @@ static class AnyPawnBlockingMapRemovalPatch
     {
         foreach (var inst in insts)
         {
-            if (inst.operand == isColonyMech)
+            if (isColonyMech.Equals(inst.operand))
                 inst.operand = AccessTools.Method(typeof(RecacheColonistBelieverCountPatch), nameof(RecacheColonistBelieverCountPatch.IsColonyMechAnyFaction));
 
             yield return inst;
@@ -557,10 +557,10 @@ static class IsValidColonyPawnPatch
     {
         foreach (var inst in insts)
         {
-            if (inst.operand == isColonist)
+            if (isColonist.Equals(inst.operand))
                 inst.operand = AccessTools.Method(typeof(RecacheColonistBelieverCountPatch), nameof(RecacheColonistBelieverCountPatch.IsColonistAnyFaction));
 
-            if (inst.operand == isColonySubhuman)
+            if (isColonySubhuman.Equals(inst.operand))
                 inst.operand = AccessTools.Method(typeof(RecacheColonistBelieverCountPatch), nameof(RecacheColonistBelieverCountPatch.IsColonySubhumanAnyFaction));
 
             yield return inst;
@@ -577,7 +577,7 @@ static class ValidatePawnPatch
     {
         foreach (var inst in insts)
         {
-            if (inst.operand == isFreeNonSlaveColonist)
+            if (isFreeNonSlaveColonist.Equals(inst.operand))
                 inst.operand = AccessTools.Method(typeof(ValidatePawnPatch), nameof(IsFreeNonSlaveColonistAnyFaction));
 
             yield return inst;
@@ -632,7 +632,7 @@ static class LetterStackReceiveSoundOnlyMyFaction
     {
         foreach (var inst in insts)
         {
-            if (inst.operand == PlayOneShotOnCamera)
+            if (PlayOneShotOnCamera.Equals(inst.operand))
                 yield return new CodeInstruction(
                     OpCodes.Call,
                     SymbolExtensions.GetMethodInfo((SoundDef s, Map m) => PlaySoundReplacement(s, m)));
@@ -661,7 +661,7 @@ static class ApparelWornGraphicPathGetterPatch
 
             // This instruction is part of wornGraphicPaths[thingIDNumber % wornGraphicPaths.Count]
             // The function makes sure the id is positive
-            if (inst.operand == thingIDNumberField)
+            if (thingIDNumberField.Equals(inst.operand))
                 yield return new CodeInstruction(OpCodes.Call,
                     AccessTools.Method(typeof(ApparelWornGraphicPathGetterPatch), nameof(MakeIdPositive)));
         }
@@ -721,7 +721,7 @@ static class CharacterCardUtilityDontDrawIdeoPlate
             yield return inst;
 
             // Don't draw the ideo plate while choosing starting pawns in multifaction
-            if (inst.operand == classicModeField)
+            if (classicModeField.Equals(inst.operand))
             {
                 yield return new CodeInstruction(OpCodes.Ldarg_2);
                 yield return new CodeInstruction(OpCodes.Call,

--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -421,7 +421,7 @@ static class StartingAnimalPatch
         {
             yield return inst;
 
-            if (playerFactionField.Equals(inst.operand))
+            if (inst.operand as MethodInfo == playerFactionField)
                 yield return new CodeInstruction(OpCodes.Call, factionOfPlayer.Method);
         }
     }
@@ -442,7 +442,7 @@ static class PawnIsColonistPatch
 
         foreach (var inst in insts)
         {
-            if (isPlayerMethodGetter.Equals(inst.operand))
+            if (inst.operand as MethodInfo == isPlayerMethodGetter)
                 inst.operand = factionIsPlayer.Method;
 
             yield return inst;
@@ -464,7 +464,7 @@ static class RecacheColonistBelieverCountPatch
     {
         foreach (var inst in insts)
         {
-            if (allColonists.Equals(inst.operand))
+            if (inst.operand as MethodInfo == allColonists)
                 inst.operand = AccessTools.Method(typeof(RecacheColonistBelieverCountPatch), nameof(ColonistsAllPlayerFactions));
             yield return inst;
         }
@@ -516,7 +516,7 @@ static class AnyPawnBlockingMapRemovalPatch
     {
         foreach (var inst in insts)
         {
-            if (isColonyMech.Equals(inst.operand))
+            if (inst.operand as MethodInfo == isColonyMech)
                 inst.operand = AccessTools.Method(typeof(RecacheColonistBelieverCountPatch), nameof(RecacheColonistBelieverCountPatch.IsColonyMechAnyFaction));
 
             yield return inst;
@@ -557,10 +557,10 @@ static class IsValidColonyPawnPatch
     {
         foreach (var inst in insts)
         {
-            if (isColonist.Equals(inst.operand))
+            if (inst.operand as MethodInfo == isColonist)
                 inst.operand = AccessTools.Method(typeof(RecacheColonistBelieverCountPatch), nameof(RecacheColonistBelieverCountPatch.IsColonistAnyFaction));
 
-            if (isColonySubhuman.Equals(inst.operand))
+            if (inst.operand as MethodInfo == isColonySubhuman)
                 inst.operand = AccessTools.Method(typeof(RecacheColonistBelieverCountPatch), nameof(RecacheColonistBelieverCountPatch.IsColonySubhumanAnyFaction));
 
             yield return inst;
@@ -577,7 +577,7 @@ static class ValidatePawnPatch
     {
         foreach (var inst in insts)
         {
-            if (isFreeNonSlaveColonist.Equals(inst.operand))
+            if (inst.operand as MethodInfo == isFreeNonSlaveColonist)
                 inst.operand = AccessTools.Method(typeof(ValidatePawnPatch), nameof(IsFreeNonSlaveColonistAnyFaction));
 
             yield return inst;
@@ -632,7 +632,7 @@ static class LetterStackReceiveSoundOnlyMyFaction
     {
         foreach (var inst in insts)
         {
-            if (PlayOneShotOnCamera.Equals(inst.operand))
+            if (inst.operand as MethodInfo == PlayOneShotOnCamera)
                 yield return new CodeInstruction(
                     OpCodes.Call,
                     SymbolExtensions.GetMethodInfo((SoundDef s, Map m) => PlaySoundReplacement(s, m)));
@@ -661,7 +661,7 @@ static class ApparelWornGraphicPathGetterPatch
 
             // This instruction is part of wornGraphicPaths[thingIDNumber % wornGraphicPaths.Count]
             // The function makes sure the id is positive
-            if (thingIDNumberField.Equals(inst.operand))
+            if (inst.operand as MethodInfo == thingIDNumberField)
                 yield return new CodeInstruction(OpCodes.Call,
                     AccessTools.Method(typeof(ApparelWornGraphicPathGetterPatch), nameof(MakeIdPositive)));
         }
@@ -721,7 +721,7 @@ static class CharacterCardUtilityDontDrawIdeoPlate
             yield return inst;
 
             // Don't draw the ideo plate while choosing starting pawns in multifaction
-            if (classicModeField.Equals(inst.operand))
+            if (inst.operand as MethodInfo == classicModeField)
             {
                 yield return new CodeInstruction(OpCodes.Ldarg_2);
                 yield return new CodeInstruction(OpCodes.Call,

--- a/Source/Client/Patches/AllGroupsPatch.cs
+++ b/Source/Client/Patches/AllGroupsPatch.cs
@@ -19,7 +19,7 @@ namespace Multiplayer.Client
 
             foreach (CodeInstruction inst in insts)
             {
-                if (inst.operand == AllGroups)
+                if (AllGroups.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_1).MoveLabelsFrom(inst);
                     yield return new CodeInstruction(OpCodes.Call, method);

--- a/Source/Client/Patches/AllGroupsPatch.cs
+++ b/Source/Client/Patches/AllGroupsPatch.cs
@@ -19,7 +19,7 @@ namespace Multiplayer.Client
 
             foreach (CodeInstruction inst in insts)
             {
-                if (AllGroups.Equals(inst.operand))
+                if (inst.operand as MethodInfo == AllGroups)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_1).MoveLabelsFrom(inst);
                     yield return new CodeInstruction(OpCodes.Call, method);

--- a/Source/Client/Patches/ArbiterPatches.cs
+++ b/Source/Client/Patches/ArbiterPatches.cs
@@ -43,7 +43,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (IsCreated.Equals(inst.operand))
+                if (inst.operand as MethodInfo == IsCreated)
                 {
                     yield return new CodeInstruction(OpCodes.Ldsfld, ArbiterField);
                     yield return new CodeInstruction(OpCodes.Or);

--- a/Source/Client/Patches/ArbiterPatches.cs
+++ b/Source/Client/Patches/ArbiterPatches.cs
@@ -43,7 +43,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.operand == IsCreated)
+                if (IsCreated.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldsfld, ArbiterField);
                     yield return new CodeInstruction(OpCodes.Or);

--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -76,7 +76,7 @@ namespace Multiplayer.Client.Patches
 
             for (int i = insts.Count - 1; i >= 0; i--)
             {
-                if (insts[i].operand == FirstOrDefault)
+                if (FirstOrDefault.Equals(insts[i].operand))
                     insts.Insert(
                        i + 1,
                        new CodeInstruction(OpCodes.Ldloc_1),
@@ -138,7 +138,7 @@ namespace Multiplayer.Client.Patches
             {
                 yield return inst;
 
-                if (inst.operand == CellRectContains)
+                if (CellRectContains.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldc_I4_1);
                     yield return new CodeInstruction(OpCodes.Or);
@@ -155,7 +155,7 @@ namespace Multiplayer.Client.Patches
             foreach (CodeInstruction inst in insts)
             {
                 yield return inst;
-                if (!found && inst.operand == cellsShuffledField)
+                if (!found && cellsShuffledField.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(CellsShufflePatchShared), nameof(ShouldShuffle)));
                     yield return new CodeInstruction(OpCodes.Not);
@@ -266,7 +266,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (inst.operand == AccessTools.PropertyGetter(typeof(ModLister), nameof(ModLister.BiotechInstalled)))
+                if (AccessTools.PropertyGetter(typeof(ModLister), nameof(ModLister.BiotechInstalled)).Equals(inst.operand))
                     inst.operand = AccessTools.PropertyGetter(typeof(ModsConfig), nameof(ModsConfig.BiotechActive));
                 yield return inst;
             }
@@ -302,7 +302,7 @@ namespace Multiplayer.Client.Patches
             foreach (var inst in insts)
             {
                 // Remove mutation of battleActive during saving which was a source of non-determinism
-                if (inst.opcode == OpCodes.Stfld && inst.operand == battleActiveField)
+                if (inst.opcode == OpCodes.Stfld && battleActiveField.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Pop);
                     yield return new CodeInstruction(OpCodes.Pop);
@@ -341,7 +341,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (inst.opcode == OpCodes.Stfld && inst.operand == queryTickField)
+                if (inst.opcode == OpCodes.Stfld && queryTickField.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldarg_1);
@@ -385,7 +385,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (inst.operand == clearMethod)
+                if (clearMethod.Equals(inst.operand))
                     yield return new CodeInstruction(OpCodes.Pop);
                 else
                     yield return inst;

--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -76,7 +76,7 @@ namespace Multiplayer.Client.Patches
 
             for (int i = insts.Count - 1; i >= 0; i--)
             {
-                if (FirstOrDefault.Equals(insts[i].operand))
+                if (insts[i].operand as MethodInfo == FirstOrDefault)
                     insts.Insert(
                        i + 1,
                        new CodeInstruction(OpCodes.Ldloc_1),
@@ -138,7 +138,7 @@ namespace Multiplayer.Client.Patches
             {
                 yield return inst;
 
-                if (CellRectContains.Equals(inst.operand))
+                if (inst.operand as MethodInfo == CellRectContains)
                 {
                     yield return new CodeInstruction(OpCodes.Ldc_I4_1);
                     yield return new CodeInstruction(OpCodes.Or);
@@ -155,7 +155,7 @@ namespace Multiplayer.Client.Patches
             foreach (CodeInstruction inst in insts)
             {
                 yield return inst;
-                if (!found && cellsShuffledField.Equals(inst.operand))
+                if (!found && inst.operand as MethodInfo == cellsShuffledField)
                 {
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(CellsShufflePatchShared), nameof(ShouldShuffle)));
                     yield return new CodeInstruction(OpCodes.Not);
@@ -266,7 +266,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (AccessTools.PropertyGetter(typeof(ModLister), nameof(ModLister.BiotechInstalled)).Equals(inst.operand))
+                if (inst.operand as MethodInfo == AccessTools.PropertyGetter(typeof(ModLister), nameof(ModLister.BiotechInstalled)))
                     inst.operand = AccessTools.PropertyGetter(typeof(ModsConfig), nameof(ModsConfig.BiotechActive));
                 yield return inst;
             }
@@ -302,7 +302,7 @@ namespace Multiplayer.Client.Patches
             foreach (var inst in insts)
             {
                 // Remove mutation of battleActive during saving which was a source of non-determinism
-                if (inst.opcode == OpCodes.Stfld && battleActiveField.Equals(inst.operand))
+                if (inst.opcode == OpCodes.Stfld && inst.operand as MethodInfo == battleActiveField)
                 {
                     yield return new CodeInstruction(OpCodes.Pop);
                     yield return new CodeInstruction(OpCodes.Pop);
@@ -341,7 +341,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (inst.opcode == OpCodes.Stfld && queryTickField.Equals(inst.operand))
+                if (inst.opcode == OpCodes.Stfld && inst.operand as MethodInfo == queryTickField)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldarg_1);
@@ -385,7 +385,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (clearMethod.Equals(inst.operand))
+                if (inst.operand as MethodInfo == clearMethod)
                     yield return new CodeInstruction(OpCodes.Pop);
                 else
                     yield return inst;

--- a/Source/Client/Patches/Feedback.cs
+++ b/Source/Client/Patches/Feedback.cs
@@ -121,7 +121,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (IsSelected.Equals(inst.operand))
+                if (inst.operand as MethodInfo == IsSelected)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Call, DeselectOnDespawnMethod);

--- a/Source/Client/Patches/Feedback.cs
+++ b/Source/Client/Patches/Feedback.cs
@@ -121,7 +121,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (inst.operand == IsSelected)
+                if (IsSelected.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Call, DeselectOnDespawnMethod);

--- a/Source/Client/Patches/HashCodes.cs
+++ b/Source/Client/Patches/HashCodes.cs
@@ -44,7 +44,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (Combine.Equals(inst.operand))
+                if (inst.operand as MethodInfo == Combine)
                     inst.operand = AccessTools.Method(typeof(PatchTargetInfoHashCodes), nameof(CombineHashes));
 
                 yield return inst;

--- a/Source/Client/Patches/HashCodes.cs
+++ b/Source/Client/Patches/HashCodes.cs
@@ -44,7 +44,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (inst.operand == Combine)
+                if (Combine.Equals(inst.operand))
                     inst.operand = AccessTools.Method(typeof(PatchTargetInfoHashCodes), nameof(CombineHashes));
 
                 yield return inst;

--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -37,7 +37,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.operand == FrameCountField)
+                if (FrameCountField.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Call, FrameCountReplacementMethod);

--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -37,7 +37,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (FrameCountField.Equals(inst.operand))
+                if (inst.operand as MethodInfo == FrameCountField)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Call, FrameCountReplacementMethod);

--- a/Source/Client/Patches/Seeds.cs
+++ b/Source/Client/Patches/Seeds.cs
@@ -121,7 +121,7 @@ namespace Multiplayer.Client
         {
             foreach (CodeInstruction inst in insts)
             {
-                if (Rot4GetRandom.Equals(inst.operand))
+                if (inst.operand as MethodInfo == Rot4GetRandom)
                 {
                     // Load newThing.thingIdNumber to the stack
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
@@ -137,7 +137,7 @@ namespace Multiplayer.Client
 
                 yield return inst;
 
-                if (Rot4GetRandom.Equals(inst.operand))
+                if (inst.operand as MethodInfo == Rot4GetRandom)
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Rand), nameof(Rand.PopState)));
             }
         }

--- a/Source/Client/Patches/Seeds.cs
+++ b/Source/Client/Patches/Seeds.cs
@@ -121,7 +121,7 @@ namespace Multiplayer.Client
         {
             foreach (CodeInstruction inst in insts)
             {
-                if (inst.operand == Rot4GetRandom)
+                if (Rot4GetRandom.Equals(inst.operand))
                 {
                     // Load newThing.thingIdNumber to the stack
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
@@ -137,7 +137,7 @@ namespace Multiplayer.Client
 
                 yield return inst;
 
-                if (inst.operand == Rot4GetRandom)
+                if (Rot4GetRandom.Equals(inst.operand))
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Rand), nameof(Rand.PopState)));
             }
         }

--- a/Source/Client/Persistent/ISwitchToMap.cs
+++ b/Source/Client/Persistent/ISwitchToMap.cs
@@ -19,7 +19,7 @@ namespace Multiplayer.Client
         {
             foreach (var inst in insts)
             {
-                if (inst.opcode == OpCodes.Ldfld && inst.operand == doCloseXField)
+                if (inst.opcode == OpCodes.Ldfld && doCloseXField.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0); // This window
                     yield return new CodeInstruction(OpCodes.Ldloc_0); // Window rect

--- a/Source/Client/Persistent/ISwitchToMap.cs
+++ b/Source/Client/Persistent/ISwitchToMap.cs
@@ -19,7 +19,7 @@ namespace Multiplayer.Client
         {
             foreach (var inst in insts)
             {
-                if (inst.opcode == OpCodes.Ldfld && doCloseXField.Equals(inst.operand))
+                if (inst.opcode == OpCodes.Ldfld && inst.operand as MethodInfo == doCloseXField)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0); // This window
                     yield return new CodeInstruction(OpCodes.Ldloc_0); // Window rect

--- a/Source/Client/Persistent/RitualPatches.cs
+++ b/Source/Client/Persistent/RitualPatches.cs
@@ -121,7 +121,7 @@ namespace Multiplayer.Client.Persistent
 
             foreach (var inst in list)
             {
-                if (inst.operand == listClear)
+                if (listClear.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Call,
                         AccessTools.Method(typeof(DontClearDialogBeginRitualCache), nameof(ShouldCancelCacheClear)));

--- a/Source/Client/Persistent/RitualPatches.cs
+++ b/Source/Client/Persistent/RitualPatches.cs
@@ -121,7 +121,7 @@ namespace Multiplayer.Client.Persistent
 
             foreach (var inst in list)
             {
-                if (listClear.Equals(inst.operand))
+                if (inst.operand as MethodInfo == listClear)
                 {
                     yield return new CodeInstruction(OpCodes.Call,
                         AccessTools.Method(typeof(DontClearDialogBeginRitualCache), nameof(ShouldCancelCacheClear)));

--- a/Source/Client/Persistent/Trading.cs
+++ b/Source/Client/Persistent/Trading.cs
@@ -781,7 +781,7 @@ namespace Multiplayer.Client
         {
             foreach (var inst in insts)
             {
-                if (AgeBiologicalFloat.Equals(inst.operand))
+                if (inst.operand as MethodInfo == AgeBiologicalFloat)
                 {
                     yield return new CodeInstruction(OpCodes.Callvirt, AgeBiologicalInt);
                     yield return new CodeInstruction(OpCodes.Conv_R4);

--- a/Source/Client/Persistent/Trading.cs
+++ b/Source/Client/Persistent/Trading.cs
@@ -781,7 +781,7 @@ namespace Multiplayer.Client
         {
             foreach (var inst in insts)
             {
-                if (inst.operand == AgeBiologicalFloat)
+                if (AgeBiologicalFloat.Equals(inst.operand))
                 {
                     yield return new CodeInstruction(OpCodes.Callvirt, AgeBiologicalInt);
                     yield return new CodeInstruction(OpCodes.Conv_R4);

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -462,7 +462,7 @@ namespace Multiplayer.Client
             foreach (var inst in insts)
             {
                 // this.plantCells.Add(t.Cell) => CompPlantable_AddCell(t.Cell, this)
-                if (inst.operand == typeof(List<IntVec3>).GetMethod("Add"))
+                if (typeof(List<IntVec3>).GetMethod("Add").Equals(inst.operand))
                 {
                     // Load this
                     yield return new CodeInstruction(OpCodes.Ldarg_0);

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -5,6 +5,7 @@ using RimWorld;
 using RimWorld.Planet;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using Multiplayer.Client.Util;
 using Verse;
@@ -462,7 +463,7 @@ namespace Multiplayer.Client
             foreach (var inst in insts)
             {
                 // this.plantCells.Add(t.Cell) => CompPlantable_AddCell(t.Cell, this)
-                if (typeof(List<IntVec3>).GetMethod("Add").Equals(inst.operand))
+                if (inst.operand as MethodInfo == typeof(List<IntVec3>).GetMethod("Add"))
                 {
                     // Load this
                     yield return new CodeInstruction(OpCodes.Ldarg_0);

--- a/Source/Client/Windows/ModCompatWindow.cs
+++ b/Source/Client/Windows/ModCompatWindow.cs
@@ -412,13 +412,13 @@ namespace Multiplayer.Client
 
             var endGroupMethod = AccessTools.Method(typeof(Widgets), nameof(Widgets.EndGroup));
 
-            var saveLoadListString = list.First(i => i.operand == "SaveLoadList");
+            var saveLoadListString = list.First(i => "SaveLoadList".Equals(i.operand));
             // WidgetRow is not stored as a local, only staying on stack. We need to duplicate it before its last use so we can use it as well.
             var dupInst = new CodeInstruction(OpCodes.Dup);
             saveLoadListString.MoveLabelsTo(dupInst);
             list.Insert(list.IndexOf(saveLoadListString), dupInst);
 
-            var endGroupCall = list.First(i => i.operand == endGroupMethod);
+            var endGroupCall = list.First(i => endGroupMethod.Equals(i.operand));
             var ldarg = new CodeInstruction(OpCodes.Ldarg_0);
             endGroupCall.MoveLabelsTo(ldarg);
 

--- a/Source/Client/Windows/ModCompatWindow.cs
+++ b/Source/Client/Windows/ModCompatWindow.cs
@@ -412,13 +412,13 @@ namespace Multiplayer.Client
 
             var endGroupMethod = AccessTools.Method(typeof(Widgets), nameof(Widgets.EndGroup));
 
-            var saveLoadListString = list.First(i => "SaveLoadList".Equals(i.operand));
+            var saveLoadListString = list.First(i => i.operand as string == "SaveLoadList");
             // WidgetRow is not stored as a local, only staying on stack. We need to duplicate it before its last use so we can use it as well.
             var dupInst = new CodeInstruction(OpCodes.Dup);
             saveLoadListString.MoveLabelsTo(dupInst);
             list.Insert(list.IndexOf(saveLoadListString), dupInst);
 
-            var endGroupCall = list.First(i => endGroupMethod.Equals(i.operand));
+            var endGroupCall = list.First(i => i.operand as MethodInfo == endGroupMethod);
             var ldarg = new CodeInstruction(OpCodes.Ldarg_0);
             endGroupCall.MoveLabelsTo(ldarg);
 


### PR DESCRIPTION
Feel free to reject, but the warnings are triggering me.  This PR resolves 41 compiler warnings.

[CS0252](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0252) warns:
> warning CS0252: Possible unintended reference comparison; to get a value comparison, cast the left hand side to type 'type'

Basically we could inadvertently be doing reference checks instead of value checks. The compiler suggests casting to a concrete class (since most of these are generic `object`s).  But that introduces new risks, and complicates the checks. Switching to using `.Equals` on the known concrete class will, at worst do the same reference check, and at best do an value check.  Plus it has the added bonus of clearing the compiler warnings.

I plan to resolve a bunch more warnings, but I figured splitting them up by warning type may be more likely to get at least some of them merged. I tried to prevent as many auto-format changes as possible (to prevent overcomplicating the changes), but a few whitespace ones slipped through.