### PR TITLE
Fix incorrect class casts

### DIFF
--- a/Source/Client/AsyncTime/TimeControlUI.cs
+++ b/Source/Client/AsyncTime/TimeControlUI.cs
@@ -42,7 +42,7 @@ public static class TimeControlPatch
 
             yield return inst;
 
-            if (inst.operand as MethodInfo == AccessTools.Constructor(typeof(Rect),
+            if (inst.operand as ConstructorInfo == AccessTools.Constructor(typeof(Rect),
                     new[] { typeof(float), typeof(float), typeof(float), typeof(float) }))
             {
                 yield return new CodeInstruction(OpCodes.Ldloca_S, 1);

--- a/Source/Client/Factions/Blueprints.cs
+++ b/Source/Client/Factions/Blueprints.cs
@@ -335,7 +335,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.opcode == OpCodes.Isinst && inst.operand as MethodInfo == typeof(Blueprint))
+                if (inst.opcode == OpCodes.Isinst && inst.operand as Type == typeof(Blueprint))
                 {
                     yield return new CodeInstruction(OpCodes.Ldnull);
                     yield return new CodeInstruction(OpCodes.Cgt_Un);

--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -421,7 +421,7 @@ static class StartingAnimalPatch
         {
             yield return inst;
 
-            if (inst.operand as MethodInfo == playerFactionField)
+            if (inst.operand as FieldInfo == playerFactionField)
                 yield return new CodeInstruction(OpCodes.Call, factionOfPlayer.Method);
         }
     }
@@ -661,7 +661,7 @@ static class ApparelWornGraphicPathGetterPatch
 
             // This instruction is part of wornGraphicPaths[thingIDNumber % wornGraphicPaths.Count]
             // The function makes sure the id is positive
-            if (inst.operand as MethodInfo == thingIDNumberField)
+            if (inst.operand as FieldInfo == thingIDNumberField)
                 yield return new CodeInstruction(OpCodes.Call,
                     AccessTools.Method(typeof(ApparelWornGraphicPathGetterPatch), nameof(MakeIdPositive)));
         }
@@ -721,7 +721,7 @@ static class CharacterCardUtilityDontDrawIdeoPlate
             yield return inst;
 
             // Don't draw the ideo plate while choosing starting pawns in multifaction
-            if (inst.operand as MethodInfo == classicModeField)
+            if (inst.operand as FieldInfo == classicModeField)
             {
                 yield return new CodeInstruction(OpCodes.Ldarg_2);
                 yield return new CodeInstruction(OpCodes.Call,

--- a/Source/Client/Patches/AllGroupsPatch.cs
+++ b/Source/Client/Patches/AllGroupsPatch.cs
@@ -19,7 +19,7 @@ namespace Multiplayer.Client
 
             foreach (CodeInstruction inst in insts)
             {
-                if (inst.operand as MethodInfo == AllGroups)
+                if (inst.operand as FieldInfo == AllGroups)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_1).MoveLabelsFrom(inst);
                     yield return new CodeInstruction(OpCodes.Call, method);

--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -76,7 +76,7 @@ namespace Multiplayer.Client.Patches
 
             for (int i = insts.Count - 1; i >= 0; i--)
             {
-                if (insts[i].operand as MethodInfo == FirstOrDefault)
+                if (insts[i].operand as MethodBase == FirstOrDefault)
                     insts.Insert(
                        i + 1,
                        new CodeInstruction(OpCodes.Ldloc_1),
@@ -155,7 +155,7 @@ namespace Multiplayer.Client.Patches
             foreach (CodeInstruction inst in insts)
             {
                 yield return inst;
-                if (!found && inst.operand as MethodInfo == cellsShuffledField)
+                if (!found && inst.operand as FieldInfo == cellsShuffledField)
                 {
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(CellsShufflePatchShared), nameof(ShouldShuffle)));
                     yield return new CodeInstruction(OpCodes.Not);
@@ -302,7 +302,7 @@ namespace Multiplayer.Client.Patches
             foreach (var inst in insts)
             {
                 // Remove mutation of battleActive during saving which was a source of non-determinism
-                if (inst.opcode == OpCodes.Stfld && inst.operand as MethodInfo == battleActiveField)
+                if (inst.opcode == OpCodes.Stfld && inst.operand as FieldInfo == battleActiveField)
                 {
                     yield return new CodeInstruction(OpCodes.Pop);
                     yield return new CodeInstruction(OpCodes.Pop);
@@ -341,7 +341,7 @@ namespace Multiplayer.Client.Patches
         {
             foreach (var inst in insts)
             {
-                if (inst.opcode == OpCodes.Stfld && inst.operand as MethodInfo == queryTickField)
+                if (inst.opcode == OpCodes.Stfld && inst.operand as FieldInfo == queryTickField)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldarg_1);

--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -37,7 +37,7 @@ namespace Multiplayer.Client
             {
                 yield return inst;
 
-                if (inst.operand as MethodInfo == FrameCountField)
+                if (inst.operand as FieldInfo == FrameCountField)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Call, FrameCountReplacementMethod);
@@ -579,7 +579,7 @@ namespace Multiplayer.Client
             {
                 return false; // Skip opening/closing the dev palette during multiplayer reload
             }
-            
+
             return true; // Execute normally
         }
     }

--- a/Source/Client/Persistent/ISwitchToMap.cs
+++ b/Source/Client/Persistent/ISwitchToMap.cs
@@ -19,7 +19,7 @@ namespace Multiplayer.Client
         {
             foreach (var inst in insts)
             {
-                if (inst.opcode == OpCodes.Ldfld && inst.operand as MethodInfo == doCloseXField)
+                if (inst.opcode == OpCodes.Ldfld && inst.operand as FieldInfo == doCloseXField)
                 {
                     yield return new CodeInstruction(OpCodes.Ldarg_0); // This window
                     yield return new CodeInstruction(OpCodes.Ldloc_0); // Window rect


### PR DESCRIPTION
For 1.6

My PR #576 was flawed. I saw a pattern and ran with it, relying too much on the compiler to catch any errors. My bad.

Thanks to @Tick-git for highlighting the issue.  Many of these `CodeInstruction` operands weren't actually `MethodInfo`.  The problem is that they shared common classes (a lot were `FieldInfo` which extends from `MethodInfo`), so the compiler let it all slide.

I've gone through this _twice_ to ensure I'm casting to the correct classes now.

According to Tick this should resolve #590.

_Note:_ Tick also pointed out that Harmony provides a bunch of [extensions](https://harmony.pardeike.net/api/HarmonyLib.CodeInstructionExtensions.html) for doing these comparisons (for example [`.Calls(MethodInfo method)`](https://harmony.pardeike.net/api/HarmonyLib.CodeInstructionExtensions.html#HarmonyLib_CodeInstructionExtensions_Calls_HarmonyLib_CodeInstruction_System_Reflection_MethodInfo_) or [`.LoadsField(FieldInfo field)`](https://harmony.pardeike.net/api/HarmonyLib.CodeInstructionExtensions.html#HarmonyLib_CodeInstructionExtensions_LoadsField_HarmonyLib_CodeInstruction_System_Reflection_FieldInfo_System_Boolean_)).  I looked briefly at updating the code to use these, but I'm not confident enough with the Reflection and patches to ensure it's doing the right thing (for example `.Calls()` [makes checks on the `instruction.opcode`](https://github.com/pardeike/Harmony/blob/master/Harmony/Tools/Extensions.cs#L453) before doing an equality check)