### PR TITLE
Patch TickManager for Chemical Dependency Gene

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimePatches.cs
+++ b/Source/Client/AsyncTime/AsyncTimePatches.cs
@@ -73,6 +73,58 @@ namespace Multiplayer.Client.AsyncTime
         }
     }
 
+    [HarmonyPatch]
+    static class GeneLastIngestPatch
+    {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Gene_ChemicalDependency), nameof(Gene_ChemicalDependency.PostAdd));
+            yield return AccessTools.Method(typeof(Gene_ChemicalDependency), nameof(Gene_ChemicalDependency.Reset));
+        }
+
+        static void Prefix(Gene_ChemicalDependency __instance, ref int? __state)
+        {
+            if (Multiplayer.Client == null && Multiplayer.RealPlayerFaction != null) return;
+
+            Map map = __instance.pawn.Map;
+            if (map == null) return;
+
+            __state = Find.TickManager.TicksGame;
+            FactionContext.Push(Multiplayer.RealPlayerFaction);
+            Find.TickManager.DebugSetTicksGame(map.AsyncTime().mapTicks);
+        }
+
+        static void Finalizer(int? __state)
+        {
+            if (!__state.HasValue) return;
+            Find.TickManager.DebugSetTicksGame(__state.Value);
+            FactionContext.Pop();
+        }
+    }
+
+    [HarmonyPatch(typeof(Hediff_ChemicalDependency), nameof(Hediff_ChemicalDependency.TipStringExtra), MethodType.Getter)]
+    static class HediffTipTextPatch
+    {
+        static void Prefix(Hediff_ChemicalDependency __instance, ref int? __state)
+        {
+            if (Multiplayer.Client == null && Multiplayer.RealPlayerFaction != null) return;
+
+            Map map = __instance.pawn.Map;
+            if (map == null) return;
+
+            __state = Find.TickManager.TicksGame;
+            FactionContext.Push(Multiplayer.RealPlayerFaction);
+            Find.TickManager.DebugSetTicksGame(map.AsyncTime().mapTicks);
+        }
+
+        static void Finalizer(int? __state)
+        {
+            if (!__state.HasValue) return;
+            Find.TickManager.DebugSetTicksGame(__state.Value);
+            FactionContext.Pop();
+        }
+    }
+
     [HarmonyPatch(typeof(TickManager), nameof(TickManager.RegisterAllTickabilityFor))]
     public static class TickListAdd
     {

--- a/Source/Client/AsyncTime/AsyncTimePatches.cs
+++ b/Source/Client/AsyncTime/AsyncTimePatches.cs
@@ -73,58 +73,6 @@ namespace Multiplayer.Client.AsyncTime
         }
     }
 
-    [HarmonyPatch]
-    static class GeneLastIngestPatch
-    {
-        static IEnumerable<MethodBase> TargetMethods()
-        {
-            yield return AccessTools.Method(typeof(Gene_ChemicalDependency), nameof(Gene_ChemicalDependency.PostAdd));
-            yield return AccessTools.Method(typeof(Gene_ChemicalDependency), nameof(Gene_ChemicalDependency.Reset));
-        }
-
-        static void Prefix(Gene_ChemicalDependency __instance, ref int? __state)
-        {
-            if (Multiplayer.Client == null && Multiplayer.RealPlayerFaction != null) return;
-
-            Map map = __instance.pawn.Map;
-            if (map == null) return;
-
-            __state = Find.TickManager.TicksGame;
-            FactionContext.Push(Multiplayer.RealPlayerFaction);
-            Find.TickManager.DebugSetTicksGame(map.AsyncTime().mapTicks);
-        }
-
-        static void Finalizer(int? __state)
-        {
-            if (!__state.HasValue) return;
-            Find.TickManager.DebugSetTicksGame(__state.Value);
-            FactionContext.Pop();
-        }
-    }
-
-    [HarmonyPatch(typeof(Hediff_ChemicalDependency), nameof(Hediff_ChemicalDependency.TipStringExtra), MethodType.Getter)]
-    static class HediffTipTextPatch
-    {
-        static void Prefix(Hediff_ChemicalDependency __instance, ref int? __state)
-        {
-            if (Multiplayer.Client == null && Multiplayer.RealPlayerFaction != null) return;
-
-            Map map = __instance.pawn.Map;
-            if (map == null) return;
-
-            __state = Find.TickManager.TicksGame;
-            FactionContext.Push(Multiplayer.RealPlayerFaction);
-            Find.TickManager.DebugSetTicksGame(map.AsyncTime().mapTicks);
-        }
-
-        static void Finalizer(int? __state)
-        {
-            if (!__state.HasValue) return;
-            Find.TickManager.DebugSetTicksGame(__state.Value);
-            FactionContext.Pop();
-        }
-    }
-
     [HarmonyPatch(typeof(TickManager), nameof(TickManager.RegisterAllTickabilityFor))]
     public static class TickListAdd
     {

--- a/Source/Client/AsyncTime/SetMapTime.cs
+++ b/Source/Client/AsyncTime/SetMapTime.cs
@@ -24,6 +24,7 @@ namespace Multiplayer.Client
             yield return AccessTools.Method(typeof(AlertsReadout), nameof(AlertsReadout.AlertsReadoutUpdate));
             yield return AccessTools.Method(typeof(SoundRoot), nameof(SoundRoot.Update));
             yield return AccessTools.Method(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.ChoicesAtFor));
+            yield return AccessTools.Method(typeof(Hediff), nameof(Hediff.GetTooltip));
         }
 
         [HarmonyPriority(MpPriority.MpFirst)]


### PR DESCRIPTION
When playing MP 1.5 with AsyncTime I noticed pawns with chemical dependencies were misreporting their last ingest times based on what map they were in. 

After some admittedly quick digging through the async time patches I devised 2 new patches that are specifically targeted at this one issue.  

However I believe this type of issue to exist elsewhere for AsyncTime games.  But I lack a solid way of reproducing different instances of this kind of issue.  For instance, Rimworld's code calls `TickManager.TicksGame` in the "Deathrest Gene" as well.  I recall seeing a shield recharge time count with an absurd value once too, but don't know how to reproduce this.

All things considered my MP knowledge is too limited to know if there may be a more concise and universal fix for this class of async time issue or if rwmt would prefer that these issues are patched on an individual basis.

The issue on a map that is ahead of the first map:
<img width="1544" height="1131" alt="invalid-ingest-time" src="https://github.com/user-attachments/assets/56887096-5d21-4f2d-bbfa-75672dbd4624" />


After the fix:
<img width="1445" height="1117" alt="fixed" src="https://github.com/user-attachments/assets/1635e2b8-ae6f-485f-8aa8-6aa84a9eeaa1" />
