### PR TITLE
Clear warnings about conflicting types

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,12 +1,17 @@
 root = true
- 
+
 [*]
 charset = utf-8
 indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
- 
+
 [*.{cs,js,ts,sql}]
 indent_size = 4
 end_of_line = crlf
+
+[*.cs]
+# The conflicting classes provided in this assembly are essentially polyfills
+# of .NET Core features to allow running on .NET Framework.
+dotnet_diagnostic.cs0436.severity = none


### PR DESCRIPTION
This resolves 4 compiler warnings.

Based off [this comment](https://github.com/rwmt/Multiplayer/pull/577#issuecomment-3089864522), CS0436 looks like this:

> `\Source\Common\Util\Endpoints.cs(10,66)`: warning CS0436: The type `NotNullWhenAttribute` in `\Source\Common\Util\CompilerTypes.cs` conflicts with the imported type `NotNullWhenAttribute` in `mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089`. Using the type defined in `\Source\Common\Util\CompilerTypes.cs`.

Basically some newer features from .NET Core have been replicated in this codebase to support .NET Framework.  In other languages we'd call this a [polyfill](https://en.wikipedia.org/wiki/Polyfill_(programming)).

It turns out to be harder to disable this in-code than expected, because the compiler warns on a generated file:
> `\Source\MultiplayerLoader\obj\Debug\MultiplayerLoader.AssemblyInfo.cs(13,44)`: warning CS0436: The type 'IgnoresAccessChecksToAttribute'...

```cs
//------------------------------------------------------------------------------
// <auto-generated>
//     This code was generated by a tool.
//
//     Changes to this file may cause incorrect behavior and will be lost if
//     the code is regenerated.
// </auto-generated>
//------------------------------------------------------------------------------

using System;
using System.Reflection;

// The class IgnoresAccessChecksToAttribute triggers this warning
[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute("0Harmony")]
[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute("Assembly-CSharp")]
```
And the generated file is... regenerated on each build.  Changes do not persist.

So instead of suppressing on a case-by-case basis (which was already a flimsy solution), we can simply [suppress this warning](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings) in `.editorconfig`.

There is also some serious irony that the file specifying that trailing whitespace should be eliminated contained trailing whitespace:  
<img width="907" height="423" alt="image" src="https://github.com/user-attachments/assets/d78ae30c-97b6-45b4-a10d-325199ef5e72" />
