### PR TITLE
Remove anomaly check from colony subhuman check

### DIFF
--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -507,7 +507,7 @@ static class RecacheColonistBelieverCountPatch
 
     public static bool IsColonySubhumanAnyFaction(Pawn p)
     {
-        return ModsConfig.AnomalyActive && p.IsSubhuman && p.Faction is { IsPlayer: true };
+        return p.IsSubhuman && p.Faction is { IsPlayer: true };
     }
 }
 


### PR DESCRIPTION
In 1.5, this used to be a check for colony mutant, and included Anomaly check since base game did so as well.

In 1.6, the code we patched was replaced to not be a mutant check, but a subhuman check. This check doesn't include a check for Anomaly DLC, so I've removed it to match base game behavior.