### PR TITLE
Trigger desync debug action, faster desync report generation, and separated metadata in the report

### DIFF
--- a/Source/Client/Debug/DebugActions.cs
+++ b/Source/Client/Debug/DebugActions.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 using HarmonyLib;
 using LudeonTK;
+using Multiplayer.Client.Desyncs;
 using Multiplayer.Client.Util;
 using RimWorld;
 using RimWorld.Planet;
@@ -130,6 +131,20 @@ namespace Multiplayer.Client
             Game game = Current.Game;
             byte[] data = ScribeUtil.WriteExposable(game, "game", true);
             File.WriteAllBytes($"game_{Multiplayer.username}.xml", data);
+        }
+
+        public const string TriggerDesyncActionName = "Trigger desync";
+
+        [DebugAction(MultiplayerCategory, name = TriggerDesyncActionName, allowedGameStates = AllowedGameStates.Playing)]
+        public static void TriggerDesync()
+        {
+            var logItem = StackTraceLogItemRaw.GetFromPool();
+            var trace = logItem.raw;
+            int hash = 0;
+            int depth = DeferredStackTracingImpl.TraceImpl(trace, ref hash);
+
+            Multiplayer.game.asyncWorldTimeComp.randState++;
+            Multiplayer.game.sync.TryAddStackTraceForDesyncLogRaw(logItem, depth, hash);
         }
 
         [DebugAction(MultiplayerCategory, "Dump Sync Types", allowedGameStates = AllowedGameStates.Entry)]

--- a/Source/Client/Debug/DebugSync.cs
+++ b/Source/Client/Debug/DebugSync.cs
@@ -95,7 +95,7 @@ namespace Multiplayer.Client
                 {
                     var targetCell = new IntVec3(cursorX, 0, cursorZ);
                     var handleTargetSelected = (state.currentData as Action<LocalTargetInfo>);
-                 
+
                     handleTargetSelected?.Invoke(new LocalTargetInfo(targetCell));
                 }
             }
@@ -271,7 +271,8 @@ namespace Multiplayer.Client
     {
         static void Prefix(DebugActionNode __instance)
         {
-            if (Multiplayer.Client != null && __instance.action is {Target: not MpDebugAction})
+            if (Multiplayer.Client != null && __instance.action is { Target: not MpDebugAction } &&
+                __instance.label != MpDebugActions.TriggerDesyncActionName)
                 __instance.action = new MpDebugAction { node = __instance, original = __instance.action }.Action;
         }
 

--- a/Source/Client/Desyncs/ClientSyncOpinion.cs
+++ b/Source/Client/Desyncs/ClientSyncOpinion.cs
@@ -8,11 +8,11 @@ using Verse;
 namespace Multiplayer.Client
 {
 
-    public class ClientSyncOpinion
+    public class ClientSyncOpinion(int startTick)
     {
         public bool isLocalClientsOpinion;
 
-        public int startTick;
+        public int startTick = startTick;
         public List<uint> commandRandomStates = new();
         public List<uint> worldRandomStates = new();
         public List<MapRandomStateData> mapStates = new();
@@ -22,15 +22,12 @@ namespace Multiplayer.Client
         public List<int> pawnStatHashes = new();
         public List<int> pawnNeedHashes = new();
 
+        // Serialized only after a desync to reduce bandwidth usage in regular gameplay (only the hashes are used) and
+        // help with debugging in case something goes wrong.
         public List<StackTraceLogItem> desyncStackTraces = new();
         public List<int> desyncStackTraceHashes = new();
         public bool simulating;
         public RoundModeEnum roundMode;
-
-        public ClientSyncOpinion(int startTick)
-        {
-            this.startTick = startTick;
-        }
 
         public string CheckForDesync(ClientSyncOpinion other)
         {
@@ -146,7 +143,7 @@ namespace Multiplayer.Client
         public void Clear()
         {
             for (int i = 0; i < desyncStackTraces.Count; i++)
-                desyncStackTraces[i].ReturnToPool();
+                desyncStackTraces[i].Dispose();
         }
     }
 }

--- a/Source/Client/Desyncs/LogGenerator.cs
+++ b/Source/Client/Desyncs/LogGenerator.cs
@@ -1,12 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
-using HarmonyLib;
 using UnityEngine;
 using Verse;
 
@@ -15,7 +10,7 @@ namespace Multiplayer.Client
     /// <summary>
     /// Collects the game logs and loaded mods to be included with desync file.
     /// </summary>
-    public class LogGenerator
+    public static class LogGenerator
     {
         private const int MaxLogLineCount = 10000;
 
@@ -38,12 +33,7 @@ namespace Multiplayer.Client
                 }
                 else logSection = "Could not find the log";
 
-                var collatedData = string.Concat(MakeLogTimestamp(),
-                    ListActiveMods(), "\n",
-                    ListHarmonyPatches(), "\n",
-                    logSection);
-
-                return collatedData;
+                return logSection;
             }
             catch
             {
@@ -164,12 +154,7 @@ namespace Multiplayer.Client
             var fileContents = File.ReadAllText(tempPath);
             File.Delete(tempPath);
 
-            return "Log file contents:\n" + fileContents;
-        }
-
-        private static string MakeLogTimestamp()
-        {
-            return string.Concat("Log generated on ", DateTime.Now.ToLongDateString(), ", ", DateTime.Now.ToLongTimeString(), "\n");
+            return fileContents;
         }
 
         private static string RedactString(string original, string redactStart, string redactEnd, string replacement)
@@ -186,81 +171,6 @@ namespace Multiplayer.Client
             result += logTail;
 
             return result;
-        }
-
-        public static string ListHarmonyPatches()
-        {
-            var patchListing = DescribeAllPatchedMethods();
-
-            return string.Concat("Active Harmony patches:\n",
-                patchListing,
-                patchListing.EndsWith("\n") ? "" : "\n",
-                HarmonyUtil.DescribeHarmonyVersions(), "\n");
-        }
-
-        private static string ListActiveMods()
-        {
-            var builder = new StringBuilder();
-            builder.Append("Loaded mods:\n");
-            foreach (var modContentPack in LoadedModManager.RunningMods)
-            {
-                builder.AppendFormat("{0}({1})", modContentPack.Name, modContentPack.PackageIdPlayerFacing);
-                TryAppendOverrideVersion(builder, modContentPack);
-                TryAppendManifestVersion(builder, modContentPack);
-                builder.Append(": ");
-                var firstAssembly = true;
-                var anyAssemblies = false;
-                foreach (var loadedAssembly in modContentPack.assemblies.loadedAssemblies)
-                {
-                    if (!firstAssembly)
-                    {
-                        builder.Append(", ");
-                    }
-                    firstAssembly = false;
-                    builder.Append(loadedAssembly.GetName().Name);
-
-                    var (version, fileVersion) = ReadModAssembly(loadedAssembly, modContentPack);
-
-                    if (version != null)
-                    {
-                        if (fileVersion == null) builder.AppendFormat("({0} [no file version])", version);
-                        else if (version == fileVersion) builder.AppendFormat("({0})", version);
-                        else builder.AppendFormat("(av: {0} fv:{1})", version, fileVersion);
-                    }
-
-                    anyAssemblies = true;
-                }
-                if (!anyAssemblies)
-                {
-                    builder.Append("(no assemblies)");
-                }
-                builder.Append("\n");
-            }
-            return builder.ToString();
-        }
-
-        private static void TryAppendOverrideVersion(StringBuilder builder, ModContentPack pack)
-        {
-            var filePath = Path.Combine(pack.RootDir, Path.Combine("About", "Version.xml"));
-            if (!File.Exists(filePath)) return;
-
-            var doc = XDocument.Load(filePath);
-
-            var overrideVersionElement = doc.Root?.Element("overrideVersion");
-            if (overrideVersionElement != null)
-                builder.AppendFormat("[ov:{0}]", overrideVersionElement.Value);
-        }
-
-        private static void TryAppendManifestVersion(StringBuilder builder, ModContentPack pack)
-        {
-            if (pack == null) return;
-
-            var filePath = Path.Combine(pack.RootDir, Path.Combine("About", "Manifest.xml"));
-            if (!File.Exists(filePath)) return;
-
-            var doc = XDocument.Load(filePath);
-            var versionElement = doc.Root?.Element("version") ?? doc.Root?.Element("Version");
-            if (versionElement != null) builder.AppendFormat("[mv:{0}]", versionElement.Value);
         }
 
         /// <summary>
@@ -285,21 +195,6 @@ namespace Multiplayer.Client
             };
         }
 
-        /// <summary>
-        /// Produces a human-readable list of all methods patched by all Harmony instances and their respective patches.
-        /// </summary>
-        private static string DescribeAllPatchedMethods()
-        {
-            try
-            {
-                return HarmonyUtil.DescribePatchedMethodsList(Harmony.GetAllPatchedMethods());
-            }
-            catch (Exception e)
-            {
-                return "Could not retrieve patched methods from the Harmony library:\n" + e;
-            }
-        }
-
         private static string TryGetCommandLineOptionValue(string key)
         {
             const string keyPrefix = "-";
@@ -317,42 +212,6 @@ namespace Multiplayer.Client
                 }
             }
             return null;
-        }
-
-        /// <summary>
-        /// Reads assembly version information for a mod assembly.
-        /// Mod assemblies require special treatment, since they are loaded from byte arrays and their <see cref="Assembly.Location"/> is null.
-        /// </summary>
-        /// <param name="assembly">The assembly to read</param>
-        /// <param name="contentPack">The content pack the assembly was loaded from</param>
-        public static (string assemblyVersion, string assemblyFileVersion) ReadModAssembly(Assembly assembly, ModContentPack contentPack)
-        {
-            static string ToSemanticString(Version v)
-            {
-                // System.Version parts: Major.Minor.Build.Revision
-                return v.Build < 0
-                    ? $"{v.ToString(2)}.0"
-                    : v.ToString(v.Revision <= 0 ? 3 : 4);
-            }
-
-            if (assembly == null) return (null, null);
-            const string assembliesFolderName = "Assemblies";
-
-            var expectedAssemblyFileName = $"{assembly.GetName().Name}.dll";
-            var modAssemblyFolderFiles = ModContentPack.GetAllFilesForMod(contentPack, assembliesFolderName);
-            var fileHandle = modAssemblyFolderFiles.Values.FirstOrDefault(f => f.Name == expectedAssemblyFileName);
-
-            try
-            {
-                var assemblyFilePath = fileHandle?.FullName ?? assembly.Location;
-                var fileInfo = FileVersionInfo.GetVersionInfo(assemblyFilePath);
-
-                return (ToSemanticString(assembly.GetName().Version), ToSemanticString(new Version(fileInfo.FileVersion)));
-            }
-            catch (Exception)
-            {
-                return (ToSemanticString(assembly.GetName().Version), null);
-            }
         }
     }
 }

--- a/Source/Client/Desyncs/MapRandomStateData.cs
+++ b/Source/Client/Desyncs/MapRandomStateData.cs
@@ -5,14 +5,9 @@ namespace Multiplayer.Client
     /// <summary>
     /// Holds the random states for a given map, and its map id
     /// </summary>
-    public class MapRandomStateData
+    public class MapRandomStateData(int mapId)
     {
-        public int mapId;
-        public List<uint> randomStates = new List<uint>();
-
-        public MapRandomStateData(int mapId)
-        {
-            this.mapId = mapId;
-        }
+        public int mapId = mapId;
+        public List<uint> randomStates = new();
     }
 }

--- a/Source/Client/Desyncs/MetadataGenerator.cs
+++ b/Source/Client/Desyncs/MetadataGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -19,19 +20,24 @@ public static class MetadataGenerator
 
     private static string ListHarmonyPatches()
     {
-        var patchListing = DescribeAllPatchedMethods();
+        var patchMethods = Harmony
+            .GetAllPatchedMethods()
+            .Select(method => (method, patches: Harmony.GetPatchInfo(method)))
+            .Where(x => x.patches != null)
+            .ToList();
+        var patchListing = DescribeAllPatchedMethods(patchMethods);
         var newline = patchListing.EndsWith('\n') ? "" : "\n";
-        return $"Active Harmony patches:\n{patchListing}{newline}{HarmonyUtil.DescribeHarmonyVersions()}\n";
+        return $"Active Harmony patches:\n{patchListing}{newline}{HarmonyUtil.DescribeHarmonyVersions(patchMethods)}\n";
     }
 
     /// <summary>
     /// Produces a human-readable list of all methods patched by all Harmony instances and their respective patches.
     /// </summary>
-    private static string DescribeAllPatchedMethods()
+    private static string DescribeAllPatchedMethods(List<(MethodBase, HarmonyLib.Patches)> patchMethods)
     {
         try
         {
-            return HarmonyUtil.DescribePatchedMethodsList(Harmony.GetAllPatchedMethods());
+            return HarmonyUtil.DescribePatchedMethodsList(patchMethods);
         }
         catch (Exception e)
         {

--- a/Source/Client/Desyncs/MetadataGenerator.cs
+++ b/Source/Client/Desyncs/MetadataGenerator.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Xml.Linq;
+using HarmonyLib;
+using Verse;
+
+namespace Multiplayer.Client.Desyncs;
+
+public static class MetadataGenerator
+{
+    public static string Generate() => $"{MakeLogTimestamp()}\n{ListActiveMods()}\n{ListHarmonyPatches()}";
+
+    private static string MakeLogTimestamp() =>
+        $"Log generated on {DateTime.Now.ToLongDateString()}, {DateTime.Now.ToLongTimeString()}";
+
+    private static string ListHarmonyPatches()
+    {
+        var patchListing = DescribeAllPatchedMethods();
+        var newline = patchListing.EndsWith('\n') ? "" : "\n";
+        return $"Active Harmony patches:\n{patchListing}{newline}{HarmonyUtil.DescribeHarmonyVersions()}\n";
+    }
+
+    /// <summary>
+    /// Produces a human-readable list of all methods patched by all Harmony instances and their respective patches.
+    /// </summary>
+    private static string DescribeAllPatchedMethods()
+    {
+        try
+        {
+            return HarmonyUtil.DescribePatchedMethodsList(Harmony.GetAllPatchedMethods());
+        }
+        catch (Exception e)
+        {
+            return "Could not retrieve patched methods from the Harmony library:\n" + e;
+        }
+    }
+
+    private static string ListActiveMods()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Loaded mods:");
+        foreach (var modContentPack in LoadedModManager.RunningMods)
+        {
+            builder.AppendFormat("{0}({1})", modContentPack.Name, modContentPack.PackageIdPlayerFacing);
+            TryAppendOverrideVersion(builder, modContentPack);
+            TryAppendManifestVersion(builder, modContentPack);
+            builder.Append(": ");
+            var firstAssembly = true;
+            var anyAssemblies = false;
+            foreach (var loadedAssembly in modContentPack.assemblies.loadedAssemblies)
+            {
+                if (!firstAssembly)
+                {
+                    builder.Append(", ");
+                }
+
+                firstAssembly = false;
+                builder.Append(loadedAssembly.GetName().Name);
+
+                var (version, fileVersion) = ReadModAssembly(loadedAssembly, modContentPack);
+
+                if (version != null)
+                {
+                    if (fileVersion == null) builder.AppendFormat("({0} [no file version])", version);
+                    else if (version == fileVersion) builder.AppendFormat("({0})", version);
+                    else builder.AppendFormat("(av: {0} fv:{1})", version, fileVersion);
+                }
+
+                anyAssemblies = true;
+            }
+
+            if (!anyAssemblies)
+            {
+                builder.Append("(no assemblies)");
+            }
+
+            builder.AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    private static void TryAppendOverrideVersion(StringBuilder builder, ModContentPack pack)
+    {
+        var filePath = Path.Combine(pack.RootDir, "About", "Version.xml");
+        if (!File.Exists(filePath)) return;
+
+        var doc = XDocument.Load(filePath);
+
+        var overrideVersionElement = doc.Root?.Element("overrideVersion");
+        if (overrideVersionElement != null) builder.AppendFormat("[ov:{0}]", overrideVersionElement.Value);
+    }
+
+    private static void TryAppendManifestVersion(StringBuilder builder, ModContentPack pack)
+    {
+        var filePath = Path.Combine(pack.RootDir, "About", "Manifest.xml");
+        if (!File.Exists(filePath)) return;
+
+        var doc = XDocument.Load(filePath);
+        var versionElement = doc.Root?.Element("version") ?? doc.Root?.Element("Version");
+        if (versionElement != null) builder.AppendFormat("[mv:{0}]", versionElement.Value);
+    }
+
+    /// <summary>
+    /// Reads assembly version information for a mod assembly.
+    /// Mod assemblies require special treatment, since they are loaded from byte arrays and their <see cref="Assembly.Location"/> is null.
+    /// </summary>
+    /// <param name="assembly">The assembly to read</param>
+    /// <param name="contentPack">The content pack the assembly was loaded from</param>
+    private static (string assemblyVersion, string assemblyFileVersion) ReadModAssembly(Assembly assembly,
+        ModContentPack contentPack)
+    {
+        static string ToSemanticString(Version v)
+        {
+            // System.Version parts: Major.Minor.Build.Revision
+            return v.Build < 0
+                ? $"{v.ToString(2)}.0"
+                : v.ToString(v.Revision <= 0 ? 3 : 4);
+        }
+
+        if (assembly == null) return (null, null);
+        const string assembliesFolderName = "Assemblies";
+
+        var expectedAssemblyFileName = $"{assembly.GetName().Name}.dll";
+        var modAssemblyFolderFiles = ModContentPack.GetAllFilesForMod(contentPack, assembliesFolderName);
+        var fileHandle = modAssemblyFolderFiles.Values.FirstOrDefault(f => f.Name == expectedAssemblyFileName);
+
+        try
+        {
+            var assemblyFilePath = fileHandle?.FullName ?? assembly.Location;
+            var fileInfo = FileVersionInfo.GetVersionInfo(assemblyFilePath);
+
+            return (ToSemanticString(assembly.GetName().Version), ToSemanticString(new Version(fileInfo.FileVersion)));
+        }
+        catch (Exception)
+        {
+            return (ToSemanticString(assembly.GetName().Version), null);
+        }
+    }
+}

--- a/Source/Client/Desyncs/SaveableDesyncInfo.cs
+++ b/Source/Client/Desyncs/SaveableDesyncInfo.cs
@@ -38,6 +38,8 @@ public class SaveableDesyncInfo(
 
             var extraLogs = LogGenerator.PrepareLogData();
             if (extraLogs != null) zip.AddEntry("local_logs.txt", extraLogs);
+
+            zip.AddEntry("local_metadata.txt", MetadataGenerator.Generate());
         }
         catch (Exception e)
         {

--- a/Source/Client/Desyncs/SaveableDesyncInfo.cs
+++ b/Source/Client/Desyncs/SaveableDesyncInfo.cs
@@ -13,20 +13,15 @@ using Verse;
 
 namespace Multiplayer.Client.Desyncs;
 
-public class SaveableDesyncInfo
+public class SaveableDesyncInfo(
+    SyncCoordinator coordinator,
+    ClientSyncOpinion local,
+    ClientSyncOpinion remote,
+    int diffAt)
 {
-    private readonly SyncCoordinator coordinator;
-    public readonly ClientSyncOpinion local;
-    public readonly ClientSyncOpinion remote;
-    public readonly int diffAt;
-
-    public SaveableDesyncInfo(SyncCoordinator coordinator, ClientSyncOpinion local, ClientSyncOpinion remote, int diffAt)
-    {
-        this.coordinator = coordinator;
-        this.local = local;
-        this.remote = remote;
-        this.diffAt = diffAt;
-    }
+    public readonly ClientSyncOpinion local = local;
+    public readonly ClientSyncOpinion remote = remote;
+    public readonly int diffAt = diffAt;
 
     public void Save()
     {

--- a/Source/Client/Desyncs/SaveableDesyncInfo.cs
+++ b/Source/Client/Desyncs/SaveableDesyncInfo.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using HarmonyLib;
 using Multiplayer.Common;
 using Multiplayer.Common.Util;
@@ -22,6 +23,7 @@ public class SaveableDesyncInfo(
     public readonly ClientSyncOpinion local = local;
     public readonly ClientSyncOpinion remote = remote;
     public readonly int diffAt = diffAt;
+    private readonly Task<string> metadata = Task.Run(MetadataGenerator.Generate);
 
     public void Save()
     {
@@ -39,7 +41,7 @@ public class SaveableDesyncInfo(
             var extraLogs = LogGenerator.PrepareLogData();
             if (extraLogs != null) zip.AddEntry("local_logs.txt", extraLogs);
 
-            zip.AddEntry("local_metadata.txt", MetadataGenerator.Generate());
+            zip.AddEntry("local_metadata.txt", metadata.Result);
         }
         catch (Exception e)
         {

--- a/Source/Client/Desyncs/SaveableDesyncInfo.cs
+++ b/Source/Client/Desyncs/SaveableDesyncInfo.cs
@@ -24,6 +24,7 @@ public class SaveableDesyncInfo(
     public readonly ClientSyncOpinion remote = remote;
     public readonly int diffAt = diffAt;
     private readonly Task<string> metadata = Task.Run(MetadataGenerator.Generate);
+    public bool ReadyToSave => metadata.IsCompleted;
 
     public void Save()
     {

--- a/Source/Client/Desyncs/StackTraceLogItem.cs
+++ b/Source/Client/Desyncs/StackTraceLogItem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Multiplayer.Client.Desyncs;
@@ -5,7 +6,7 @@ using Verse;
 
 namespace Multiplayer.Client
 {
-    public abstract class StackTraceLogItem
+    public abstract class StackTraceLogItem : IDisposable
     {
         public int tick;
         public int hash;
@@ -19,7 +20,9 @@ namespace Multiplayer.Client
             return $"Tick:{tick} Hash:{hash} '{AdditionalInfo}'\n{StackTraceString}";
         }
 
-        public virtual void ReturnToPool() { }
+        public virtual void Dispose()
+        {
+        }
     }
 
     public class StackTraceLogItemObj : StackTraceLogItem
@@ -60,10 +63,7 @@ namespace Multiplayer.Client
                     if (!methodNameCache.TryGetValue(addr, out string method))
                         methodNameCache[addr] = method = Native.MethodNameFromAddr(raw[i], false);
 
-                    if (method != null)
-                        builder.AppendLine(SyncCoordinator.MethodNameWithIL(method));
-                    else
-                        builder.AppendLine("Null");
+                    builder.AppendLine(method != null ? SyncCoordinator.MethodNameWithIL(method) : "Null");
                 }
 
                 return builder.ToString();
@@ -75,7 +75,7 @@ namespace Multiplayer.Client
             return SimplePool<StackTraceLogItemRaw>.Get();
         }
 
-        public override void ReturnToPool()
+        public override void Dispose()
         {
             depth = 0;
             ticksGame = 0;

--- a/Source/Client/Desyncs/SyncCoordinator.cs
+++ b/Source/Client/Desyncs/SyncCoordinator.cs
@@ -29,7 +29,9 @@ namespace Multiplayer.Client
             }
         }
 
-        public readonly List<ClientSyncOpinion> knownClientOpinions = new();
+        // Contains both local and remote opinions. The first opinion is the oldest one, and the last is the newest one.
+        // The host player has only local opinions.
+        public readonly List<ClientSyncOpinion> knownClientOpinions = [];
 
         public ClientSyncOpinion currentOpinion;
 
@@ -59,48 +61,49 @@ namespace Multiplayer.Client
                 knownClientOpinions.Add(newOpinion);
                 if (knownClientOpinions.Count > MaxBacklog)
                     RemoveAndClearFirst();
+                return;
+            }
+
+            // Remove all opinions that started before this one, as it's the most up-to-date one
+            while (knownClientOpinions.Count > 0 && knownClientOpinions[0].startTick < newOpinion.startTick)
+                RemoveAndClearFirst();
+
+            // If there are none left, we don't need to compare this new one
+            if (knownClientOpinions.Count == 0)
+            {
+                knownClientOpinions.Add(newOpinion);
+                return;
+            }
+
+            if (knownClientOpinions.First().startTick != newOpinion.startTick)
+            {
+                // Ignore this opinion
+                newOpinion.Clear();
+                return;
+            }
+
+            // If these two contain the same tick range - i.e., they start at the same time, because they should
+            // continue to the current tick, then do a comparison.
+            var oldOpinion = knownClientOpinions.RemoveFirst();
+
+            // Actually do the comparison to find any desync
+            var desyncMessage = oldOpinion.CheckForDesync(newOpinion);
+
+            if (desyncMessage != null)
+            {
+                MpLog.Log($"Desynced after last valid tick {lastValidTick}: {desyncMessage}");
+                Multiplayer.session.desynced = true;
+                TickPatch.ClearSimulating();
+                OnMainThread.Enqueue(() => HandleDesync(oldOpinion, newOpinion, desyncMessage));
             }
             else
             {
-                //Remove all opinions that started before this one, as it's the most up to date one
-                while (knownClientOpinions.Count > 0 && knownClientOpinions[0].startTick < newOpinion.startTick)
-                    RemoveAndClearFirst();
+                // Update fields
+                lastValidTick = oldOpinion.startTick;
+                arbiterWasPlayingOnLastValidTick = Multiplayer.session.ArbiterPlaying;
 
-                //If there are none left, we don't need to compare this new one
-                if (knownClientOpinions.Count == 0)
-                {
-                    knownClientOpinions.Add(newOpinion);
-                }
-                else if (knownClientOpinions.First().startTick == newOpinion.startTick)
-                {
-                    //If these two contain the same tick range - i.e. they start at the same time, because they should continue to the current tick, then do a comparison.
-                    var oldOpinion = knownClientOpinions.RemoveFirst();
-
-                    //Actually do the comparison to find any desync
-                    var desyncMessage = oldOpinion.CheckForDesync(newOpinion);
-
-                    if (desyncMessage != null)
-                    {
-                        MpLog.Log($"Desynced after last valid tick {lastValidTick}: {desyncMessage}");
-                        Multiplayer.session.desynced = true;
-                        TickPatch.ClearSimulating();
-                        OnMainThread.Enqueue(() => HandleDesync(oldOpinion, newOpinion, desyncMessage));
-                    }
-                    else
-                    {
-                        //Update fields
-                        lastValidTick = oldOpinion.startTick;
-                        arbiterWasPlayingOnLastValidTick = Multiplayer.session.ArbiterPlaying;
-
-                        // Return inner data to the pool
-                        oldOpinion.Clear();
-                    }
-                }
-                // Ignore this opinion
-                else
-                {
-                    newOpinion.Clear();
-                }
+                // Return inner data to the pool
+                oldOpinion.Clear();
             }
         }
 
@@ -118,7 +121,7 @@ namespace Multiplayer.Client
         /// <param name="desyncMessage">The error message that explains exactly what desynced.</param>
         private void HandleDesync(ClientSyncOpinion oldOpinion, ClientSyncOpinion newOpinion, string desyncMessage)
         {
-            //Identify which of the two sync infos is local, and which is the remote.
+            // Identify which of the two sync infos is local and which is the remote.
             var local = oldOpinion.isLocalClientsOpinion ? oldOpinion : newOpinion;
             var remote = !oldOpinion.isLocalClientsOpinion ? oldOpinion : newOpinion;
 
@@ -133,7 +136,7 @@ namespace Multiplayer.Client
             ));
         }
 
-        private int FindTraceHashesDiffTick(ClientSyncOpinion local, ClientSyncOpinion remote)
+        private static int FindTraceHashesDiffTick(ClientSyncOpinion local, ClientSyncOpinion remote)
         {
             //Find the length of whichever stack trace is shorter.
             var localCount = local.desyncStackTraceHashes.Count;

--- a/Source/Client/Multiplayer.csproj
+++ b/Source/Client/Multiplayer.csproj
@@ -66,7 +66,9 @@
 
   <Target Name="CopyToRimworld" AfterTargets="Build">
     <Copy SourceFiles="bin\Multiplayer.dll" DestinationFiles="$(ModOutputPath)\AssembliesCustom\Multiplayer.dll" />
+    <Copy SourceFiles="bin\Multiplayer.pdb" DestinationFiles="$(ModOutputPath)\AssembliesCustom\Multiplayer.pdb" />
     <Copy SourceFiles="bin\MultiplayerCommon.dll" DestinationFiles="$(ModOutputPath)\AssembliesCustom\MultiplayerCommon.dll" />
+    <Copy SourceFiles="bin\MultiplayerCommon.pdb" DestinationFiles="$(ModOutputPath)\AssembliesCustom\MultiplayerCommon.pdb" />
 
     <Copy SourceFiles="bin\0MultiplayerAPI.dll" DestinationFiles="$(ModOutputPath)\Assemblies\0MultiplayerAPI.dll" />
     <Copy SourceFiles="bin\0PrepatcherAPI.dll" DestinationFiles="$(ModOutputPath)\Assemblies\0PrepatcherAPI.dll" />

--- a/Source/Client/Util/CollectionExtensions.cs
+++ b/Source/Client/Util/CollectionExtensions.cs
@@ -102,6 +102,28 @@ namespace Multiplayer.Client
             return dict;
         }
 
+        /// <summary>
+        /// Like ToDictionary but allows duplicate keys as long as the values are equal
+        /// </summary>
+        public static Dictionary<K, V> ToDictionaryConsistent<T, K, V>(this IEnumerable<T> e, Func<T, K> keys, Func<T, V> values)
+        {
+            var dict = new Dictionary<K, V>();
+            foreach (var item in e)
+            {
+                var key = keys(item);
+                var newValue = values(item);
+                if (dict.TryGetValue(key, out var oldValue))
+                {
+                    if (newValue == null ? oldValue == null : !newValue.Equals(oldValue)) throw new ArgumentException();
+                }
+                else
+                {
+                    dict[key] = newValue;
+                }
+            }
+            return dict;
+        }
+
         public static IEnumerable<V> GetOrEmpty<K, V>(this Dictionary<K, V> dict, K key)
         {
             if (dict.TryGetValue(key, out var value))

--- a/Source/Client/Util/HarmonyUtil.cs
+++ b/Source/Client/Util/HarmonyUtil.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using HarmonyLib;
+using Verse;
 
 namespace Multiplayer.Client
 {
@@ -21,14 +22,12 @@ namespace Multiplayer.Client
         {
             try
             {
-                var methodList = patchedMethods.ToList();
                 // generate method name strings so we can sort the patches alphabetically
-                var namedMethodList = new List<(string methodName, HarmonyLib.Patches patches)>(methodList.Count);
-                foreach (var method in methodList)
+                var namedMethodList = patchedMethods.Select(x =>
                 {
-                    var nestedName = GetNestedMemberName(method.method);
-                    namedMethodList.Add((nestedName, method.patches));
-                }
+                    var nestedName = GetNestedMemberName(x.method);
+                    return (methodName: nestedName, x.patches);
+                }).ToList();
 
                 if (namedMethodList.Count == 0)
                 {
@@ -39,42 +38,44 @@ namespace Multiplayer.Client
                 namedMethodList.Sort((m1, m2) =>
                     string.Compare(m1.methodName, m2.methodName, StringComparison.Ordinal));
 
-                var builder = new StringBuilder();
+                var builder = new StringBuilder(namedMethodList.Count * 100);
+                var workList = new List<Patch>(6);
                 foreach (var (methodName, patches) in namedMethodList)
                 {
                     // write patched method
                     builder.Append(methodName);
                     builder.Append(": ");
                     // write patches
-                    if (HasActivePatches(patches))
+                    bool anyPatches = false;
+                    // write prefixes
+                    if (patches.Prefixes is { Count: > 0 })
                     {
-                        // write prefixes
-                        if (patches.Prefixes is { Count: > 0 })
-                        {
-                            builder.Append("PRE: ");
-                            AppendPatchList(patches.Prefixes, builder);
-                        }
-
-                        // write postfixes
-                        if (patches.Postfixes is { Count: > 0 })
-                        {
-                            EnsureEndsWithSpace(builder);
-                            builder.Append("post: ");
-                            AppendPatchList(patches.Postfixes, builder);
-                        }
-
-                        // write transpilers
-                        if (patches.Transpilers is { Count: > 0 })
-                        {
-                            EnsureEndsWithSpace(builder);
-                            builder.Append("TRANS: ");
-                            AppendPatchList(patches.Transpilers, builder);
-                        }
+                        anyPatches = true;
+                        builder.Append("PRE: ");
+                        patches.Prefixes.CopyToList(workList);
+                        AppendPatchList(workList, builder);
                     }
-                    else
+
+                    // write postfixes
+                    if (patches.Postfixes is { Count: > 0 })
                     {
-                        builder.Append("(no patches)");
+                        anyPatches = true;
+                        builder.EnsureEndsWithSpace();
+                        builder.Append("post: ");
+                        patches.Postfixes.CopyToList(workList);
+                        AppendPatchList(workList, builder);
                     }
+
+                    // write transpilers
+                    if (patches.Transpilers is { Count: > 0 })
+                    {
+                        anyPatches = true;
+                        builder.EnsureEndsWithSpace();
+                        builder.Append("TRANS: ");
+                        patches.Transpilers.CopyToList(workList);
+                        AppendPatchList(workList, builder);
+                    }
+                    if (!anyPatches) builder.Append("(no patches)");
 
                     builder.AppendLine();
                 }
@@ -114,7 +115,7 @@ namespace Multiplayer.Client
                 .ToDictionaryConsistent(fix => fix.PatchMethod.DeclaringType.Assembly, fix => fix.owner);
             assemblies.Do(info =>
             {
-                AssemblyName assemblyName = info.Key.GetReferencedAssemblies().FirstOrDefault(a => a.FullName.StartsWith("0Harmony, Version", StringComparison.Ordinal));
+                AssemblyName assemblyName = info.Key.GetReferencedAssemblies().FirstOrDefault(a => a.Name.Equals("0Harmony", StringComparison.Ordinal));
                 if (assemblyName == null) return;
                 result[info.Value] = assemblyName.Version;
             });
@@ -137,14 +138,15 @@ namespace Multiplayer.Client
             return sb.ToString();
         }
 
-        private static void AppendPatchList(IEnumerable<Patch> patchList, StringBuilder builder)
+        private static void AppendPatchList(List<Patch> patchList, StringBuilder builder)
         {
             // ensure that patches appear in the same order they execute
-            var sortedPatches = new List<Patch>(patchList);
-            sortedPatches.Sort();
+            patchList.Sort((left, right) => left.priority != right.priority
+                ? -left.priority.CompareTo(right.priority)
+                : left.index.CompareTo(right.index));
 
             var isFirstEntry = true;
-            foreach (var patch in sortedPatches)
+            foreach (var patch in patchList)
             {
                 if (!isFirstEntry)
                 {
@@ -155,7 +157,7 @@ namespace Multiplayer.Client
                 // write priority if set
                 if (patch.priority != DefaultPatchPriority)
                 {
-                    builder.AppendFormat("[{0}]", patch.priority);
+                    builder.Append('[').Append(patch.priority).Append(']');
                 }
 
                 // write full destination method name
@@ -163,15 +165,7 @@ namespace Multiplayer.Client
             }
         }
 
-        private static bool HasActivePatches(HarmonyLib.Patches patches)
-        {
-            return patches != null &&
-                   ((patches.Prefixes != null && patches.Prefixes.Count != 0) ||
-                    (patches.Postfixes != null && patches.Postfixes.Count != 0) ||
-                    (patches.Transpilers != null && patches.Transpilers.Count != 0));
-        }
-
-        private static void EnsureEndsWithSpace(StringBuilder builder)
+        private static void EnsureEndsWithSpace(this StringBuilder builder)
         {
             if (builder[builder.Length - 1] != ' ')
             {

--- a/Source/Client/Util/HarmonyUtil.cs
+++ b/Source/Client/Util/HarmonyUtil.cs
@@ -17,18 +17,17 @@ namespace Multiplayer.Client
         /// <summary>
         /// Produces a human-readable list of Harmony patches on a given set of methods.
         /// </summary>
-        public static string DescribePatchedMethodsList(IEnumerable<MethodBase> patchedMethods)
+        public static string DescribePatchedMethodsList(List<(MethodBase method, HarmonyLib.Patches patches)> patchedMethods)
         {
             try
             {
                 var methodList = patchedMethods.ToList();
                 // generate method name strings so we can sort the patches alphabetically
-                var namedMethodList = new List<(string methodName, MethodBase method)>(methodList.Count);
+                var namedMethodList = new List<(string methodName, HarmonyLib.Patches patches)>(methodList.Count);
                 foreach (var method in methodList)
                 {
-                    if (method == null) continue;
-                    var nestedName = GetNestedMemberName(method);
-                    namedMethodList.Add((nestedName, method));
+                    var nestedName = GetNestedMemberName(method.method);
+                    namedMethodList.Add((nestedName, method.patches));
                 }
 
                 if (namedMethodList.Count == 0)
@@ -41,13 +40,12 @@ namespace Multiplayer.Client
                     string.Compare(m1.methodName, m2.methodName, StringComparison.Ordinal));
 
                 var builder = new StringBuilder();
-                foreach (var (methodName, method) in namedMethodList)
+                foreach (var (methodName, patches) in namedMethodList)
                 {
                     // write patched method
                     builder.Append(methodName);
                     builder.Append(": ");
                     // write patches
-                    var patches = Harmony.GetPatchInfo(method);
                     if (HasActivePatches(patches))
                     {
                         // write prefixes
@@ -92,11 +90,11 @@ namespace Multiplayer.Client
         /// <summary>
         /// Produces a human-readable list of all Harmony versions present and their respective owners.
         /// </summary>
-        public static string DescribeHarmonyVersions()
+        public static string DescribeHarmonyVersions(List<(MethodBase, HarmonyLib.Patches)> patchMethods)
         {
             try
             {
-                var modVersionPairs = Harmony.VersionInfo(out _);
+                var modVersionPairs = GetHarmonyVersions(patchMethods);
                 return "Harmony versions present: " +
                        modVersionPairs.GroupBy(kv => kv.Value, kv => kv.Key).OrderByDescending(grp => grp.Key)
                            .Select(grp => $"{grp.Key}: {grp.Join(", ")}").Join("; ");
@@ -105,6 +103,22 @@ namespace Multiplayer.Client
             {
                 return "An exception occurred while collating Harmony version data:\n" + e;
             }
+        }
+
+        private static Dictionary<string, Version> GetHarmonyVersions(List<(MethodBase, HarmonyLib.Patches patches)> patchMethods)
+        {
+            var result = new Dictionary<string, Version>();
+            var assemblies = patchMethods
+                .Select(x => x.patches)
+                .SelectMany(x => x.Prefixes.Concat(x.Postfixes).Concat(x.Transpilers).Concat(x.Finalizers))
+                .ToDictionaryConsistent(fix => fix.PatchMethod.DeclaringType.Assembly, fix => fix.owner);
+            assemblies.Do(info =>
+            {
+                AssemblyName assemblyName = info.Key.GetReferencedAssemblies().FirstOrDefault(a => a.FullName.StartsWith("0Harmony, Version", StringComparison.Ordinal));
+                if (assemblyName == null) return;
+                result[info.Value] = assemblyName.Version;
+            });
+            return result;
         }
 
         internal static string GetNestedMemberName(MemberInfo member, int maxParentTypes = 10)

--- a/Source/Client/Windows/DesyncedWindow.cs
+++ b/Source/Client/Windows/DesyncedWindow.cs
@@ -91,7 +91,7 @@ namespace Multiplayer.Client
             const float maxWait = 5f;
 
             var shouldWrite = Multiplayer.session?.desyncTracesFromHost != null || Time.realtimeSinceStartup - openedAt > maxWait;
-            if (!infoWritten && shouldWrite)
+            if (!infoWritten && shouldWrite && desyncInfo.ReadyToSave)
             {
                 desyncInfo.Save();
                 infoWritten = true;

--- a/Source/MultiplayerLoader/MultiplayerLoader.cs
+++ b/Source/MultiplayerLoader/MultiplayerLoader.cs
@@ -19,27 +19,31 @@ namespace MultiplayerLoader
             instance = this;
             LoadAssembliesCustom();
 
-            GenTypes.GetTypeInAnyAssembly("Multiplayer.Client.Multiplayer")!.GetMethod("InitMultiplayer")!.Invoke(null, null);
+            FindTypeInAppDomain("Multiplayer.Client.Multiplayer")!.GetMethod("InitMultiplayer")!.Invoke(null, null);
         }
+
+        public static Type? FindTypeInAppDomain(string typeFullName) =>
+            AppDomain.CurrentDomain.GetAssemblies()
+                .Select(assembly => assembly.GetType(typeFullName, throwOnError: false, ignoreCase: false))
+                .FirstOrDefault(type => type != null);
 
         private void LoadAssembliesCustom()
         {
             var assemblies = new List<Assembly>();
 
-            foreach (FileInfo item in
-                     from f
-                         in ModContentPack.GetAllFilesForModPreserveOrder(Content, "AssembliesCustom/",
-                             e => e.ToLower() == ".dll")
-                     select f.Item2)
+            foreach (FileInfo item in ModContentPack
+                         .GetAllFilesForModPreserveOrder(Content, "AssembliesCustom/", e => e.ToLower() == ".dll")
+                         .Select(f => f.Item2))
             {
                 Assembly assembly;
-
                 try
                 {
+                    // This would work with Assembly.Load the same as ModAssemblyHandler does it, but then the .dll
+                    // files are locked and cannot be replaced when a game instance is already running. This way it's
+                    // possible to keep a game instance open and just rebuild and reopen another instance without any
+                    // issues with replacing the dll files.
                     byte[] rawAssembly = File.ReadAllBytes(item.FullName);
-                    FileInfo fileInfo =
-                        new FileInfo(Path.Combine(item.DirectoryName!, Path.GetFileNameWithoutExtension(item.FullName)) +
-                                     ".pdb");
+                    FileInfo fileInfo = new FileInfo(Path.ChangeExtension(item.FullName, "pdb"));
 
                     if (fileInfo.Exists)
                     {
@@ -60,25 +64,14 @@ namespace MultiplayerLoader
                 assemblies.Add(assembly);
             }
 
-            var asmResolve = (Delegate)typeof(AppDomain).GetField("AssemblyResolve", BindingFlags.Instance | BindingFlags.NonPublic)
-                !.GetValue(AppDomain.CurrentDomain)!;
+            AppDomain.CurrentDomain.AssemblyResolve += (_, args) =>
+                Content.assemblies.loadedAssemblies.FirstOrDefault(a => a.FullName == args.Name);
 
-            Assembly Resolver(object _, ResolveEventArgs args)
+            foreach (var asm in assemblies.Where(asm => Content.assemblies.AssemblyIsUsable(asm)))
             {
-                return assemblies.Concat(Content.assemblies.loadedAssemblies).FirstOrDefault(a => a.FullName == args.Name);
+                GenTypes.ClearCache();
+                Content.assemblies.loadedAssemblies.Add(asm);
             }
-
-            typeof(AppDomain).GetField("AssemblyResolve", BindingFlags.Instance | BindingFlags.NonPublic)
-                !.SetValue(AppDomain.CurrentDomain, Delegate.Combine(
-                    (ResolveEventHandler)Resolver,
-                    asmResolve));
-
-            foreach (var asm in assemblies)
-                if (Content.assemblies.AssemblyIsUsable(asm))
-                {
-                    GenTypes.ClearCache();
-                    Content.assemblies.loadedAssemblies.Add(asm);
-                }
         }
 
         public override string SettingsCategory() => "Multiplayer";


### PR DESCRIPTION
This adds a debug action to trigger a desync, improves desync generation by: making it faster, on my system it takes ~0.9s, where as before it took ~1.8s; the game no longer freezes when saving the desync report (saving now takes ~50ms, because the slowest code is run in the background - metadata generation); added a new file to the desync report with just the metadata (mods, patches, harmony versions).