### PR TITLE
Make plans faction-based

### DIFF
--- a/Source/Client/Comp/Map/FactionMapData.cs
+++ b/Source/Client/Comp/Map/FactionMapData.cs
@@ -14,6 +14,7 @@ public class FactionMapData : IExposable
     public DesignationManager designationManager;
     public AreaManager areaManager;
     public ZoneManager zoneManager;
+    public PlanManager planManager;
 
     // Not saved
     public HaulDestinationManager haulDestinationManager;
@@ -43,6 +44,7 @@ public class FactionMapData : IExposable
         designationManager = new DesignationManager(map);
         areaManager = new AreaManager(map);
         zoneManager = new ZoneManager(map);
+        planManager = new PlanManager(map);
     }
 
     public void ExposeData()
@@ -53,6 +55,7 @@ public class FactionMapData : IExposable
         Scribe_Deep.Look(ref designationManager, "designationManager", map);
         Scribe_Deep.Look(ref areaManager, "areaManager", map);
         Scribe_Deep.Look(ref zoneManager, "zoneManager", map);
+        Scribe_Deep.Look(ref planManager, "planManager", map);
 
         ExposeActor.OnPostInit(() => map.PopFaction());
     }
@@ -71,6 +74,7 @@ public class FactionMapData : IExposable
             designationManager = map.designationManager,
             areaManager = map.areaManager,
             zoneManager = map.zoneManager,
+            planManager = map.planManager,
 
             haulDestinationManager = map.haulDestinationManager,
             listerHaulables = map.listerHaulables,

--- a/Source/Client/Comp/Map/MultiplayerMapComp.cs
+++ b/Source/Client/Comp/Map/MultiplayerMapComp.cs
@@ -129,6 +129,7 @@ namespace Multiplayer.Client
             map.designationManager = data.designationManager;
             map.areaManager = data.areaManager;
             map.zoneManager = data.zoneManager;
+            map.planManager = data.planManager;
 
             map.haulDestinationManager = data.haulDestinationManager;
             map.listerHaulables = data.listerHaulables;


### PR DESCRIPTION
Added `PlanManager` to `FactionMapData`, initialized it, and exposed. It'll also be applied from `SetFaction` call.

I'll be honest, I expected this to need much more work than it actually was? Everything seems to be handled due to the faction being set properly where it needs to be set. Everything seems to work fine on my end.

Unrelated to this PR, but we may need to double-check the plan renaming feature since it seems to cause a double write/read.