### PR TITLE
Fixes Random Desyncs Due To Statue Exception And NextThingId Missmatch

### DIFF
--- a/Source/Client/Patches/Odyssey.cs
+++ b/Source/Client/Patches/Odyssey.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using RimWorld;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -30,6 +31,51 @@ namespace Multiplayer.Client.Patches
 
             return Gen.HashCombineInt(body.map?.uniqueID ?? 0, body.rootCell.x, body.rootCell.z, (int)body.waterBodyType);
         }
+    }
 
+
+    [HarmonyPatch(typeof(CompStatue), nameof(CompStatue.InitFakePawn))]
+    public static class PatchInitFakePawnToNotSyncPawnNameAndForceUseLocalIds
+    {
+        static void Prefix(ref InitFakePawnData __state)
+        {
+            if (Multiplayer.Client == null) return;
+
+            __state = new InitFakePawnData()
+            {
+                valuesChanged = true,
+                dontSync = Multiplayer.dontSync,
+                longEventHandlerCurrentEvent = LongEventHandler.currentEvent,
+            };
+
+            StopFakePawnNameSync();
+            ForceUseLocalIds();
+        }
+
+        static void Finalizer(ref InitFakePawnData __state)
+        {
+            if (__state.valuesChanged)
+            {
+                Multiplayer.dontSync = __state.dontSync;
+                LongEventHandler.currentEvent = __state.longEventHandlerCurrentEvent;
+            }
+        }
+
+        private static void ForceUseLocalIds()
+        {
+            LongEventHandler.currentEvent = null;
+        }
+
+        private static void StopFakePawnNameSync()
+        {
+            Multiplayer.dontSync = true;
+        }
+
+        struct InitFakePawnData
+        {
+            public bool valuesChanged;
+            public bool dontSync;
+            public LongEventHandler.QueuedLongEvent longEventHandlerCurrentEvent;
+        }
     }
 }


### PR DESCRIPTION
Label: 1.6, High Priority, Fix

- This problem causes save files to constantly desync.
- The issue is caused by the new 1.6 statue created in the art bench.
- The root cause happens during the statue expose process, a nextThingId mismatch occurs because the host uses negative local thing IDs (patched by us) while the clients use unpatched ones.
- I suspect the problem occurs more often when flying with the gravship, since a statue can sometimes be present on NPC maps (just a guess).

### Tested:
- Test that damaged save files work correctly
- Test creating a Statue with art bench
- Spawning a Statue via debug tool (Statues look different but do not lead to problems)

### This PR fixes two issues with the new method CompStatue.InitFakePawn:

#

1. **Pawn name sync issue:** The pawn getter is synced while pawn is not fully initialized, which caused syncing errors due to a missing PawnKindDef.

#

2. **Desyncs due to UniqueIdsPatch (nextThingId missmatch):** This was the main reason I investigated the issue. Many desyncs occurred because UniqueIdsPatch (look link below for code) generates negative thing IDs if certain values are set in a specific way. These values differ between client and host - specifically the Multiplayer.InInterface property. The method InitFakePawn is called inside an ExecuteWhenFinished event (look below for code). On the host, this event runs as an async long event, while on the client it runs as a synced event. As a result, the LongEventHandler.currentEvent field is different on host and client, which makes InInterface differ as well. This causes the host to generate negative new thing IDs, while the clients generate positive ones. Since clients get ahead in nextThingIds, the desyncs occur

<img width="1920" height="415" alt="image" src="https://github.com/user-attachments/assets/4de45e08-6ceb-4bb6-84be-a8d58a2e5d88" />

```
class CompStatue
...
public override void PostExposeData()
{
    ...
    if (Scribe.mode == LoadSaveMode.PostLoadInit)
    {
        ...
        LongEventHandler.ExecuteWhenFinished(new Action(this.InitFakePawn));
    }
}
```

https://github.com/rwmt/Multiplayer/blob/8b9b44e3e2040302565c3a17b581e65b2e66019a/Source/Client/Patches/UniqueIds.cs#L9C5-L31C6

#

### Important:
I'm not entirely sure if the fix is the right approach. I haven’t looked into why we use two different events or why we rely on local IDs that are negative values. If the fix feels off to you, I can dig deeper into the problem.

