### PR TITLE
Fix Gravship Lights Turned Off While and After Landing

### DIFF
--- a/Source/Client/Patches/GravshipTravelSessionPatches.cs
+++ b/Source/Client/Patches/GravshipTravelSessionPatches.cs
@@ -27,14 +27,14 @@ namespace Multiplayer.Client.Patches
 
             PlanetTile tile = engine.Map.Tile;
 
-            if (GravshipTravelSessionUtils.HasSessionAt(tile))
+            if (GravshipTravelUtils.HasSessionAt(tile))
             {
                 // If a session already exists, we don't need to show the dialog again
                 MpLog.Debug($"[MP] [{Multiplayer.AsyncWorldTime.worldTicks}] Patch_GravshipPreLaunchConfirmation: Session already exists for tile {engine.Map.Tile}, skipping dialog.");
                 return true;
             }
 
-            GravshipTravelSessionUtils.OpenSessionAt(tile);
+            GravshipTravelUtils.OpenSessionAt(tile);
 
             launchAction = () =>
             {
@@ -82,7 +82,7 @@ namespace Multiplayer.Client.Patches
             {
                 __instance.buttonBAction = () =>
                 {
-                    GravshipTravelSessionUtils.SyncCloseSession(Find.CurrentMap.Tile);
+                    GravshipTravelUtils.SyncCloseSession(Find.CurrentMap.Tile);
                     SyncGravshipDialogCancel();
                 };
             }
@@ -103,7 +103,7 @@ namespace Multiplayer.Client.Patches
         {
             if (Multiplayer.Client == null) return true;
 
-            GravshipTravelSessionUtils.OpenSessionAt(__instance.engine.Map.Tile);
+            GravshipTravelUtils.OpenSessionAt(__instance.engine.Map.Tile);
 
             initialTile = __instance.parent.Map.Tile;
             return true;
@@ -148,6 +148,18 @@ namespace Multiplayer.Client.Patches
         }
     }
 
+    [HarmonyPatch(typeof(WorldComponent_GravshipController), nameof(WorldComponent_GravshipController.PlaceGravship))]
+    public static class PatchPlaceGravshipToUpdateSystemsAfterTheySpawn
+    {
+        static void Postfix(Map map)
+        {
+            if (Multiplayer.Client == null) return;
+
+            map.powerNetManager.UpdatePowerNetsAndConnections_First();
+            map.glowGrid.GlowGridUpdate_First();
+        }
+    }
+
     //Tile cancel input
     [HarmonyPatch(typeof(TilePicker), nameof(TilePicker.StopTargeting))]
     public static class Patch_TilePicker_StopTargeting
@@ -164,7 +176,7 @@ namespace Multiplayer.Client.Patches
                 return;
             }
 
-            GravshipTravelSessionUtils.SyncCloseSession(Patch_CompPilotConsole_StartChoosingDestination.initialTile.Value);
+            GravshipTravelUtils.SyncCloseSession(Patch_CompPilotConsole_StartChoosingDestination.initialTile.Value);
             SyncStopTargeting();
         }
 
@@ -191,7 +203,7 @@ namespace Multiplayer.Client.Patches
         }
         static void Postfix(Gravship gravship)
         {
-            GravshipTravelSessionUtils.OpenSessionAt(gravship.destinationTile);
+            GravshipTravelUtils.OpenSessionAt(gravship.destinationTile);
         }
     }
 
@@ -244,7 +256,7 @@ namespace Multiplayer.Client.Patches
             if (Multiplayer.Client == null) return;
             if (!Multiplayer.ExecutingCmds) return;
 
-            GravshipTravelSessionUtils.CloseSessionAt(__instance.landingTile);
+            GravshipTravelUtils.CloseSessionAt(__instance.landingTile);
         }
     }
 
@@ -265,7 +277,7 @@ namespace Multiplayer.Client.Patches
         {
             if (Multiplayer.Client == null) return;
 
-            Multiplayer.Client.Send(Common.Packets.Client_Freeze, [true]);
+            GravshipTravelUtils.StartFreeze();
         }
     }
 
@@ -276,8 +288,8 @@ namespace Multiplayer.Client.Patches
         {
             if (Multiplayer.Client == null) return;
 
-            Multiplayer.Client.Send(Common.Packets.Client_Freeze, [false]);
-            GravshipTravelSessionUtils.CloseSessionAt(__instance.takeoffTile);
+            GravshipTravelUtils.StopFreeze();
+            GravshipTravelUtils.CloseSessionAt(__instance.takeoffTile);
         }
     }
 
@@ -291,9 +303,8 @@ namespace Multiplayer.Client.Patches
             Rand.PushState();
             Rand.StateCompressed = __instance.map.AsyncTime().randState;
 
-            Multiplayer.Client.Send(Common.Packets.Client_Freeze, [false]);
-
-            GravshipTravelSessionUtils.CloseSessionAt(__instance.gravship.destinationTile);
+            GravshipTravelUtils.StopFreeze();
+            GravshipTravelUtils.CloseSessionAt(__instance.gravship.destinationTile);
         }
         
         static void Finalizer()

--- a/Source/Client/Patches/GravshipTravelSessionPatches.cs
+++ b/Source/Client/Patches/GravshipTravelSessionPatches.cs
@@ -203,6 +203,8 @@ namespace Multiplayer.Client.Patches
         }
         static void Postfix(Gravship gravship)
         {
+            if (Multiplayer.Client == null) return;
+
             GravshipTravelUtils.OpenSessionAt(gravship.destinationTile);
         }
     }

--- a/Source/Client/Persistent/GravshipTravelSession.cs
+++ b/Source/Client/Persistent/GravshipTravelSession.cs
@@ -34,7 +34,7 @@ public class GravshipTravelSession : Session
     }
 }
 
-public static class GravshipTravelSessionUtils
+public static class GravshipTravelUtils
 {
     public static void OpenSessionAt(PlanetTile tile)
     {
@@ -79,6 +79,22 @@ public static class GravshipTravelSessionUtils
     public static bool HasSessionAt(PlanetTile takeoffTile)
     {
         return TryGetSessionAt(takeoffTile, out _);
+    }
+
+    public static void StartFreeze()
+    {
+        SetFreeze(true);
+    }
+
+    public static void StopFreeze()
+    {
+        SetFreeze(false);
+    }
+
+    private static void SetFreeze(bool value)
+    { 
+    
+        Multiplayer.Client.Send(Common.Packets.Client_Freeze, [value]);
     }
 
     [SyncMethod]


### PR DESCRIPTION
Label: 1.6, Fix, Odyssey

Fixes lights not turning on during and after gravship landing animation

Previously, lights would fail to turn on after landing until you either changed their color or rejoined the game.

### Fix:

In our multiplayer layer, some systems are updated in Tick that in singleplayer are normally updated in UpdateLoop, not via the tick system.

This commit makes sure those systems are updated once after gravship things are spawned on the map.

### Additional Info

This took me way longer than I expected. I spent a lot of time looking into the gravship code because I didn’t understand why the problem was happening. I also experimented a bit to see if we could make gravship travel work without freezing all clients, since that’s important for the multi-faction experience when we implement it. I’ll try to write everything that’s in my head down and post it over the weekend, so the information doesn’t get lost.

I don’t think this fix is a long-term solution, though. It might cause desyncs later on with the async/multi-faction gravship implementation as well. 