### PR TITLE
Fix disconnect packet handling when connected through LiteNetLib

### DIFF
--- a/Source/Client/Networking/NetworkingLiteNet.cs
+++ b/Source/Client/Networking/NetworkingLiteNet.cs
@@ -35,7 +35,7 @@ namespace Multiplayer.Client.Networking
         public void OnPeerDisconnected(NetPeer peer, DisconnectInfo info)
         {
             MpDisconnectReason reason;
-            byte[] data;
+            ByteReader reader;
 
             if (info.AdditionalData.IsNull)
             {
@@ -46,16 +46,15 @@ namespace Multiplayer.Client.Networking
                 else
                     reason = MpDisconnectReason.NetFailed;
 
-                data = new [] { (byte)info.Reason };
+                reader = new ByteReader(ByteWriter.GetBytes(info.Reason));
             }
             else
             {
-                var reader = new ByteReader(info.AdditionalData.GetRemainingBytes());
+                reader = new ByteReader(info.AdditionalData.GetRemainingBytes());
                 reason = reader.ReadEnum<MpDisconnectReason>();
-                data = reader.ReadPrefixedBytes();
             }
 
-            Multiplayer.session.ProcessDisconnectPacket(reason, data);
+            Multiplayer.session.ProcessDisconnectPacket(reason, reader);
             ConnectionStatusListeners.TryNotifyAll_Disconnected();
 
             Multiplayer.StopMultiplayer();

--- a/Source/Client/Networking/NetworkingSteam.cs
+++ b/Source/Client/Networking/NetworkingSteam.cs
@@ -63,7 +63,7 @@ namespace Multiplayer.Client.Networking
             {
                 Multiplayer.session.ProcessDisconnectPacket(
                     reader.ReadEnum<MpDisconnectReason>(),
-                    reader.ReadPrefixedBytes()
+                    reader
                 );
                 OnDisconnect();
                 return;

--- a/Source/Client/Session/MultiplayerSession.cs
+++ b/Source/Client/Session/MultiplayerSession.cs
@@ -114,9 +114,8 @@ namespace Multiplayer.Client
             SoundDefOf.PageChange.PlayOneShotOnCamera();
         }
 
-        public void ProcessDisconnectPacket(MpDisconnectReason reason, byte[] data)
+        public void ProcessDisconnectPacket(MpDisconnectReason reason, ByteReader reader)
         {
-            var reader = new ByteReader(data);
             string titleKey = null;
             string descKey = null;
 


### PR DESCRIPTION
`NetworkingLiteNet.OnPeerDisconnected` manually encoded `LNL.DisconnectReason` by casting it to a byte and creating an array out of that. At the same time, `ProcessDisconnectPacket` read the `DisconnectReason` using `ByteReader.ReadEnum`. As the `DisconnectReason` is an `int`, the `ByteReader` expected 4 bytes to be present, but `OnPeerDisconnected` only provided one byte.