### PR TITLE
Improve handling of packets when loading

### DIFF
--- a/Source/Client/Networking/State/ClientBaseState.cs
+++ b/Source/Client/Networking/State/ClientBaseState.cs
@@ -2,11 +2,33 @@ using Multiplayer.Common;
 
 namespace Multiplayer.Client;
 
-public abstract class ClientBaseState : MpConnectionState
+public abstract class ClientBaseState(ConnectionBase connection) : MpConnectionState(connection)
 {
     protected MultiplayerSession Session => Multiplayer.session;
 
-    public ClientBaseState(ConnectionBase connection) : base(connection)
+    protected void HandleKeepAlive(ByteReader data)
     {
+        int id = data.ReadInt32();
+        int ticksBehind = TickPatch.tickUntil - TickPatch.Timer;
+
+        connection.Send(
+            Packets.Client_KeepAlive,
+            ByteWriter.GetBytes(id, ticksBehind, TickPatch.Simulating, TickPatch.workTicks),
+            false
+        );
+    }
+
+    protected void HandleTimeControl(ByteReader data)
+    {
+        int tickUntil = data.ReadInt32();
+        int sentCmds = data.ReadInt32();
+        float stpt = data.ReadFloat();
+
+        if (Multiplayer.session.remoteTickUntil >= tickUntil) return;
+
+        TickPatch.serverTimePerTick = stpt;
+        Multiplayer.session.remoteTickUntil = tickUntil;
+        Multiplayer.session.remoteSentCmds = sentCmds;
+        Multiplayer.session.ProcessTimeControl();
     }
 }

--- a/Source/Client/Networking/State/ClientLoadingState.cs
+++ b/Source/Client/Networking/State/ClientLoadingState.cs
@@ -136,4 +136,10 @@ public class ClientLoadingState(ConnectionBase connection) : ClientBaseState(con
         Log.Message($"Loaded game in {loadingMs}ms");
         connection.ChangeState(ConnectionStateEnum.ClientPlaying);
     }
+
+    [PacketHandler(Packets.Server_KeepAlive)]
+    public new void HandleKeepAlive(ByteReader data) => base.HandleKeepAlive(data);
+
+    [PacketHandler(Packets.Server_TimeControl)]
+    public new void HandleTimeControl(ByteReader data) => base.HandleTimeControl(data);
 }

--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -9,39 +9,13 @@ using Verse;
 
 namespace Multiplayer.Client
 {
-    public class ClientPlayingState : ClientBaseState
+    public class ClientPlayingState(ConnectionBase connection) : ClientBaseState(connection)
     {
-        public ClientPlayingState(ConnectionBase connection) : base(connection)
-        {
-        }
+        [PacketHandler(Packets.Server_KeepAlive)]
+        public new void HandleKeepAlive(ByteReader data) => base.HandleKeepAlive(data);
 
         [PacketHandler(Packets.Server_TimeControl)]
-        public void HandleTimeControl(ByteReader data)
-        {
-            int tickUntil = data.ReadInt32();
-            int sentCmds = data.ReadInt32();
-            float stpt = data.ReadFloat();
-
-            if (Multiplayer.session.remoteTickUntil >= tickUntil) return;
-
-            TickPatch.serverTimePerTick = stpt;
-            Multiplayer.session.remoteTickUntil = tickUntil;
-            Multiplayer.session.remoteSentCmds = sentCmds;
-            Multiplayer.session.ProcessTimeControl();
-        }
-
-        [PacketHandler(Packets.Server_KeepAlive)]
-        public void HandleKeepAlive(ByteReader data)
-        {
-            int id = data.ReadInt32();
-            int ticksBehind = TickPatch.tickUntil - TickPatch.Timer;
-
-            connection.Send(
-                Packets.Client_KeepAlive,
-                ByteWriter.GetBytes(id, ticksBehind, TickPatch.Simulating, TickPatch.workTicks),
-                false
-            );
-        }
+        public new void HandleTimeControl(ByteReader data) => base.HandleTimeControl(data);
 
         [PacketHandler(Packets.Server_Command)]
         public void HandleCommand(ByteReader data)

--- a/Source/Client/OnMainThread.cs
+++ b/Source/Client/OnMainThread.cs
@@ -48,7 +48,8 @@ namespace Multiplayer.Client
                 PerformanceRecorder.RecordFrame();
             }
 
-            if (!Multiplayer.arbiterInstance && Application.isFocused && !TickPatch.Simulating && !Multiplayer.session.desynced)
+            if (!Multiplayer.arbiterInstance && Application.isFocused && !TickPatch.Simulating &&
+                !Multiplayer.session.desynced && Multiplayer.session.client.State == ConnectionStateEnum.ClientPlaying)
                 Multiplayer.session.playerCursors.SendVisuals();
 
             if (Multiplayer.Client is SteamBaseConn steamConn && SteamManager.Initialized)

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -202,6 +202,13 @@ namespace Multiplayer.Common
             SendToPlaying(id, ByteWriter.GetBytes(data));
         }
 
+        public void SendToIngame(Packets id, byte[] data, bool reliable = true, ServerPlayer? excluding = null)
+        {
+            foreach (ServerPlayer player in PlayingIngamePlayers)
+                if (player != excluding)
+                    player.conn.Send(id, data, reliable);
+        }
+
         public void SendToPlaying(Packets id, byte[] data, bool reliable = true, ServerPlayer? excluding = null)
         {
             foreach (ServerPlayer player in PlayingPlayers)

--- a/Source/Common/Networking/State/ServerPlayingState.cs
+++ b/Source/Common/Networking/State/ServerPlayingState.cs
@@ -139,7 +139,7 @@ namespace Multiplayer.Common
 
             Player.lastCursorTick = Server.NetTimer;
 
-            Server.SendToPlaying(Packets.Server_Cursor, writer.ToArray(), reliable: false, excluding: Player);
+            Server.SendToIngame(Packets.Server_Cursor, writer.ToArray(), reliable: false, excluding: Player);
         }
 
         [PacketHandler(Packets.Client_Selected)]


### PR DESCRIPTION
When a client is joining a server, the server sends a lot of packets during client loading that aren't properly handled (or shouldn't actually be sent). Now, the Server_Cursor packet is only sent to players that are already loaded (as it doesn't make sense to send it to players that are loading), and Server_KeepAlive and Server_TimeControl are now handled by the client during loading time too. 