### PR TITLE
Fix Gravship Launch Anchored Map Session Creation

### DIFF
--- a/Source/Client/Patches/GravshipTravelSessionPatches.cs
+++ b/Source/Client/Patches/GravshipTravelSessionPatches.cs
@@ -25,49 +25,34 @@ namespace Multiplayer.Client.Patches
         }
     }
 
-    [HarmonyPatch(typeof(Dialog_MessageBox), MethodType.Constructor, [typeof(TaggedString), typeof(string), typeof(Action), typeof(string), typeof(Action), typeof(string), typeof(bool), typeof(Action), typeof(Action), typeof(WindowLayer)])]
+    [HarmonyPatch]
     public static class PatchGravshipPreLaunchCancel
     {
+        static MethodBase TargetMethod()
+        {
+            return MpMethodUtil.GetLambda(typeof(GravshipUtility), nameof(GravshipUtility.PreLaunchConfirmation), lambdaOrdinal: 4);
+        }
+
         static void Postfix(Dialog_MessageBox __instance)
         {
             if (Multiplayer.Client == null) return;
-            if (!GravshipTravelUtils.IsGravShipMessageDialog(__instance)) return;
+            if (!Multiplayer.ExecutingCmds) return;
 
-            __instance.buttonBAction = () =>
-            {
-                GravshipTravelUtils.SyncCloseSession(Find.CurrentMap.Tile);
-                GravshipTravelUtils.SyncGravshipDialogCancel();
-            };
+            GravshipTravelUtils.CloseSessionAt(Find.CurrentMap.Tile);
+            GravshipTravelUtils.CloseGravshipPrelaunchDialog();
         }
     }
 
     [HarmonyPatch(typeof(CompPilotConsole), nameof(CompPilotConsole.StartChoosingDestination_NewTemp))]
     public static class PatchPilotConsoleStartChoosingDestination
     {
-        static void Prefix(bool launching, ref bool __state)
-        {
-            if (Multiplayer.Client == null || launching || Multiplayer.dontSync)
-                return;
-
-            // If we're trying to open the distance preview, don't sync
-            Multiplayer.dontSync = true;
-            __state = true;
-        }
-
         static void Postfix(CompPilotConsole __instance, bool launching)
         {
             if (Multiplayer.Client == null) return;
-            if (!Multiplayer.ExecutingCmds) return;
             if (!launching) return;
 
-            GravshipTravelUtils.CloseGravshipDialog();
+            GravshipTravelUtils.CloseGravshipPrelaunchDialog();
             GravshipTravelUtils.OpenSessionAt(__instance.engine.Map.Tile);
-        }
-
-        static void Finalizer(bool __state)
-        {
-            if (__state)
-                Multiplayer.dontSync = false;
         }
     }
 
@@ -90,7 +75,7 @@ namespace Multiplayer.Client.Patches
 
         // TODO: Something in Feedback.cs seems to block the wantedMode switch.
         // For now, it's set manually - consider keeping it this way permanently.
-        static void Finalizer(bool ___launching, bool __state)
+        static void Finalizer(bool ___launching, PlanetTile ___curTile, bool __state)
         {
             if (Multiplayer.Client == null) return;
             if (__state) Multiplayer.dontSync = false;
@@ -98,7 +83,7 @@ namespace Multiplayer.Client.Patches
 
             Find.World.renderer.wantedMode = WorldRenderMode.None;
             Find.TilePicker.StopTargetingInt();
-            GravshipTravelUtils.CloseSessionAt(Find.CurrentMap.Tile);
+            GravshipTravelUtils.CloseSessionAt(___curTile);
         }
     }
 

--- a/Source/Client/Persistent/GravshipTravelSession.cs
+++ b/Source/Client/Persistent/GravshipTravelSession.cs
@@ -45,7 +45,7 @@ public static class GravshipTravelUtils
 
         GravshipTravelSession session = new GravshipTravelSession(map);
         map.MpComp()?.sessionManager?.AddSession(session);
-    }  
+    }
 
     public static void CloseSessionAt(PlanetTile tile)
     {
@@ -69,7 +69,6 @@ public static class GravshipTravelUtils
                     session = iSession;
                     return true;
                 }
-                    
             }
         }
 
@@ -92,28 +91,17 @@ public static class GravshipTravelUtils
     }
 
     private static void SetFreeze(bool value)
-    { 
-    
+    {
         Multiplayer.Client.Send(Common.Packets.Client_Freeze, [value]);
     }
     private static string GravshipDialogPrefix => "ConfirmGravEngineLaunch".Translate().RawText;
 
     // TODO: Try to find a better solution for that
-    public static void CloseGravshipDialog()
+    public static void CloseGravshipPrelaunchDialog()
     {
         Dialog_MessageBox dialog = Find.WindowStack.Windows
             .OfType<Dialog_MessageBox>()
             .FirstOrDefault(w => w.text.RawText.StartsWith(GravshipDialogPrefix));
         dialog?.Close();
     }
-    public static bool IsGravShipMessageDialog(Dialog_MessageBox messageBox)
-    {
-        return messageBox.text.RawText.StartsWith(GravshipDialogPrefix);
-    }
-
-    [SyncMethod]
-    public static void SyncGravshipDialogCancel() => CloseGravshipDialog();
-
-    [SyncMethod]
-    public static void SyncCloseSession(PlanetTile tile) => CloseSessionAt(tile);
 }

--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -139,6 +139,8 @@ namespace Multiplayer.Client
             SyncMethod.Lambda(typeof(CompPilotConsole), nameof(CompPilotConsole.CompGetGizmosExtra), 2).SetDebugOnly(); // Dev reset cooldown
             SyncDelegate.Lambda(typeof(CompPilotConsole), nameof(CompPilotConsole.StartChoosingDestination_NewTemp), 4);  // Cancel gravship tile picker
             SyncDelegate.Lambda(typeof(CompPilotConsole), nameof(CompPilotConsole.StartChoosingDestination_NewTemp), 5);  // Confirm gravship landing tile
+            SyncDelegate.Lambda(typeof(RitualOutcomeEffectWorker_GravshipLaunch), nameof(RitualOutcomeEffectWorker_GravshipLaunch.Apply), 0); // Confirm gravship prelaunch dialog
+            SyncDelegate.Lambda(typeof(GravshipUtility), nameof(GravshipUtility.PreLaunchConfirmation), 4); // Cancel gravship prelaunch dialog
 
             // Biosculpter pod
             SyncMethod.Lambda(typeof(CompBiosculpterPod), nameof(CompBiosculpterPod.CompGetGizmosExtra), 1);                // Interrupt cycle (eject contents)

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -428,9 +428,6 @@ namespace Multiplayer.Client
 
             SyncMethod.Register(typeof(WorldComponent_GravshipController), nameof(WorldComponent_GravshipController.PlaceGravship));
             SyncMethod.Register(typeof(WorldComponent_GravshipController), nameof(WorldComponent_GravshipController.AbortLanding)).SetContext(SyncContext.CurrentMap);
-            SyncMethod.Register(typeof(CompPilotConsole), nameof(CompPilotConsole.StartChoosingDestination_NewTemp));
-
-            //SyncMethod.Register(typeof(FreezeManager), nameof(FreezeManager.DoIceMelting));
 
             // Double ExecuteWhenFinished ensures it'll load after MP Compat late patches,
             // so it will have registered all its sync workers already.


### PR DESCRIPTION
Label: 1.6, Fix, Odyssey

Launching a gravship from an anchored map failed to create the session correctly when the world tile picker is selected.

This bug was introduced by my recent refactor of GravshipTravelSessionPatches.cs.

The fix updates how preconfirm dialog options are synced, removing the need to sync `StartChoosingDestination_NewTemp`, where the postfix and `!Multiplayer.ExecutingCmds` check caused the issue.

Additionally, removed some code that was needed because the method was synced.