### PR TITLE
Fix syncing of CompUsable that trigger another targetter

### DIFF
--- a/Source/Client/Patches/Feedback.cs
+++ b/Source/Client/Patches/Feedback.cs
@@ -2,6 +2,7 @@ using HarmonyLib;
 using RimWorld;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using RimWorld.Planet;
@@ -120,7 +121,7 @@ namespace Multiplayer.Client.Patches
         internal static void EnableCanceling()
         {
             stopCancel = true;
-        }        
+        }
     }
 
     [HarmonyPatch(typeof(Thing), nameof(Thing.DeSpawn))]
@@ -201,6 +202,29 @@ namespace Multiplayer.Client.Patches
                 healingDescriptionForPawn.NullOrEmpty()));
 
             return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(CompUsable), nameof(CompUsable.OrderForceTarget))]
+    static class NoTargetableCompUsableSyncing
+    {
+        static void Prefix(CompUsable __instance, ref bool __state)
+        {
+            if (Multiplayer.Client == null || Multiplayer.dontSync) return;
+
+            // Hopefully, all mods implement `PlayerChoosesTarget` as either always being true or false.
+            // If this is conditional then there could be some issues.
+            if (__instance.parent.GetComps<CompTargetable>().Any(x => x.PlayerChoosesTarget))
+            {
+                Multiplayer.dontSync = true;
+                __state = true;
+            }
+        }
+
+        static void Finalizer(bool __state)
+        {
+            if (__state)
+                Multiplayer.dontSync = false;
         }
     }
 

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -152,13 +152,25 @@ namespace Multiplayer.Client
 
             {
                 var methods = typeof(ITargetingSource).AllImplementing()
-                    .Except(typeof(CompInteractableRocketswarmLauncher)) // Skip it, as all it does is open another targeter
                     .Where(t => t.Assembly == typeof(Game).Assembly)
+                    .Except(typeof(CompInteractableRocketswarmLauncher)) // Skip it, as all it does is open another targeter
                     .Select(t => t.GetMethod(nameof(ITargetingSource.OrderForceTarget), AccessTools.allDeclared))
                     .AllNotNull();
 
                 foreach (var method in methods) {
-                    Sync.RegisterSyncMethod(method);
+                    var sync = Sync.RegisterSyncMethod(method);
+
+                    if (method.DeclaringType == typeof(CompTargetable))
+                    {
+                        // Possible errors/bugs if multiple people had targeter open for the same item and synced it (with some delay between each sync).
+                        sync.TransformTarget(Serializer.New(
+                            (CompTargetable comp) => (comp, comp.caster),
+                            x =>
+                            {
+                                x.comp.caster = x.caster;
+                                return x.comp;
+                            }));
+                    }
                 }
             }
 


### PR DESCRIPTION
We're syncing anything in the vanilla assembly implementing the `ITargetingSource:OrderForceTarget` method (with exception of `CompInteractableRocketswarmLauncher`).

This causes issues with `CompUsable`, since the execution of its `OrderForceTarget` method can be cancelled and instead another targeter opened (if the thing also has `CompTargetable` whose `PlayerChoosesTarget` property returns true).

In multiplayer, this causes an issue where targeter is opened for all players, and on top of that since the caster pawn is selected from that method it could end up being overwritten by a different caster or null.

This should fix the issues related to such situations. This means that it'll fix sentience catalyst, resurrector serums, as well as other things. This may potentially fix #655, assuming the issue is related to the gizmo rather than right click float menu.

Changes:
- Added a patch to `CompUsable:OrderForceTarget` to set `dontSync` to true if the item will instead cause another targeter to open
- Added a sync transformer to `CompTargetable:OrderForceTarget` to make sure the caster pawn is correctly synced
- (Minor) Changed when we call `Except` on the enumerable of all classes implementing `ITargetingSource` (less to enumerate over)