### PR TITLE
Make world's travelling transporters smoother

### DIFF
--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -43,10 +43,10 @@ namespace Multiplayer.Client.Patches
             if (Multiplayer.Client == null)
                 return true;
 
-            __result = VTRSync.MaximumVtr;
-
-            if (__instance is Gravship)
+            if (__instance is Gravship or TravellingTransporters)
                 __result = VTRSync.MinimumVtr;
+            else
+                __result = VTRSync.MaximumVtr;
 
             return false;
         }


### PR DESCRIPTION
Just like a gravship, travelling transporters (drop pods, shuttles) calculate their position in tick interval (once every 15 ticks if VTR is active). Since we always assume VTR is active on the world (besides gravships), this means they won't be moving too smoothly. I've set their update rate to always be 1 to fix this issue, just like with gravships.

On top of that, I've rearranged the code into if/else branches to make sure we only assign the result once, instead of potentially twice.