### PR TITLE
Refactor ThingsById system to use non static data

### DIFF
--- a/Source/Client/Debug/DebugSync.cs
+++ b/Source/Client/Debug/DebugSync.cs
@@ -50,7 +50,7 @@ namespace Multiplayer.Client
 
             if (Multiplayer.MapContext != null)
             {
-                var thing = ThingsById.thingsById.GetValueSafe(selectedId);
+                var thing = Multiplayer.ThingsById.GetValueSafe(selectedId);
                 if (thing != null)
                     Find.Selector.selected.Add(thing);
             }

--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -43,6 +43,7 @@ namespace Multiplayer.Client
         public static MultiplayerGameComp GameComp => game.gameComp;
         public static MultiplayerWorldComp WorldComp => game.worldComp;
         public static AsyncWorldTimeComp AsyncWorldTime => game.asyncWorldTimeComp;
+        public static ThingsById ThingsById => game.thingsById;
 
         public static bool ShowDevInfo => Prefs.DevMode && settings.showDevInfo;
         public static bool GhostMode => session is { ghostModeCheckbox: true };

--- a/Source/Client/MultiplayerAPIBridge.cs
+++ b/Source/Client/MultiplayerAPIBridge.cs
@@ -177,12 +177,12 @@ namespace Multiplayer.Common
 
         public Thing GetThingById(int id)
         {
-            return ThingsById.thingsById[id];
+            return Client.Multiplayer.ThingsById.GetValue(id);
         }
 
         public bool TryGetThingById(int id, out Thing value)
         {
-            return ThingsById.thingsById.TryGetValue(id, out value);
+            return Client.Multiplayer.ThingsById.TryGetValue(id, out value);
         }
 
         public IReadOnlyList<IPlayerInfo> GetPlayers()

--- a/Source/Client/MultiplayerGame.cs
+++ b/Source/Client/MultiplayerGame.cs
@@ -24,6 +24,7 @@ namespace Multiplayer.Client
         public List<MultiplayerMapComp> mapComps = new();
         public List<AsyncTimeComp> asyncTimeComps = new();
         public SharedCrossRefs sharedCrossRefs = new();
+        public ThingsById thingsById = new();
 
         private Faction myFaction;
         public Faction myFactionLoading;

--- a/Source/Client/Saving/CrossRefs.cs
+++ b/Source/Client/Saving/CrossRefs.cs
@@ -16,7 +16,7 @@ namespace Multiplayer.Client
             if (__instance.def.HasThingIDNumber)
             {
                 ScribeUtil.sharedCrossRefs.RegisterLoaded(__instance);
-                ThingsById.Register(__instance);
+                Multiplayer.ThingsById.Register(__instance);
             }
         }
     }
@@ -30,7 +30,7 @@ namespace Multiplayer.Client
             if (Multiplayer.game == null) return;
 
             ScribeUtil.sharedCrossRefs.Unregister(__instance);
-            ThingsById.Unregister(__instance);
+            Multiplayer.ThingsById.Unregister(__instance);
         }
     }
 
@@ -173,7 +173,7 @@ namespace Multiplayer.Client
             if (Multiplayer.game == null) return;
 
             ScribeUtil.sharedCrossRefs.UnregisterAllFrom(map);
-            ThingsById.UnregisterAllFrom(map);
+            Multiplayer.ThingsById.UnregisterAllFrom(map);
 
             ScribeUtil.sharedCrossRefs.Unregister(map);
         }
@@ -257,7 +257,7 @@ namespace Multiplayer.Client
             if (item.def.HasThingIDNumber && item.thingIDNumber >= 0)
             {
                 ScribeUtil.sharedCrossRefs.RegisterLoaded(item);
-                ThingsById.Register(item);
+                Multiplayer.ThingsById.Register(item);
             }
         }
     }
@@ -271,7 +271,7 @@ namespace Multiplayer.Client
             if (Multiplayer.game == null) return;
 
             ScribeUtil.sharedCrossRefs.Unregister(item);
-            ThingsById.Unregister(item);
+            Multiplayer.ThingsById.Unregister(item);
         }
     }
 
@@ -296,7 +296,7 @@ namespace Multiplayer.Client
                 if (item != null && item is not MinifiedThing { InnerThing: null } && item.thingIDNumber >= 0)
                 {
                     ScribeUtil.sharedCrossRefs.RegisterLoaded(item);
-                    ThingsById.Register(item);
+                    Multiplayer.ThingsById.Register(item);
                 }
             }
         }

--- a/Source/Client/Saving/ThingsById.cs
+++ b/Source/Client/Saving/ThingsById.cs
@@ -1,24 +1,30 @@
-﻿using System.Collections.Generic;
+using HarmonyLib;
+using System.Collections.Generic;
 using Verse;
 
 namespace Multiplayer.Client;
 
-public static class ThingsById
+public class ThingsById
 {
-    public static Dictionary<int, Thing> thingsById = new();
+    private Dictionary<int, Thing> thingsById = new();
 
-    public static void Register(Thing t)
+    public void Register(Thing t)
     {
         thingsById[t.thingIDNumber] = t;
     }
 
-    public static void Unregister(Thing t)
+    public void Unregister(Thing t)
     {
         thingsById.Remove(t.thingIDNumber);
     }
 
-    public static void UnregisterAllFrom(Map map)
+    public void UnregisterAllFrom(Map map)
     {
         thingsById.RemoveAll(kv => kv.Value.Map == map);
     }
+
+    public Thing GetValueSafe(int thingIDNumber) => thingsById.GetValueSafe(thingIDNumber);
+    public Thing GetValue(int thingIdNumber) => thingsById[thingIdNumber];
+    public bool TryGetValue(int thingIDNumber, out Thing thing) => thingsById.TryGetValue(thingIDNumber, out thing);
+
 }

--- a/Source/Client/Saving/ThingsById.cs
+++ b/Source/Client/Saving/ThingsById.cs
@@ -8,23 +8,16 @@ public class ThingsById
 {
     private Dictionary<int, Thing> thingsById = new();
 
-    public void Register(Thing t)
-    {
-        thingsById[t.thingIDNumber] = t;
-    }
+    public void Register(Thing t) => thingsById[t.thingIDNumber] = t;
 
-    public void Unregister(Thing t)
-    {
-        thingsById.Remove(t.thingIDNumber);
-    }
+    public void Unregister(Thing t) => thingsById.Remove(t.thingIDNumber);
 
-    public void UnregisterAllFrom(Map map)
-    {
-        thingsById.RemoveAll(kv => kv.Value.Map == map);
-    }
+    public void UnregisterAllFrom(Map map) => thingsById.RemoveAll(kv => kv.Value.Map == map);
 
     public Thing GetValueSafe(int thingIDNumber) => thingsById.GetValueSafe(thingIDNumber);
+
     public Thing GetValue(int thingIdNumber) => thingsById[thingIdNumber];
+
     public bool TryGetValue(int thingIDNumber, out Thing thing) => thingsById.TryGetValue(thingIDNumber, out thing);
 
 }

--- a/Source/Client/Session/PlayerInfo.cs
+++ b/Source/Client/Session/PlayerInfo.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-using System.Linq;
 using Multiplayer.API;
 using Multiplayer.Common;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Verse;
 
@@ -47,7 +47,7 @@ public class PlayerInfo : IPlayerInfo
         .ToList()
         .AsReadOnly();
     public IReadOnlyList<Thing> SelectedThings => selectedThings
-        .Select(x => ThingsById.thingsById.TryGetValue(x.Key, out var thing) ? thing : null)
+        .Select(x => Multiplayer.ThingsById.TryGetValue(x.Key, out var thing) ? thing : null)
         .Where(x => x != null)
         .ToList()
         .AsReadOnly();

--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -1,17 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using HarmonyLib;
 using Multiplayer.API;
 using Multiplayer.Common;
 using RimWorld;
 using RimWorld.Planet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Verse;
 using Verse.AI;
 using Verse.AI.Group;
-using static Multiplayer.Client.SyncSerialization;
 using static Multiplayer.Client.CompSerialization;
-using static UnityEngine.GraphicsBuffer;
+using static Multiplayer.Client.SyncSerialization;
 // ReSharper disable RedundantLambdaParameterType
 
 namespace Multiplayer.Client
@@ -825,7 +823,7 @@ namespace Multiplayer.Client
                         }
                     }
 
-                    return ThingsById.thingsById.GetValueSafe(thingId);
+                    return Multiplayer.ThingsById.GetValueSafe(thingId);
                 }, true
             },
             {

--- a/Source/Client/UI/CursorPatches.cs
+++ b/Source/Client/UI/CursorPatches.cs
@@ -86,7 +86,7 @@ namespace Multiplayer.Client
                     foreach (var sel in player.selectedThings)
                     {
                         if (!drawnThisUpdate.Add(sel.Key)) continue;
-                        if (!ThingsById.thingsById.TryGetValue(sel.Key, out Thing thing)) continue;
+                        if (!Multiplayer.ThingsById.TryGetValue(sel.Key, out Thing thing)) continue;
                         if (thing.MapHeld != Find.CurrentMap) continue;
 
                         selTimes[thing] = sel.Value;


### PR DESCRIPTION
Label: 1.6, 1.5, Fix

The error in this PR probably didn’t occur often before, but with gravship it will happen more frequently since maps are generated and abandoned often. I also encountered this in #581, but couldn’t reproduce it at the time.

### Issue:

The static data causes problems when two saves are played in one process.

`public static Dictionary<int, Thing> thingsById = new();`

In the first game, many maps are used, therefore some static cached things have a high mapIndex.

In the next game, fewer maps are used and one map is abandoned.

The static data from save before is not cleared correctly, and when map gets abandoned:

```
public class ThingsById

 public void UnregisterAllFrom(Map map)
 {
     thingsById.RemoveAll(kv => kv.Value.Map == map);
 }
```

calls a map getter that uses Find.Maps and tries to access it with the thing high mapIndex from the old save, which leads to an out-of-bounds error.

### Fix

The PR removes the static data and introduces a non static ThingById class where the instance is part of the multiplayer game instance. This ensures we get a clean data structure with every new load. It also prevents direct access to the data structure by introducing wrapper methods for improved maintainability.