### PR TITLE
Remove Rbp Probing - Fixes #612 (Skylantern), #658 (GoldenCube)

### DIFF
--- a/Source/Common/DeferredStackTracingImpl.cs
+++ b/Source/Common/DeferredStackTracingImpl.cs
@@ -34,16 +34,14 @@ public static class DeferredStackTracingImpl
     public const int MaxDepth = 32;
     public const int HashInfluence = 6;
 
-    private static unsafe delegate*<long> getRbpFunc;
-    static unsafe DeferredStackTracingImpl() => getRbpFunc = &GetRbpProbed;
-
     public static unsafe int TraceImpl(long[] traceIn, ref int hash)
     {
         if (Native.LmfPtr == 0)
             return 0;
-        
+
         long[] trace = traceIn;
-        long rbp = getRbpFunc();
+        long rbp = GetRbp();
+
         long stck = rbp;
         rbp = *(long*)rbp;
 
@@ -244,30 +242,12 @@ public static class DeferredStackTracingImpl
         }
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-    private static unsafe long GetRbpProbed()
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe long GetRbp()
     {
-        long local = 0;
-        long* p = &local;
+        long rbp = 0;
 
-        // Scan up to 32 q-words (~256 B) – copes with big frames from extra locals,
-        // tier-1 JIT prologues and the 6-register spill variant.
-        for (int i = 1; i <= 32; i++)
-        {
-            long cand = *(&local + i);
-
-            if (cand <= (long)p) continue;   // must be above us
-            if ((cand & 7) != 0) continue;   // 8-byte aligned
-
-            // Cheap sanity: return address slot should be executable
-            if (Native.mono_jit_info_table_find(Native.DomainPtr, *(IntPtr*)(cand + 8)) == IntPtr.Zero)
-                continue;
-
-            return cand;                              // looks like a real frame ptr
-        }
-
-        // Fallback – old +1 assumption
-        return *(p + 1);
+        return *(&rbp + 1);
     }
 
     public static int HashCombineInt(int seed, int value)


### PR DESCRIPTION
**Label: 1.6, fix**

Important: Might be good to wait with merging until someone tests Windows -> Mac. But I'm almost certain it should work.

Fixes: #612 (Skylantern), #658 (GoldenCube)

I investigated issue #658. I tried reverting the changes to DeferredStackTracingImpl.cs step by step because I couldn't get my head around why this only happens in 1.6 and not in 1.5.

**Reverts: #562**
Rbp probing was originally introduced to address 1.6 crossplay issues between Windows and Linux, as well as mismatches when players were not using the same mod build. These issues have since been resolved by #623.

The probing caused errors when a constructor was invoked via reflection because it failed to find the next rbp pointer and then we tried to dereference a null pointer(#612, #658). I don’t have an exact explanation for why the probing fails, but since the issue is resolved by reverting to Zetrith’s original implementation (together with the #623 fix), there’s no need to investigate further, I think.

**Reverts: #548**
This was our first attempt changing rbp lookup in 1.6. However, it caused problems, which led to #562. In that PR, we changed the offset from +1 to +4. I initially reverted it back to this PR, but the stack trace was incomplete. Then, after switching the offset back to +1 - everything works fine. I assume this was also related to the #623 issue.

### Tests

* Windows release build → Windows release build → **OK**
* Windows debug build → Windows debug build → **OK**
* Windows release build → Linux release build → **OK**
* Windows debug build → Linux release build → **DESYNC** (but this also happens on current dev)
* Windows release build → Mac release build → **Not tested** (requested on Discord)
