### PR TITLE
Fix harmony errors on startup #614

### DIFF
--- a/Source/Client/AsyncTime/SetMapTime.cs
+++ b/Source/Client/AsyncTime/SetMapTime.cs
@@ -76,16 +76,16 @@ namespace Multiplayer.Client
 
     // TODO 1.3: set time on the new renderer
     //[HarmonyPatch(typeof(PawnRenderer), nameof(PawnRenderer.RenderPortrait))]
-    static class PawnRenderPortraitMapTime
-    {
-        static void Prefix(PawnRenderer __instance, ref TimeSnapshot? __state)
-        {
-            if (Multiplayer.Client == null || Current.ProgramState != ProgramState.Playing) return;
-            __state = TimeSnapshot.GetAndSetFromMap(__instance.pawn.MapHeld);
-        }
+    //static class PawnRenderPortraitMapTime
+    //{
+    //    static void Prefix(PawnRenderer __instance, ref TimeSnapshot? __state)
+    //    {
+    //        if (Multiplayer.Client == null || Current.ProgramState != ProgramState.Playing) return;
+    //        __state = TimeSnapshot.GetAndSetFromMap(__instance.pawn.MapHeld);
+    //    }
 
-        static void Postfix(TimeSnapshot? __state) => __state?.Set();
-    }
+    //    static void Postfix(TimeSnapshot? __state) => __state?.Set();
+    //}
 
     [HarmonyPatch(typeof(PawnTweener), nameof(PawnTweener.PreDrawPosCalculation))]
     static class PreDrawPosCalculationMapTime

--- a/Source/Client/EarlyInit.cs
+++ b/Source/Client/EarlyInit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
@@ -34,8 +34,8 @@ public static class EarlyInit
         // Might fix some mod desyncs
         harmony.PatchMeasure(
             AccessTools.Constructor(typeof(Def), Type.EmptyTypes),
-            new HarmonyMethod(typeof(RandPatches), nameof(RandPatches.Prefix)),
-            finalizer: new HarmonyMethod(typeof(RandPatches), nameof(RandPatches.Finalizer))
+            new HarmonyMethod(typeof(RandPatches), nameof(RandPatches.RandPrefix)),
+            finalizer: new HarmonyMethod(typeof(RandPatches), nameof(RandPatches.RandFinalizer))
         );
 
         Assembly.GetCallingAssembly().GetTypes().Do(type =>

--- a/Source/Client/Factions/Blueprints.cs
+++ b/Source/Client/Factions/Blueprints.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using RimWorld;
 using System;
 using System.Collections.Generic;
@@ -298,22 +298,22 @@ namespace Multiplayer.Client
 
     // todo revisit for pvp
     //[HarmonyPatch(typeof(Designator_Build), nameof(Designator_Build.DesignateSingleCell))]
-    static class DisableInstaBuild
-    {
-        static MethodInfo GetStatValueAbstract = AccessTools.Method(typeof(StatExtension), nameof(StatExtension.GetStatValueAbstract), new []{ typeof(BuildableDef), typeof(StatDef), typeof(ThingDef) });
-        static MethodInfo WorkToBuildMethod = AccessTools.Method(typeof(DisableInstaBuild), nameof(WorkToBuild));
+    //static class DisableInstaBuild
+    //{
+    //    static MethodInfo GetStatValueAbstract = AccessTools.Method(typeof(StatExtension), nameof(StatExtension.GetStatValueAbstract), new []{ typeof(BuildableDef), typeof(StatDef), typeof(ThingDef) });
+    //    static MethodInfo WorkToBuildMethod = AccessTools.Method(typeof(DisableInstaBuild), nameof(WorkToBuild));
 
-        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> e, MethodBase original)
-        {
-            List<CodeInstruction> insts = e.ToList();
-            int pos = new CodeFinder(original, insts).Forward(OpCodes.Call, GetStatValueAbstract);
-            insts[pos + 1] = new CodeInstruction(OpCodes.Call, WorkToBuildMethod);
+    //    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> e, MethodBase original)
+    //    {
+    //        List<CodeInstruction> insts = e.ToList();
+    //        int pos = new CodeFinder(original, insts).Forward(OpCodes.Call, GetStatValueAbstract);
+    //        insts[pos + 1] = new CodeInstruction(OpCodes.Call, WorkToBuildMethod);
 
-            return insts;
-        }
+    //        return insts;
+    //    }
 
-        static float WorkToBuild() => Multiplayer.Client == null ? 0f : -1f;
-    }
+    //    static float WorkToBuild() => Multiplayer.Client == null ? 0f : -1f;
+    //}
 
     [HarmonyPatch(typeof(Frame), nameof(Frame.WorkToBuild), MethodType.Getter)]
     static class NoZeroWorkFrames

--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -211,7 +211,7 @@ namespace Multiplayer.Client
 
             TickPatch.Reset();
 
-            Find.WindowStack?.WindowOfType<ServerBrowser>()?.Cleanup(true);
+            Find.WindowStack?.WindowOfType<ServerBrowser>()?.CleanupServerBrowser(true);
             SyncFieldUtil.ClearAllBufferedChanges();
 
             if (arbiterInstance)

--- a/Source/Client/MultiplayerStatic.cs
+++ b/Source/Client/MultiplayerStatic.cs
@@ -408,8 +408,8 @@ namespace Multiplayer.Client
 
             // Set FactionContext in common WorldObject methods
             {
-                var prefix = new HarmonyMethod(typeof(WorldObjectMethodPatches).GetMethod(nameof(WorldObjectMethodPatches.Prefix)));
-                var finalizer = new HarmonyMethod(typeof(WorldObjectMethodPatches).GetMethod(nameof(WorldObjectMethodPatches.Finalizer)));
+                var prefix = new HarmonyMethod(typeof(WorldObjectMethodPatches).GetMethod(nameof(WorldObjectMethodPatches.WorldObjectPrefix)));
+                var finalizer = new HarmonyMethod(typeof(WorldObjectMethodPatches).GetMethod(nameof(WorldObjectMethodPatches.WorldObjectFinalizer)));
 
                 var thingMethods = new[]
                 {

--- a/Source/Client/MultiplayerStatic.cs
+++ b/Source/Client/MultiplayerStatic.cs
@@ -344,8 +344,8 @@ namespace Multiplayer.Client
 
             // Remove side effects from methods which are non-deterministic during ticking (e.g. camera dependent motes and sound effects)
             {
-                var randPatchPrefix = new HarmonyMethod(typeof(RandPatches), nameof(RandPatches.Prefix));
-                var randPatchFinalizer = new HarmonyMethod(typeof(RandPatches), nameof(RandPatches.Finalizer));
+                var randPatchPrefix = new HarmonyMethod(typeof(RandPatches), nameof(RandPatches.RandPrefix));
+                var randPatchFinalizer = new HarmonyMethod(typeof(RandPatches), nameof(RandPatches.RandFinalizer));
 
                 var subSustainerStart = MpMethodUtil.GetLambda(typeof(SubSustainer), parentMethodType: MethodType.Constructor, parentArgs: new[] { typeof(Sustainer), typeof(SubSoundDef) });
                 var sampleCtor = typeof(Sample).GetConstructor(new[] { typeof(SubSoundDef) });
@@ -377,8 +377,8 @@ namespace Multiplayer.Client
 
             // Set ThingContext and FactionContext (for pawns and buildings) in common Thing methods
             {
-                var thingMethodPrefix = new HarmonyMethod(typeof(ThingMethodPatches).GetMethod(nameof(ThingMethodPatches.Prefix)));
-                var thingMethodFinalizer = new HarmonyMethod(typeof(ThingMethodPatches).GetMethod(nameof(ThingMethodPatches.Finalizer)));
+                var thingMethodPrefix = new HarmonyMethod(typeof(ThingMethodPatches).GetMethod(nameof(ThingMethodPatches.ThingPrefix)));
+                var thingMethodFinalizer = new HarmonyMethod(typeof(ThingMethodPatches).GetMethod(nameof(ThingMethodPatches.ThingFinalizer)));
                 var thingMethodPrefixSpawnSetup = new HarmonyMethod(typeof(ThingMethodPatches).GetMethod(nameof(ThingMethodPatches.Prefix_SpawnSetup)));
 
                 var thingMethods = new[]

--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -149,7 +149,7 @@ namespace Multiplayer.Client.Patches
 
     public static class CellsShufflePatchShared
     {
-        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts, FieldInfo cellsShuffledField)
+        public static IEnumerable<CodeInstruction> CellShuffleTranspiler(IEnumerable<CodeInstruction> insts, FieldInfo cellsShuffledField)
         {
             bool found = false;
             foreach (CodeInstruction inst in insts)
@@ -176,7 +176,7 @@ namespace Multiplayer.Client.Patches
     {
         static readonly FieldInfo CellsShuffled = AccessTools.Field(typeof(Zone), "cellsShuffled");
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
-            => CellsShufflePatchShared.Transpiler(insts, CellsShuffled);
+            => CellsShufflePatchShared.CellShuffleTranspiler(insts, CellsShuffled);
     }
 
     [HarmonyPatch(typeof(Plan), nameof(Plan.Cells), MethodType.Getter)]
@@ -184,7 +184,7 @@ namespace Multiplayer.Client.Patches
     {
         static readonly FieldInfo CellsShuffled = AccessTools.Field(typeof(Plan), "cellsShuffled");
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
-            => CellsShufflePatchShared.Transpiler(insts, CellsShuffled);
+            => CellsShufflePatchShared.CellShuffleTranspiler(insts, CellsShuffled);
     }
 
     [HarmonyPatch]

--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -106,22 +106,22 @@ namespace Multiplayer.Client
         }
     }*/
 
-    // why patch it if it's commented out?
+    //why patch it if it's commented out?
     //[HarmonyPatch(typeof(PawnTweener), nameof(PawnTweener.PreDrawPosCalculation))]
-    public static class PreDrawPosCalcPatch
-    {
-        static void Prefix()
-        {
-            //if (MapAsyncTimeComp.tickingMap != null)
-            //    SimpleProfiler.Pause();
-        }
+    //public static class PreDrawPosCalcPatch
+    //{
+    //    static void Prefix()
+    //    {
+    //        if (MapAsyncTimeComp.tickingMap != null)
+    //            SimpleProfiler.Pause();
+    //    }
 
-        static void Postfix()
-        {
-            //if (MapAsyncTimeComp.tickingMap != null)
-            //    SimpleProfiler.Start();
-        }
-    }
+    //    static void Postfix()
+    //    {
+    //        if (MapAsyncTimeComp.tickingMap != null)
+    //            SimpleProfiler.Start();
+    //    }
+    //}
 
     public static class ValueSavePatch
     {
@@ -141,32 +141,32 @@ namespace Multiplayer.Client
     }
 
     //[HarmonyPatch(typeof(Log), nameof(Log.Warning))]
-    public static class CrossRefWarningPatch
-    {
-        private static Regex regex = new Regex(@"^Could not resolve reference to object with loadID ([\w.-]*) of type ([\w.<>+]*)\. Was it compressed away");
-        public static bool ignore;
+    //public static class CrossRefWarningPatch
+    //{
+    //    private static Regex regex = new Regex(@"^Could not resolve reference to object with loadID ([\w.-]*) of type ([\w.<>+]*)\. Was it compressed away");
+    //    public static bool ignore;
 
-        // The only non-generic entry point during cross reference resolving
-        static bool Prefix(string text)
-        {
-            if (Multiplayer.Client == null || ignore) return true;
+    //    // The only non-generic entry point during cross reference resolving
+    //    static bool Prefix(string text)
+    //    {
+    //        if (Multiplayer.Client == null || ignore) return true;
 
-            ignore = true;
+    //        ignore = true;
 
-            GroupCollection groups = regex.Match(text).Groups;
-            if (groups.Count == 3)
-            {
-                string loadId = groups[1].Value;
-                string typeName = groups[2].Value;
-                // todo
-                return false;
-            }
+    //        GroupCollection groups = regex.Match(text).Groups;
+    //        if (groups.Count == 3)
+    //        {
+    //            string loadId = groups[1].Value;
+    //            string typeName = groups[2].Value;
+    //            // todo
+    //            return false;
+    //        }
 
-            ignore = false;
+    //        ignore = false;
 
-            return true;
-        }
-    }
+    //        return true;
+    //    }
+    //}
 
     [HarmonyPatch(typeof(UI), nameof(UI.MouseCell))]
     public static class MouseCellPatch

--- a/Source/Client/Patches/Seeds.cs
+++ b/Source/Client/Patches/Seeds.cs
@@ -146,14 +146,14 @@ namespace Multiplayer.Client
     public static class RandPatches
     {
         [HarmonyPriority(MpPriority.MpFirst)]
-        public static void Prefix(ref bool __state)
+        public static void RandPrefix(ref bool __state)
         {
             Rand.PushState();
             __state = true;
         }
 
         [HarmonyPriority(MpPriority.MpLast)]
-        public static void Finalizer(bool __state)
+        public static void RandFinalizer(bool __state)
         {
             if (__state)
                 Rand.PopState();

--- a/Source/Client/Patches/ThingMethodPatches.cs
+++ b/Source/Client/Patches/ThingMethodPatches.cs
@@ -120,7 +120,7 @@ namespace Multiplayer.Client
     public static class ThingMethodPatches
     {
         [HarmonyPriority(MpPriority.MpFirst)]
-        public static void Prefix(Thing __instance, ref Container<Map>? __state)
+        public static void ThingPrefix(Thing __instance, ref Container<Map>? __state)
         {
             if (Multiplayer.Client == null) return;
 
@@ -144,7 +144,7 @@ namespace Multiplayer.Client
         }
 
         [HarmonyPriority(MpPriority.MpLast)]
-        public static void Finalizer(Thing __instance, Container<Map>? __state)
+        public static void ThingFinalizer(Thing __instance, Container<Map>? __state)
         {
             if (__state is not { Inner: var map }) return;
 

--- a/Source/Client/Patches/WorldObjectMethodPatches.cs
+++ b/Source/Client/Patches/WorldObjectMethodPatches.cs
@@ -6,7 +6,7 @@ namespace Multiplayer.Client.Patches;
 public static class WorldObjectMethodPatches
 {
     [HarmonyPriority(MpPriority.MpFirst)]
-    public static void Prefix(WorldObject __instance)
+    public static void WorldObjectPrefix(WorldObject __instance)
     {
         if (Multiplayer.Client == null) return;
 
@@ -15,7 +15,7 @@ public static class WorldObjectMethodPatches
     }
 
     [HarmonyPriority(MpPriority.MpLast)]
-    public static void Finalizer(WorldObject __instance)
+    public static void WorldObjectFinalizer(WorldObject __instance)
     {
         if (Multiplayer.Client == null) return;
 

--- a/Source/Client/Patches/WorldPawns.cs
+++ b/Source/Client/Patches/WorldPawns.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Multiplayer.API;
@@ -9,57 +9,57 @@ namespace Multiplayer.Client.Patches;
 
 // todo wip
 //[HarmonyPatch(typeof(WorldPawns), nameof(WorldPawns.AddPawn))]
-static class WorldPawnsAdd
-{
-    public static List<Action> toProcess = new();
+//static class WorldPawnsAdd
+//{
+//    public static List<Action> toProcess = new();
 
-    public static void PostProcess()
-    {
-        foreach (var action in toProcess)
-            action();
+//    public static void PostProcess()
+//    {
+//        foreach (var action in toProcess)
+//            action();
 
-        toProcess.Clear();
-    }
+//        toProcess.Clear();
+//    }
 
-    static bool Prefix(WorldPawns __instance, Pawn p)
-    {
-        Log.Message($"Add world pawn from {Multiplayer.MapContext}: {p} {new StackTrace()}");
+//    static bool Prefix(WorldPawns __instance, Pawn p)
+//    {
+//        Log.Message($"Add world pawn from {Multiplayer.MapContext}: {p} {new StackTrace()}");
 
-        if (Multiplayer.MapContext != null)
-        {
-            toProcess.Insert(0, () => Add(p));
-            OnMainThread.Enqueue(PostProcess);
-        }
+//        if (Multiplayer.MapContext != null)
+//        {
+//            toProcess.Insert(0, () => Add(p));
+//            OnMainThread.Enqueue(PostProcess);
+//        }
 
-        return Multiplayer.MapContext == null;
-    }
+//        return Multiplayer.MapContext == null;
+//    }
 
-    [SyncMethod(exposeParameters = new[]{0})]
-    static void Add(Pawn p)
-    {
-        Find.WorldPawns.AddPawn(p);
-    }
-}
+//    [SyncMethod(exposeParameters = new[]{0})]
+//    static void Add(Pawn p)
+//    {
+//        Find.WorldPawns.AddPawn(p);
+//    }
+//}
 
 //[HarmonyPatch(typeof(WorldObjectsHolder), nameof(WorldObjectsHolder.Add))]
-static class WorldObjectAdd
-{
-    static bool Prefix(WorldObjectsHolder __instance, WorldObject o)
-    {
-        Log.Message($"Add world object from {Multiplayer.MapContext}: {o}");
+//static class WorldObjectAdd
+//{
+//    static bool Prefix(WorldObjectsHolder __instance, WorldObject o)
+//    {
+//        Log.Message($"Add world object from {Multiplayer.MapContext}: {o}");
 
-        if (Multiplayer.MapContext != null)
-        {
-            WorldPawnsAdd.toProcess.Add(() => Add(o));
-            OnMainThread.Enqueue(WorldPawnsAdd.PostProcess);
-        }
+//        if (Multiplayer.MapContext != null)
+//        {
+//            WorldPawnsAdd.toProcess.Add(() => Add(o));
+//            OnMainThread.Enqueue(WorldPawnsAdd.PostProcess);
+//        }
 
-        return Multiplayer.MapContext == null;
-    }
+//        return Multiplayer.MapContext == null;
+//    }
 
-    [SyncMethod(exposeParameters = new[]{0})]
-    static void Add(WorldObject o)
-    {
-        Find.WorldObjects.Add(o);
-    }
-}
+//    [SyncMethod(exposeParameters = new[]{0})]
+//    static void Add(WorldObject o)
+//    {
+//        Find.WorldObjects.Add(o);
+//    }
+//}

--- a/Source/Client/Persistent/MapPortalPatches.cs
+++ b/Source/Client/Persistent/MapPortalPatches.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using RimWorld;
 using UnityEngine;
 using Verse;
@@ -88,7 +88,7 @@ static class CancelMapPortalAddItems
 static class OpenMapPortalSessionDialog
 {
     [MpPrefix(typeof(MapPortal), nameof(MapPortal.GetGizmos), 0)]
-    static bool Prefix(MapPortal __instance)
+    static bool OpenMapPortalPrefix(MapPortal __instance)
     {
         if (Multiplayer.Client == null)
             return true;

--- a/Source/Client/Syncing/SyncTemplates.cs
+++ b/Source/Client/Syncing/SyncTemplates.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -24,9 +24,9 @@ namespace Multiplayer.Client
         }
 
         static readonly MethodInfo m_General = SymbolExtensions.GetMethodInfo(() => General(0, null, Array.Empty<object>()));
-        static readonly MethodInfo m_Transpiler = SymbolExtensions.GetMethodInfo(() => Transpiler(null, null, null));
+        static readonly MethodInfo m_Transpiler = SymbolExtensions.GetMethodInfo(() => SyncTemplateTranspiler(null, null, null));
 
-        static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions, ILGenerator gen)
+        static IEnumerable<CodeInstruction> SyncTemplateTranspiler(MethodBase original, IEnumerable<CodeInstruction> instructions, ILGenerator gen)
         {
             int idx;
             var label = gen.DefineLabel();

--- a/Source/Client/Windows/ServerBrowser.cs
+++ b/Source/Client/Windows/ServerBrowser.cs
@@ -673,10 +673,10 @@ namespace Multiplayer.Client
 
         public override void PostClose()
         {
-            Cleanup(false);
+            CleanupServerBrowser(false);
         }
 
-        public void Cleanup(bool sync)
+        public void CleanupServerBrowser(bool sync)
         {
             void Stop(object s) => lanListener.Stop();
 


### PR DESCRIPTION
Label: Bug, 1.6
Fixes: #614

@SokyranTheDragon @notfood 

With the new Harmony update, the call at https://github.com/rwmt/Multiplayer/blob/f0221d0488282629ebbdef7d58c9d4a93e393b85/Source/Client/MultiplayerStatic.cs#L303-L305 has become much stricter. It now seems to enforce naming conventions like Prefix, Postfix, etc., which led to several errors ( see #614 ).

In this PR, I’ve addressed the issue by renaming the affected methods or commenting out patches where the corresponding [HarmonyPatch] attribute was already commented out.

However, I’m not entirely sure if this is the best long-term solution. It might be worth considering adjusting the filtering logic in the code below?! I've not worked enough with harmony to decide that confidentially.  Or maybe there is an easy solution that I'm missing. https://github.com/rwmt/Multiplayer/blob/f0221d0488282629ebbdef7d58c9d4a93e393b85/Source/Client/MultiplayerStatic.cs#L299-L309 