### PR TITLE
Fixes Transport pod exception

### DIFF
--- a/Source/Client/MultiplayerStatic.cs
+++ b/Source/Client/MultiplayerStatic.cs
@@ -421,14 +421,15 @@ namespace Multiplayer.Client
                 var thingMethods = new[]
                 {
                     ("SpawnSetup", Type.EmptyTypes),
-                    ("Tick", Type.EmptyTypes)
+                    ("Tick", Type.EmptyTypes),
+                    ("TickInterval", [typeof(int)]),
                 };
 
                 foreach (Type t in typeof(WorldObject).AllSubtypesAndSelf())
                 {
                     foreach ((string m, Type[] args) in thingMethods)
                     {
-                        MethodInfo method = t.GetMethod(m, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly, null, args, null);
+                        MethodInfo method = t.GetMethod(m, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.NonPublic, null, args, null);
                         if (method != null)
                             TryPatch(method, prefix, finalizer: finalizer);
                     }


### PR DESCRIPTION
Label: 1.6, fix

### Fixes Transport pod exception

**Commit 2:** 
Fixes an error in syncing process for Action<PlanetTile, TransportersArrivalAction> action) that is used in Transport Pod launches. This has been the main problem in both multifaction/normal play. After this commit, transport pods in normal play work correctly.

**Commit 1:** 
World objects have changed their tick system in 1.6. Therefore, the faction context was not correctly pushed anymore. Same as for things in: #616. This is needed for correct transport pod behaviour in multifaction.

**Desync:** 
When attacking a map with transport pod, more often than not a desync is happening after the pods land on the map. I tested this on 1.5 and there it happens as well. It might happen not in normal mp play and only in multifaction, but have not tested it enough to say it confidently. After a resync it works. I'll write an issue for that on Tuesday. I'm not home the next 1–2 days.