### PR TITLE
Fixes Gravship Not Looking Smoothe While Traversing World Map

### DIFF
--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -44,6 +44,10 @@ namespace Multiplayer.Client.Patches
                 return true;
 
             __result = VTRSync.MaximumVtr;
+
+            if (__instance is Gravship)
+                __result = VTRSync.MinimumVtr;
+
             return false;
         }
     }


### PR DESCRIPTION
Title: 1.6, Enhancement, Odyssey

Changed gravship UpdateTickRate from 15 to 1 to make its movement appear smooth on the world map.

Caravans were tested and look fine with UpdateTickRate = 15.

We need to revisit the VTR implementation: reports indicate bullets often don’t appear smooth, likely due to issues in the dynamic VTR code.