### PR TITLE
Fix Multifaction: Pawns Disappear When Caravan To Other Player Map

### DIFF
--- a/Source/Client/MultiplayerStatic.cs
+++ b/Source/Client/MultiplayerStatic.cs
@@ -386,8 +386,9 @@ namespace Multiplayer.Client
                     ("Tick", Type.EmptyTypes),
                     ("TickRare", Type.EmptyTypes),
                     ("TickLong", Type.EmptyTypes),
-                    ("TakeDamage", new[]{ typeof(DamageInfo) }),
-                    ("Kill", new[]{ typeof(DamageInfo?), typeof(Hediff) })
+                    ("TickInterval", [typeof(int)]),
+                    ("TakeDamage", [typeof(DamageInfo)]),
+                    ("Kill", [typeof(DamageInfo?), typeof(Hediff)])
                 };
 
                 foreach (Type t in typeof(Thing).AllSubtypesAndSelf())
@@ -399,7 +400,7 @@ namespace Multiplayer.Client
 
                     foreach ((string m, Type[] args) in thingMethods)
                     {
-                        MethodInfo method = t.GetMethod(m, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly, null, args, null);
+                        MethodInfo method = t.GetMethod(m, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.NonPublic, null, args, null);
                         if (method != null)
                             TryPatch(method, thingMethodPrefix, finalizer: thingMethodFinalizer);
                     }


### PR DESCRIPTION
Label: 1.6, Fix, Mulifaction, but might be relevant in normal, too

This commit ensures that Things push their faction before ticking their systems.

This is required due to changes in RimWorld 1.6, where the tick process for things was updated:

- The method TickInterval() was introduced and is now part of the tick flow, so we added a patch for it.

- The method Tick() was changed to protected, so we updated our method search to include non-public methods to ensure proper patching.