### PR TITLE
Extended support for fragmented packets and handling them. Improved download dialog

### DIFF
--- a/Source/Client/Networking/NetworkingSteam.cs
+++ b/Source/Client/Networking/NetworkingSteam.cs
@@ -53,13 +53,9 @@ namespace Multiplayer.Client.Networking
         }
     }
 
-    public class SteamClientConn : SteamBaseConn
+    public class SteamClientConn(CSteamID remoteId) : SteamBaseConn(remoteId, RandomChannelId(), 0)
     {
         static ushort RandomChannelId() => (ushort)new Random().Next();
-
-        public SteamClientConn(CSteamID remoteId) : base(remoteId, RandomChannelId(), 0)
-        {
-        }
 
         protected override void HandleReceiveMsg(int msgId, int fragState, ByteReader reader, bool reliable)
         {
@@ -91,12 +87,8 @@ namespace Multiplayer.Client.Networking
         }
     }
 
-    public class SteamServerConn : SteamBaseConn
+    public class SteamServerConn(CSteamID remoteId, ushort clientChannel) : SteamBaseConn(remoteId, 0, clientChannel)
     {
-        public SteamServerConn(CSteamID remoteId, ushort clientChannel) : base(remoteId, 0, clientChannel)
-        {
-        }
-
         protected override void HandleReceiveMsg(int msgId, int fragState, ByteReader reader, bool reliable)
         {
             if (msgId == (int)Packets.Special_Steam_Disconnect)

--- a/Source/Client/Networking/State/ClientLoadingState.cs
+++ b/Source/Client/Networking/State/ClientLoadingState.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Ionic.Zlib;
 using Multiplayer.Client.Saving;
@@ -16,13 +17,41 @@ public enum LoadingState
 public class ClientLoadingState(ConnectionBase connection) : ClientBaseState(connection)
 {
     public LoadingState subState = LoadingState.Waiting;
+    public uint WorldExpectedSize { get; private set; }
+    public uint WorldReceivedSize { get; private set; }
+    public float DownloadProgress => (float)WorldReceivedSize / WorldExpectedSize;
+    public int DownloadProgressPercent => (int)(DownloadProgress * 100);
+    public int DownloadSpeedKBps
+    {
+        get
+        {
+            if (downloadCheckpoints.Count == 0) return -1;
+            var firstCheckpoint = downloadCheckpoints.First();
+            var lastCheckpoint = downloadCheckpoints.Last();
+            var timeTakenMs = Utils.MillisNow - firstCheckpoint.Item1;
+            var timeTakenSecs = Math.Max(1, timeTakenMs / 1000);
+            var downloadedBytes = lastCheckpoint.Item2 - firstCheckpoint.Item2;
+            return (int)(downloadedBytes / 1000 / timeTakenSecs);
+        }
+    }
 
+    private List<(long, uint)> downloadCheckpoints = new(capacity: 64);
 
     [PacketHandler(Packets.Server_WorldDataStart)]
     public void HandleWorldDataStart(ByteReader data)
     {
         subState = LoadingState.Downloading;
         connection.Lenient = false; // Lenient is set while rejoining
+    }
+
+    [FragmentedPacketHandler(Packets.Server_WorldData)]
+    public void HandleWorldDataFragment(FragmentedPacket packet)
+    {
+        WorldExpectedSize = packet.ExpectedSize;
+        WorldReceivedSize = packet.ReceivedSize;
+        if (downloadCheckpoints.Count == downloadCheckpoints.Capacity)
+            downloadCheckpoints.RemoveAt(0);
+        downloadCheckpoints.Add((Utils.MillisNow, packet.ReceivedSize));
     }
 
     [PacketHandler(Packets.Server_WorldData, allowFragmented: true)]

--- a/Source/Client/Networking/State/ClientLoadingState.cs
+++ b/Source/Client/Networking/State/ClientLoadingState.cs
@@ -13,13 +13,10 @@ public enum LoadingState
     Downloading
 }
 
-public class ClientLoadingState : ClientBaseState
+public class ClientLoadingState(ConnectionBase connection) : ClientBaseState(connection)
 {
     public LoadingState subState = LoadingState.Waiting;
 
-    public ClientLoadingState(ConnectionBase connection) : base(connection)
-    {
-    }
 
     [PacketHandler(Packets.Server_WorldDataStart)]
     public void HandleWorldDataStart(ByteReader data)

--- a/Source/Client/Windows/ConnectingWindow.cs
+++ b/Source/Client/Windows/ConnectingWindow.cs
@@ -41,25 +41,75 @@ namespace Multiplayer.Client
         {
             string label;
 
-            if (Multiplayer.Client?.StateObj is ClientLoadingState { subState: LoadingState.Waiting })
-                label = "MpWaitingForGameData".Translate() + MpUI.FixedEllipsis();
-            else if (Multiplayer.Client?.StateObj is ClientLoadingState { subState: LoadingState.Downloading })
-                label = "MpDownloading".Translate(Multiplayer.Client.FragmentProgress);
-            else
-                label = result ?? (ConnectingString + MpUI.FixedEllipsis());
+            switch (Multiplayer.Client?.StateObj)
+            {
+                case ClientLoadingState { subState: LoadingState.Waiting }:
+                    label = "MpWaitingForGameData".Translate() + MpUI.FixedEllipsis();
+                    break;
+                case ClientLoadingState { subState: LoadingState.Downloading, WorldExpectedSize: 0 } state:
+                    label = "MpDownloading".Translate();
+                    label += $"\n{state.WorldReceivedSize / 1000}KB";
+                    break;
+                case ClientLoadingState { subState: LoadingState.Downloading } state:
+                    label = "MpDownloading".Translate() + $" ({state.DownloadProgressPercent}%)";
+                    var leftToDownloadKBps = (state.WorldExpectedSize - state.WorldReceivedSize) / 1000;
+                    if (state.DownloadSpeedKBps != 0)
+                    {
+                        var timeLeftSecs = leftToDownloadKBps / state.DownloadSpeedKBps;
+                        label +=
+                            $"\n{timeLeftSecs}s – ";
+                    }
+                    else
+                        label += "\n";
+
+                    label +=
+                        $"{state.WorldReceivedSize / 1000}/{state.WorldExpectedSize / 1000} KB ({state.DownloadSpeedKBps} KB/s)";
+                    break;
+                default:
+                    label = result ?? (ConnectingString + MpUI.FixedEllipsis());
+                    break;
+            }
 
             const float buttonHeight = 40f;
             const float buttonWidth = 120f;
 
-            Rect textRect = inRect;
-            textRect.yMax -= (buttonHeight + 10f);
-            Text.Anchor = TextAnchor.MiddleCenter;
+            var isDownloading = Multiplayer.Client?.StateObj is ClientLoadingState { subState: LoadingState.Downloading };
 
+            Rect textRect = new Rect(inRect);
+            if (isDownloading)
+            {
+                var textSize = Text.CalcSize(label);
+                textRect.height = textSize.y;
+            } else
+                textRect.height = 60f;
+
+            Text.Anchor = TextAnchor.MiddleCenter;
             Widgets.Label(textRect, label);
             Text.Anchor = TextAnchor.UpperLeft;
 
-            Rect buttonRect = new Rect((inRect.width - buttonWidth) / 2f, inRect.height - buttonHeight - 10f, buttonWidth, buttonHeight);
-            if (Widgets.ButtonText(buttonRect, "CancelButton".Translate(), true, false, true))
+            Rect buttonRect = new Rect((inRect.width - buttonWidth) / 2f, inRect.yMax - buttonHeight - 10f, buttonWidth, buttonHeight);
+            if (Multiplayer.Client?.StateObj is ClientLoadingState { subState: LoadingState.Downloading } state2)
+            {
+                Rect progressBarRect = new Rect(inRect)
+                {
+                    y = textRect.yMax + 10f,
+                    height = 30f
+                };
+                buttonRect.y = progressBarRect.yMax + 10f;
+                buttonRect.height = buttonHeight;
+                var oldHeight = inRect.height;
+                inRect.yMax = buttonRect.yMax + 10f;
+                windowRect.height += inRect.height - oldHeight;
+
+                Widgets.FillableBar(progressBarRect, state2.DownloadProgress, Widgets.BarFullTexHor,
+                    Widgets.DefaultBarBgTex, doBorder: true);
+            }
+            else
+            {
+                windowRect.height = InitialSize.y;
+            }
+
+            if (Widgets.ButtonText(buttonRect, "CancelButton".Translate(), true, false))
             {
                 Close();
             }

--- a/Source/Client/Windows/ConnectingWindow.cs
+++ b/Source/Client/Windows/ConnectingWindow.cs
@@ -82,31 +82,18 @@ namespace Multiplayer.Client
         protected override string ConnectingString => "MpJoining".Translate();
     }
 
-    public class ConnectingWindow : BaseConnectingWindow
+    public class ConnectingWindow(string address, int port) : BaseConnectingWindow
     {
         protected override string ConnectingString =>
             string.Format("MpConnectingTo".Translate("{0}", port), address);
-
-        private string address;
-        private int port;
-
-        public ConnectingWindow(string address, int port)
-        {
-            this.address = address;
-            this.port = port;
-        }
     }
 
-    public class SteamConnectingWindow : BaseConnectingWindow
+    public class SteamConnectingWindow(CSteamID hostId) : BaseConnectingWindow
     {
-        protected override string ConnectingString => (hostUsername.NullOrEmpty() ? "" : $"{"MpSteamConnectingTo".Translate(hostUsername)}\n") + "MpSteamConnectingWaiting".Translate();
+        protected override string ConnectingString =>
+            (hostUsername.NullOrEmpty() ? "" : $"{"MpSteamConnectingTo".Translate(hostUsername)}\n") +
+            "MpSteamConnectingWaiting".Translate();
 
-        public string hostUsername;
-
-        public SteamConnectingWindow(CSteamID hostId)
-        {
-            hostUsername = SteamFriends.GetFriendPersonaName(hostId);
-        }
+        public string hostUsername = SteamFriends.GetFriendPersonaName(hostId);
     }
-
 }

--- a/Source/Common/ByteReader.cs
+++ b/Source/Common/ByteReader.cs
@@ -8,11 +8,10 @@ namespace Multiplayer.Common
         const int DefaultMaxStringLen = 32767;
 
         private readonly byte[] array;
-        private int index;
         public object? context;
 
         public int Length => array.Length;
-        public int Position => index;
+        public int Position { get; private set; }
         public int Left => Length - Position;
 
         public ByteReader(byte[] array)
@@ -20,7 +19,7 @@ namespace Multiplayer.Common
             this.array = array;
         }
 
-        public virtual byte PeekByte() => array[index];
+        public virtual byte PeekByte() => array[Position];
 
         public virtual byte ReadByte() => array[IncrementIndex(1)];
 
@@ -54,8 +53,8 @@ namespace Multiplayer.Common
             if (bytes > maxLen)
                 throw new ReaderException($"String too long ({bytes}>{maxLen})");
 
-            string result = Encoding.UTF8.GetString(array, index, bytes);
-            index += bytes;
+            string result = Encoding.UTF8.GetString(array, Position, bytes);
+            Position += bytes;
 
             return result;
         }
@@ -69,8 +68,8 @@ namespace Multiplayer.Common
             if (bytes > maxLen)
                 throw new ReaderException($"String too long ({bytes}>{maxLen})");
 
-            string result = Encoding.UTF8.GetString(array, index, bytes);
-            index += bytes;
+            string result = Encoding.UTF8.GetString(array, Position, bytes);
+            Position += bytes;
 
             return result;
         }
@@ -182,22 +181,17 @@ namespace Multiplayer.Common
 
         private int IncrementIndex(int size)
         {
-            int i = index;
-            index += size;
+            int i = Position;
+            Position += size;
             return i;
         }
 
         public void Seek(int position)
         {
-            index = position;
+            Position = position;
         }
     }
 
-    public class ReaderException : Exception
-    {
-        public ReaderException(string msg) : base(msg)
-        {
-        }
-    }
+    public class ReaderException(string msg) : Exception(msg);
 
 }

--- a/Source/Common/ByteReader.cs
+++ b/Source/Common/ByteReader.cs
@@ -190,6 +190,11 @@ namespace Multiplayer.Common
         {
             Position = position;
         }
+
+        internal byte[] GetBuffer()
+        {
+            return array;
+        }
     }
 
     public class ReaderException(string msg) : Exception(msg);

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -149,16 +149,6 @@ namespace Multiplayer.Common
         private const int MaxFragmentedPackets = 1;
         private readonly List<(/* fragId */ byte, FragmentedPacket)> fragments = [];
 
-        public int FragmentProgress
-        {
-            get
-            {
-                if (fragments.Count == 0) return 0;
-                var (_, fragPacket) = fragments[0];
-                return (int)(fragPacket.ReceivedSize * 100 / fragPacket.ExpectedSize);
-            }
-        }
-
         protected virtual void HandleReceiveMsg(int msgId, int fragState, ByteReader reader, bool reliable)
         {
             if (msgId is < 0 or >= (int)Packets.Count)

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Multiplayer.Common
 {
@@ -11,6 +12,8 @@ namespace Multiplayer.Common
 
         public ConnectionStateEnum State { get; private set; }
         public MpConnectionState? StateObj { get; private set; }
+        // If lenient is set, reliable packets without handlers are ignored instead of throwing an exception.
+        // This is set during rejoining and is usually caused by connection state mismatch.
         public bool Lenient { get; set; }
 
         public T? GetState<T>() where T : MpConnectionState => (T?)StateObj;
@@ -45,8 +48,8 @@ namespace Multiplayer.Common
             if (State == ConnectionStateEnum.Disconnected)
                 return;
 
-            if (message.Length > FragmentSize)
-                throw new PacketSendException($"Packet {id} too big for sending ({message.Length}>{FragmentSize})");
+            if (message.Length > MaxSinglePacketSize)
+                throw new PacketSendException($"Packet {id} too big for sending ({message.Length}>{MaxSinglePacketSize})");
 
             byte[] full = new byte[1 + message.Length];
             full[0] = (byte)(Convert.ToByte(id) & 0x3F);
@@ -56,12 +59,17 @@ namespace Multiplayer.Common
         }
 
         // Steam doesn't like messages bigger than a megabyte
-        public const int FragmentSize = 65_536;
+        public const int MaxSinglePacketSize = 65_536;
+        // We can send a single packet up to MaxSinglePacketSize but when specifically sending a fragmented packet,
+        // use smaller sizes so that we have more control over them.
+        public const int MaxFragmentPacketSize = 1024;
         public const int MaxPacketSize = 33_554_432;
 
         private const int FragNone = 0x0;
         private const int FragMore = 0x40;
-        private const int FragEnd = 0x80;
+        private const int FragEnd  = 0x80;
+
+        private byte sendFragId;
 
         // All fragmented packets need to be sent from the same thread
         public void SendFragmented(Packets id, byte[] message)
@@ -69,25 +77,48 @@ namespace Multiplayer.Common
             if (State == ConnectionStateEnum.Disconnected)
                 return;
 
+            // +1 for Send metadata's overhead
+            if (message.Length + 1 <= MaxFragmentPacketSize)
+            {
+                Send(id, message);
+                return;
+            }
+
+            var fragId = sendFragId++;
+            // every packet has an additional 2 bytes of overhead
+            const int maxFragmentSize = MaxFragmentPacketSize - 2;
+            // the first packet has an additional 6 bytes of overhead
+            var totalLength = message.Length + 6;
+            // Divide rounding up
+            var fragParts = (totalLength + maxFragmentSize - 1) / maxFragmentSize;
             int read = 0;
+            var writer = new ByteWriter(MaxFragmentPacketSize);
             while (read < message.Length)
             {
-                int len = Math.Min(FragmentSize, message.Length - read);
+                // 1st packet contains 6 bytes of extra metadata.
+                int len = read == 0
+                    ? Math.Min(maxFragmentSize - 6, message.Length - read)
+                    : Math.Min(maxFragmentSize, message.Length - read);
                 int fragState = (read + len >= message.Length) ? FragEnd : FragMore;
                 byte headerByte = (byte)((Convert.ToByte(id) & 0x3F) | fragState);
 
-                var writer = new ByteWriter(1 + 4 + len);
-
                 // Write the packet id and fragment state: MORE or END
                 writer.WriteByte(headerByte);
+                writer.WriteByte(fragId);
 
                 // Send the message length with the first packet
-                if (read == 0) writer.WriteInt32(message.Length);
+                if (read == 0)
+                {
+                    writer.WriteUShort(Convert.ToUInt16(fragParts));
+                    writer.WriteUInt32(Convert.ToUInt32(message.Length));
+                }
 
                 // Copy the message fragment
                 writer.WriteFrom(message, read, len);
 
-                SendRaw(writer.ToArray());
+                // SendRaw copies this data so we can freely clear the writer after it executes.
+                SendRaw(writer.ToArray(), reliable: true);
+                writer.SetLength(0);
 
                 read += len;
             }
@@ -115,10 +146,18 @@ namespace Multiplayer.Common
             HandleReceiveMsg(msgId, fragState, data, reliable);
         }
 
-        private ByteWriter? fragmented;
-        private int fullSize; // Only for UI
+        private const int MaxFragmentedPackets = 1;
+        private readonly List<(/* fragId */ byte, FragmentedPacket)> fragments = [];
 
-        public int FragmentProgress => (fragmented?.Position * 100 / fullSize) ?? 0;
+        public int FragmentProgress
+        {
+            get
+            {
+                if (fragments.Count == 0) return 0;
+                var (_, fragPacket) = fragments[0];
+                return (int)(fragPacket.ReceivedSize * 100 / fragPacket.ExpectedSize);
+            }
+        }
 
         protected virtual void HandleReceiveMsg(int msgId, int fragState, ByteReader reader, bool reliable)
         {
@@ -126,45 +165,70 @@ namespace Multiplayer.Common
                 throw new PacketReadException($"Bad packet id {msgId}");
 
             Packets packetType = (Packets)msgId;
-            ServerLog.Verbose($"Received packet {this}: {packetType}");
+            if (reader.Left > MaxSinglePacketSize)
+                throw new PacketReadException($"Packet {packetType} too big {reader.Left}>{MaxSinglePacketSize}");
 
             var handler = StateObj?.GetPacketHandler(packetType);
             if (handler == null)
             {
                 if (reliable && !Lenient)
                     throw new PacketReadException($"No handler for packet {packetType} in state {State}");
-
+                ServerLog.Error($"No handler for packet {packetType} in state {State}");
                 return;
             }
 
-            if (fragState != FragNone && fragmented == null)
-                fullSize = reader.ReadInt32();
+            if (fragState == FragNone) handler.Method(StateObj, reader);
+            else HandleReceiveFragment(reader, packetType, handler);
+        }
 
-            if (reader.Left > FragmentSize)
-                throw new PacketReadException($"Packet {packetType} too big {reader.Left}>{FragmentSize}");
+        private void HandleReceiveFragment(ByteReader reader, Packets packetType, PacketHandlerInfo handler)
+        {
+            if (!handler.Fragment) throw new PacketReadException($"Packet {packetType} can't be fragmented");
+            if (reader.Left > MaxFragmentPacketSize)
+                throw new PacketReadException($"Packet fragment {packetType} too big {reader.Left}>{MaxFragmentPacketSize}");
 
-            if (fragState == FragNone)
+            var fragId = reader.ReadByte();
+            var fragIndex = fragments.FindIndex(frag => frag.Item1 == fragId);
+            FragmentedPacket fragPacket;
+            if (fragIndex == -1)
             {
-                handler.Method.Invoke(StateObj, reader);
-            }
-            else if (!handler.Fragment)
-            {
-                throw new PacketReadException($"Packet {packetType} can't be fragmented");
+                if (fragments.Count >= MaxFragmentedPackets)
+                    throw new PacketReadException(
+                        $"High number of fragmented packets at once! {fragments.Count}/{MaxFragmentedPackets}. This will likely cause issues. Dropping the just received fragmented packet (packet type: {packetType}, fragment id: {fragId}).");
+
+                var expectedParts = reader.ReadUShort();
+                var expectedSize = reader.ReadUInt32();
+                if (expectedParts < 2)
+                    ServerLog.Error($"Received fragmented packet with only {expectedParts} expected parts (packet type: {packetType}, fragment id: {fragId}, expected size: {expectedSize}).");
+                if (expectedSize > MaxPacketSize)
+                    throw new PacketReadException($"Full packet {packetType} too big {expectedSize}>{MaxPacketSize}");
+
+                fragPacket = FragmentedPacket.Create(packetType, expectedParts, expectedSize);
+                fragIndex = fragments.Count;
+                fragments.Add((fragId, fragPacket));
             }
             else
+                (_, fragPacket) = fragments[fragIndex];
+
+            if (fragPacket.Id != packetType)
+                throw new PacketReadException(
+                    $"Received fragment part with different packet id! {fragPacket.Id} != {packetType}");
+
+            fragPacket.Data.Write(reader.GetBuffer(), reader.Position, reader.Left);
+            fragPacket.ReceivedSize += Convert.ToUInt32(reader.Left);
+            fragPacket.ReceivedPartsCount++;
+
+            if (fragPacket.ReceivedPartsCount < fragPacket.ExpectedPartsCount)
             {
-                fragmented ??= new ByteWriter(reader.Left);
-                fragmented.WriteRaw(reader.ReadRaw(reader.Left));
-
-                if (fragmented.Position > MaxPacketSize)
-                    throw new PacketReadException($"Full packet {packetType} too big {fragmented.Position}>{MaxPacketSize}");
-
-                if (fragState == FragEnd)
-                {
-                    handler.Method.Invoke(StateObj, new ByteReader(fragmented.ToArray()));
-                    fragmented = null;
-                }
+                handler.FragmentHandler?.Invoke(StateObj, fragPacket);
+                return;
             }
+
+            if (fragPacket.ReceivedSize != fragPacket.ExpectedSize)
+                throw new PacketReadException($"Fragmented packet {packetType} (fragId {fragId}) recombined with different than expected size: {fragPacket.ReceivedSize} != {fragPacket.ExpectedSize}");
+
+            fragments.RemoveAt(fragIndex);
+            handler.Method(StateObj, new ByteReader(fragPacket.Data.GetBuffer()));
         }
 
         public abstract void Close(MpDisconnectReason reason, byte[]? data = null);

--- a/Source/Common/Networking/FragmentedPacket.cs
+++ b/Source/Common/Networking/FragmentedPacket.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.IO;
+
+namespace Multiplayer.Common;
+
+public record FragmentedPacket(
+    Packets Id,
+    MemoryStream Data,
+    ushort ReceivedPartsCount,
+    ushort ExpectedPartsCount,
+    uint ReceivedSize,
+    uint ExpectedSize)
+{
+    internal MemoryStream Data { get; } = Data;
+    public uint ReceivedSize { get; internal set; } = ReceivedSize;
+    public ushort ReceivedPartsCount { get; internal set; } = ReceivedPartsCount;
+
+    internal static FragmentedPacket Create(Packets id, ushort expectedPartsCount, uint expectedSize) => new(id,
+        new MemoryStream(Convert.ToInt32(expectedSize)), ReceivedPartsCount: 0, expectedPartsCount, 0, expectedSize);
+}

--- a/Source/Common/Networking/NetworkingLiteNet.cs
+++ b/Source/Common/Networking/NetworkingLiteNet.cs
@@ -4,17 +4,8 @@ using LiteNetLib;
 
 namespace Multiplayer.Common
 {
-    public class MpServerNetListener : INetEventListener
+    public class MpServerNetListener(MultiplayerServer server, bool arbiter) : INetEventListener
     {
-        private MultiplayerServer server;
-        private bool arbiter;
-
-        public MpServerNetListener(MultiplayerServer server, bool arbiter)
-        {
-            this.server = server;
-            this.arbiter = arbiter;
-        }
-
         public void OnConnectionRequest(ConnectionRequest req)
         {
             var result = server.playerManager.OnPreConnect(req.RemoteEndPoint.Address);

--- a/Source/Common/Networking/PacketHandlerAttribute.cs
+++ b/Source/Common/Networking/PacketHandlerAttribute.cs
@@ -12,5 +12,12 @@ namespace Multiplayer.Common
         public readonly bool allowFragmented = allowFragmented;
     }
 
-    public record PacketHandlerInfo(FastInvokeHandler Method, bool Fragment);
+    [MeansImplicitUse]
+    [AttributeUsage(AttributeTargets.Method)]
+    public class FragmentedPacketHandlerAttribute(Packets packet) : Attribute
+    {
+        public readonly Packets packet = packet;
+    }
+
+    public record PacketHandlerInfo(FastInvokeHandler Method, bool Fragment, FastInvokeHandler? FragmentHandler = null);
 }

--- a/Source/Common/Networking/PacketHandlerAttribute.cs
+++ b/Source/Common/Networking/PacketHandlerAttribute.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 namespace Multiplayer.Common
 {
     [MeansImplicitUse]
+    [AttributeUsage(AttributeTargets.Method)]
     public class PacketHandlerAttribute(Packets packet, bool allowFragmented = false) : Attribute
     {
         public readonly Packets packet = packet;

--- a/Source/Common/Version.cs
+++ b/Source/Common/Version.cs
@@ -3,7 +3,7 @@ namespace Multiplayer.Common
     public static class MpVersion
     {
         public const string Version = "0.10.6";
-        public const int Protocol = 48;
+        public const int Protocol = 49;
 
         public const string ApiAssemblyName = "0MultiplayerAPI";
 


### PR DESCRIPTION
Implement a more complete system for handling fragmented packets. It supports receiving multiple fragmented packets' parts at once*, and allows handling a fragmented packet's individual parts as they arrive. The latter is used to introduce a lot more information to the world download dialog when connecting to a server. It's previous implementation was bare-bones and mixed networking code with some book-keeping for the dialog. That can now be properly separated and the state is now handled by `ClientLoadingState` which the dialog just interfaces with.


https://github.com/user-attachments/assets/3c2bc3fe-5f85-4c6b-91b0-c1827707df33

In the demo video above, the progress bar jumps around a bit. That's because the fragmented packets can now see the independent parts arriving, but only when they arrive in order. Packets can arrive out of order and LiteNetLib does not expose them until all the packets before are received. This could be fixed by sending the packets as `ReliableUnordered`, however that causes some other issues which require further engineering, which I don't think is worth the effort. See the picture below for a visualization how the packets actually arrive when sending them as `ReliableUnordered`.
<img width="737" height="361" alt="image" src="https://github.com/user-attachments/assets/5d297ee6-3555-4689-918b-3955e618416b" />



*: currently the implementation is artificially limited to support receiving only 1 fragmented packet at a time, as such a feature isn't used yet and encountering it could suggest a bug