### PR TITLE
Sync "Drop pod raid at location"

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncTimeComp.cs
@@ -261,6 +261,7 @@ namespace Multiplayer.Client
 
             executingCmdMap = map;
             TickPatch.currentExecutingCmdIssuedBySelf = cmd.issuedBySelf && !TickPatch.Simulating;
+            TickPatch.currentExecutingCmdType = cmdType;
 
             PreContext();
             map.PushFaction(cmd.GetFaction());
@@ -326,6 +327,7 @@ namespace Multiplayer.Client
                 PostContext();
 
                 TickPatch.currentExecutingCmdIssuedBySelf = false;
+                TickPatch.currentExecutingCmdType = null;
                 executingCmdMap = null;
 
                 if (!keepTheMap)

--- a/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
@@ -18,7 +18,6 @@ namespace Multiplayer.Client.AsyncTime;
 public class AsyncWorldTimeComp : IExposable, ITickable
 {
     public static bool tickingWorld;
-    public static bool executingCmdWorld;
     private TimeSpeed timeSpeedInt;
 
     public float TimeToTickThrough { get; set; }
@@ -172,8 +171,8 @@ public class AsyncWorldTimeComp : IExposable, ITickable
         LoggingByteReader data = new LoggingByteReader(cmd.data);
         data.Log.Node($"{cmdType} Global");
 
-        executingCmdWorld = true;
         TickPatch.currentExecutingCmdIssuedBySelf = cmd.issuedBySelf && !TickPatch.Simulating;
+        TickPatch.currentExecutingCmdType = cmdType;
 
         PreContext();
         FactionExtensions.PushFaction(null, cmd.GetFaction());
@@ -252,7 +251,7 @@ public class AsyncWorldTimeComp : IExposable, ITickable
             FactionExtensions.PopFaction();
             PostContext();
             TickPatch.currentExecutingCmdIssuedBySelf = false;
-            executingCmdWorld = false;
+            TickPatch.currentExecutingCmdType = null;
 
             Multiplayer.game.sync.TryAddCommandRandomState(randState);
 

--- a/Source/Client/Debug/DebugSync.cs
+++ b/Source/Client/Debug/DebugSync.cs
@@ -249,7 +249,7 @@ namespace Multiplayer.Client
         {
             if (Multiplayer.Client == null) return true;
             if (!Multiplayer.GameComp.debugMode) return true;
-            if (!ActionIsCreatedInDebugActionsIncidents(action)) return true;
+            if (!Multiplayer.ExecutingCmdDebugTool) return true;
             if (!DebugSync.ShouldHandle()) return true;
 
             DebugSync.CurrentPlayerState.currentData = action;
@@ -263,11 +263,6 @@ namespace Multiplayer.Client
             };
 
             return true;
-        }
-
-        private static bool ActionIsCreatedInDebugActionsIncidents(Action<LocalTargetInfo> action)
-        {
-            return action?.Method.DeclaringType?.DeclaringType == typeof(DebugActionsIncidents);
         }
     }
 

--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -49,7 +49,8 @@ namespace Multiplayer.Client
 
         public static Faction RealPlayerFaction => Client != null ? game.RealPlayerFaction : Faction.OfPlayer;
 
-        public static bool ExecutingCmds => AsyncWorldTimeComp.executingCmdWorld || AsyncTimeComp.executingCmdMap != null;
+        public static bool ExecutingCmds => TickPatch.currentExecutingCmdType != null;
+        public static bool ExecutingCmdDebugTool => TickPatch.currentExecutingCmdType == CommandType.DebugTools;
         public static bool Ticking => AsyncWorldTimeComp.tickingWorld || AsyncTimeComp.tickingMap != null || ConstantTicker.ticking;
         public static Map MapContext => AsyncTimeComp.tickingMap ?? AsyncTimeComp.executingCmdMap;
 

--- a/Source/Client/Patches/TickPatch.cs
+++ b/Source/Client/Patches/TickPatch.cs
@@ -21,6 +21,7 @@ namespace Multiplayer.Client
         public static int tickUntil; // Ticks < tickUntil can be simulated
         public static int workTicks;
         public static bool currentExecutingCmdIssuedBySelf;
+        public static CommandType? currentExecutingCmdType;
         public static bool serverFrozen;
         public static int frozenAt;
 


### PR DESCRIPTION
Label: 1.6, fix

### Additional Notes on the "Drop pod raid at location..." Debug Option:

This debug option was introduced with **RimWorld 1.6**.

While testing this the PR, I encountered consistent crashes when setting the raid points above approximately **750**. This issue occurs even in an **unmodded** version of the game and has been confirmed by **SirWilliams**.

I haven’t yet found an existing bug report about this on the RimWorld Discord, though I didn’t search extensively. If no report surfaces, I plan to report the issue myself.

Reproduce mentioned crash:
- Rimworld 1.6
- No mods - only core
- Dev mode enabled
- Dev Quicktest
- Open Dev Tools
- Drop pod raid at location...
- Ancients(Ancients) [NO]
- 1000 pt
- 3 tiles

### PR

This PR fixes #556 and synchronizes the final step in the "Drop pod raid at location..." debug option, which uses the Targeter.BeginTarget method. While this method doesn't appear to be used elsewhere in the debug system, it is invoked by other parts of the game. Essentially, it takes an Action and executes it when the user clicks on a target.

I implemented the fix in a similar fashion to the other 'DebugSource' enums.

The main challenge I faced was ensuring that my prefix runs only when `Targeter.BeginTarget` is invoked from within the `DebugActionsIncidents.ExecuteDropPodRaidAtLocation` method - or at the very least, from somewhere within the `DebugActionsIncidents` class. To achieve this, I used a bit of reflection to check in which class the action was created via `ActionIsCreatedInDebugActionsIncidents` (shown below). I'm not entirely sure if this is an acceptable approach. 

**Feedback on better alternatives is welcome.**

```
private static bool ActionIsCreatedInDebugActionsIncidents(Action<LocalTargetInfo> action)
{
    return action?.Method.DeclaringType?.DeclaringType == typeof(DebugActionsIncidents);
}
```

### Test

The fix was tested primarily on dev
- verified functionality on both **host and client**.
- Confirmed it works when **both host and client are at the final step of the debug tree** and perform the mouse click.
- The guard using **reflection** was tested by manually calling `Targeter.BeginTarget` via `DebugSync.ReadCmd`.  I was not able to trigger this path naturally through regular gameplay in a reasonable amount of time.