### PR TITLE
Fix space maps being incorrectly considered paused/unpaused in certain circumstances

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimePatches.cs
+++ b/Source/Client/AsyncTime/AsyncTimePatches.cs
@@ -147,7 +147,7 @@ namespace Multiplayer.Client.AsyncTime
         static void Postfix(ref bool __result)
         {
             if (Multiplayer.Client == null) return;
-            if (WorldRendererUtility.WorldRendered) return;
+            if (WorldRendererUtility.WorldSelected) return;
             if (FactionCreator.generatingMap) return;
 
             var asyncTime = Find.CurrentMap.AsyncTime();


### PR DESCRIPTION
`TickManagerPausedPatch` was not running in MP if `WorldRendererUtility.WorldRendered` is true. However, we wanted to use `WorldRendererUtility.WorldSelected`, as the former checks if the world is rendered at all (including as a background for space maps), while the latter checks if the world is rendered due to the player opening the world map.

There's several bugs that could happen due to this:
- Camera shaker running while paused
  - Normally `CameraShaker:ShakeOffset` returns `Vector3.zero` while paused
- Audio samples being paused while the game is running, not pausing while the game is paused, or having incorrect pitch/volume
- `FleckMaker:ThrowMetaPuffs` creating flecks while paused
  - This method normally only does it while unpaused
- Possibly more in vanilla, and likely a lot more with mods

As for reproduction steps of the bug:
- Start async time MP game with 2 maps, one of which is in space
- Pause both maps
- Switch to the planet map, unpause
- Switch to space map, use dev mode to create explosions
- Notice that the explosions make the camera shake immediately
  - If you compare to the planet maps, the shaking never happens while paused