### PR TITLE
Use built-in constants for tick values

### DIFF
--- a/Source/Client/ConstantTicker.cs
+++ b/Source/Client/ConstantTicker.cs
@@ -40,8 +40,8 @@ namespace Multiplayer.Client
             }
         }
 
-        private const float TicksPerMinute = 60 * 60;
-        private const float TicksPerIngameDay = 2500 * 24;
+        private const float TicksPerMinute = GenTicks.TicksPerRealSecond * 60;
+        private const float TicksPerIngameDay = GenDate.TicksPerDay;
 
         private static void TickAutosave()
         {
@@ -92,7 +92,7 @@ namespace Multiplayer.Client
         {
             if (ShipCountdown.timeLeft > 0f)
             {
-                ShipCountdown.timeLeft -= 1 / 60f;
+                ShipCountdown.timeLeft -= 1f / GenTicks.TicksPerRealSecond;
 
                 if (ShipCountdown.timeLeft <= 0f)
                     ShipCountdown.CountdownEnded();

--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -524,7 +524,7 @@ namespace Multiplayer.Client.Patches
                     // We use 1/60 since 1 second at speed 1 the deltaTime
                     // should (in perfect situation) be 60 ticks.
                     ci.opcode = OpCodes.Ldc_R4;
-                    ci.operand = 1f / 60f;
+                    ci.operand = 1f / GenTicks.TicksPerRealSecond;
 
                     patchCount++;
                 }

--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -438,7 +438,7 @@ namespace Multiplayer.Client
         static void GiveTimeToNameStillborn(Thing __result)
         {
             if (Multiplayer.Client != null && __result is Pawn pawn && pawn.health.hediffSet.HasHediff(HediffDefOf.Stillborn))
-                pawn.babyNamingDeadline = Find.TickManager.TicksGame + 60000;
+                pawn.babyNamingDeadline = Find.TickManager.TicksGame + GenDate.TicksPerDay;
         }
 
         static void PickRandomTraitAndPassions(ChoiceLetter_GrowthMoment letter)

--- a/Source/Common/FreezeManager.cs
+++ b/Source/Common/FreezeManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Verse;
 
 namespace Multiplayer.Common
 {
@@ -23,7 +24,7 @@ namespace Multiplayer.Common
             Server = server;
         }
 
-        private const int MaxFreezeWaitTime = 60 * 10; // 10 seconds
+        private const int MaxFreezeWaitTime = GenTicks.TicksPerRealSecond * 10; // 10 seconds
 
         public void Tick()
         {


### PR DESCRIPTION
I've replaced a few of the constant values (that I could catch) used in the mod with references to the in-game constants.

I've done this primarily to make the intentions behind those values clearer. Using `GenTicks.TicksPerRealSecond` is more obvious that the value refers to amount of ticks in a second, rather than just using the value of `60`. Likewise, using `GenDate.TicksPerDay` is much easier to understand than a value of `60000` or `2500 * 24`.

The only "change" on top is changing `1 / 60f` to `1f / GenTicks.TicksPerRealSecond` (`1` to `1f`), as we need one of those values to be a float (or we'll end up with integer division).

This will not change anything gameplay-wise, as all those constants will be computed at compile time and end up the same in the compiled code. This will only affect the source code.