### PR TITLE
Fix: corpses do not rot

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimePatches.cs
+++ b/Source/Client/AsyncTime/AsyncTimePatches.cs
@@ -83,7 +83,7 @@ namespace Multiplayer.Client.AsyncTime
             AsyncTimeComp comp = t.Map.AsyncTime();
             TickerType tickerType = t.def.tickerType;
 
-            if (tickerType == TickerType.Normal)
+            if (t is IThingHolder || tickerType == TickerType.Normal)
                 comp.tickListNormal.RegisterThing(t);
             else if (tickerType == TickerType.Rare)
                 comp.tickListRare.RegisterThing(t);


### PR DESCRIPTION
Classes that implement IThingHolder are, as of RimWorld 1.6, always included in the normal tick list.

This PR updates our tick system to reflect that change.

Note: Corpses are IThingHolder and are still ticked rarely, but this is now handled directly via Thing.DoTick rather than through the tick list.

Reference: RimWorld 1.6 source code: `TickManager.TickListFor` `Thing.DoTick`