### PR TITLE
Add Missing Singleplayer Guard For Gravship Patch

### DIFF
--- a/Source/Client/Patches/GravshipTravelSessionPatches.cs
+++ b/Source/Client/Patches/GravshipTravelSessionPatches.cs
@@ -191,6 +191,8 @@ namespace Multiplayer.Client.Patches
         }
         static void Postfix(Gravship gravship)
         {
+            if (Multiplayer.Client == null) return;
+
             GravshipTravelSessionUtils.OpenSessionAt(gravship.destinationTile);
         }
     }


### PR DESCRIPTION
Label: 1.6, Odyssey

The missing guard caused an error in singleplayer, which forced the user back to the main menu when they tried to fly to a new map with the gravship