### PR TITLE
Fix save game name when replays dir is not relative

### DIFF
--- a/Source/Client/Windows/SaveFileReader.cs
+++ b/Source/Client/Windows/SaveFileReader.cs
@@ -60,7 +60,7 @@ namespace Multiplayer.Client
         {
             try
             {
-                var displayName = Path.ChangeExtension(file.FullName.Substring(Multiplayer.ReplaysDir.Length + 1), null);
+                var displayName = Path.ChangeExtension(Path.GetRelativePath(Multiplayer.ReplaysDir, file.FullName), null);
                 var saveFile = new SaveFile(displayName, true, file);
 
                 var replay = Replay.ForLoading(file);


### PR DESCRIPTION
I run RimWorld with `savegamedata` argument with a relative dir. The current host window doesn't properly handle that. This PR fixes that.
Before
<img width="762" height="73" alt="image" src="https://github.com/user-attachments/assets/d6ceaf72-11a5-4f82-a821-92d200e2cfdb" />
After
<img width="754" height="63" alt="image" src="https://github.com/user-attachments/assets/e7fa0d91-0a41-406b-b72a-d69593c03eb2" />