### PR TITLE
Fix Cross OS Play Immediate Desync

### DIFF
--- a/Source/Common/DeferredStackTracingImpl.cs
+++ b/Source/Common/DeferredStackTracingImpl.cs
@@ -141,15 +141,12 @@ public static class DeferredStackTracingImpl
         info.addr = ret;
         info.stackUsage = stackUsage;
 
-        // Use the original mono name for hashing, but normalize away volatile parts
-        var rawName = Native.MethodNameFromAddr(ret, true);
-        var nameForHash = NormalizeMethodName(rawName);
+        var normalizedMethodNameBetweenOS = Native.MethodNameNormalizedFromAddr(ret, true);
 
-        // nameHash: 0 => skip (aggressive inline), 1 => unknown-but-present, else stable hash
         info.nameHash =
-            rawName == null ? 1 :
+            normalizedMethodNameBetweenOS == null ? 1 :
             Native.GetMethodAggressiveInlining(ret) ? 0 :
-            StableStringHash(nameForHash);
+            StableStringHash(normalizedMethodNameBetweenOS);
 
         hashtableEntries++;
         if (hashtableEntries > hashtableSize * LoadFactor)
@@ -158,21 +155,6 @@ public static class DeferredStackTracingImpl
         return stackUsage;
     }
 
-    private static string? NormalizeMethodName(string? name)
-    {
-        if (string.IsNullOrEmpty(name)) return name;
-
-        // Drop IL offset: " (...) [0x000b6]" and everything after it
-        int idx = name.IndexOf(" [0x", StringComparison.Ordinal);
-        if (idx >= 0) name = name.Substring(0, idx);
-
-        // Drop " in <image>:line" tail, which includes per-build GUID/hashes
-        int inIdx = name.IndexOf(" in <", StringComparison.Ordinal);
-        if (inIdx >= 0) name = name.Substring(0, inIdx);
-
-        // Trim any stray whitespace
-        return name.TrimEnd();
-    }
     static ulong HashAddr(ulong addr) => ((addr >> 4) | addr << 60) * 11400714819323198485;
 
     static int ResizeHashtable()

--- a/Source/Common/DeferredStackTracingImpl.cs
+++ b/Source/Common/DeferredStackTracingImpl.cs
@@ -141,8 +141,15 @@ public static class DeferredStackTracingImpl
         info.addr = ret;
         info.stackUsage = stackUsage;
 
-        var rawName = Native.MethodNameFromAddr(ret, true); // Use the original instead of replacement for hashing
-        info.nameHash = rawName != null ? Native.GetMethodAggressiveInlining(ret) ? 0 : StableStringHash(rawName) : 1;
+        // Use the original mono name for hashing, but normalize away volatile parts
+        var rawName = Native.MethodNameFromAddr(ret, true);
+        var nameForHash = NormalizeMethodName(rawName);
+
+        // nameHash: 0 => skip (aggressive inline), 1 => unknown-but-present, else stable hash
+        info.nameHash =
+            rawName == null ? 1 :
+            Native.GetMethodAggressiveInlining(ret) ? 0 :
+            StableStringHash(nameForHash);
 
         hashtableEntries++;
         if (hashtableEntries > hashtableSize * LoadFactor)
@@ -151,6 +158,21 @@ public static class DeferredStackTracingImpl
         return stackUsage;
     }
 
+    private static string? NormalizeMethodName(string? name)
+    {
+        if (string.IsNullOrEmpty(name)) return name;
+
+        // Drop IL offset: " (...) [0x000b6]" and everything after it
+        int idx = name.IndexOf(" [0x", StringComparison.Ordinal);
+        if (idx >= 0) name = name.Substring(0, idx);
+
+        // Drop " in <image>:line" tail, which includes per-build GUID/hashes
+        int inIdx = name.IndexOf(" in <", StringComparison.Ordinal);
+        if (inIdx >= 0) name = name.Substring(0, inIdx);
+
+        // Trim any stray whitespace
+        return name.TrimEnd();
+    }
     static ulong HashAddr(ulong addr) => ((addr >> 4) | addr << 60) * 11400714819323198485;
 
     static int ResizeHashtable()

--- a/Source/Common/Native.cs
+++ b/Source/Common/Native.cs
@@ -96,6 +96,24 @@ namespace Multiplayer.Client
             return string.IsNullOrEmpty(name) ? null : name;
         }
 
+        public static string? MethodNameNormalizedFromAddr(long addr, bool harmonyOriginals)
+        {
+            var name = MethodNameFromAddr(addr, harmonyOriginals);
+
+            if (name == null) return null;
+            if (name.Length == 0) return name;
+
+            int ilOffsetIndex = name.IndexOf(" [0x", StringComparison.Ordinal);
+            if (ilOffsetIndex >= 0)
+                name = name.Substring(0, ilOffsetIndex);
+
+            int mvidIndex = name.IndexOf(" in <", StringComparison.Ordinal);
+            if (mvidIndex >= 0)
+                name = name.Substring(0, mvidIndex);
+
+            return name.TrimEnd();
+        }
+
         private static ConstructorInfo runtimeMethodHandleCtor = AccessTools.Constructor(typeof(RuntimeMethodHandle), new[]{typeof(IntPtr)});
 
         public static bool GetMethodAggressiveInlining(long addr)


### PR DESCRIPTION
Label: 1.6, Fix

With the Mono update in 1.6, method names now include additional build- and platform-specific details, which breaks cross-platform consistency.

This PR removes the new Mono 1.6 extra data to restore consistent cross-platform stack trace hashing.

I believe this should fix all cross-OS play. It has been tested on Linux/Windows.

**Desync file example below for #621 in 1.5 and 1.6** 

### Behavior in 1.5
In Mono 1.5, stack traces included a postfix like `<0xffffffff>`.

<img width="1229" height="397" alt="1 5" src="https://github.com/user-attachments/assets/d4698491-e6fb-4c18-a436-a0935f53b363" />

### Behavior in 1.6
In Mono 1.6, the format changed to `[0x00025] in <b994eb69d2df47fdb01add71b9ac29d2>:0.`
This extra data maps the method to a specific assembly and changes with each build.
Because RimWorld assemblies differ between Linux and Windows, these values also differ between platforms, causing desync issues.

<img width="1548" height="411" alt="1 6" src="https://github.com/user-attachments/assets/f2bc0490-9238-4709-a272-a117280d7d8b" />

