### PR TITLE
Use dedicated PacketHandlerInvoker delegate for handling packets

### DIFF
--- a/Source/Common/Networking/AsyncConnectionState.cs
+++ b/Source/Common/Networking/AsyncConnectionState.cs
@@ -78,12 +78,11 @@ public abstract class AsyncConnectionState(ConnectionBase connection) : MpConnec
     public override PacketHandlerInfo? GetPacketHandler(Packets packet)
     {
         if (packetAwaitable != null && packetAwaitable.PacketType == packet)
-            return new PacketHandlerInfo((_, args) =>
+            return new PacketHandlerInfo((_, data) =>
             {
                 var source = packetAwaitable;
                 packetAwaitable = null;
-                source.SetResult((ByteReader)args[0]);
-                return null;
+                source.SetResult(data);
             }, packetAwaitable.Fragment);
 
         return base.GetPacketHandler(packet);

--- a/Source/Common/Networking/MpConnectionState.cs
+++ b/Source/Common/Networking/MpConnectionState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Reflection.Emit;
 using HarmonyLib;
 
 namespace Multiplayer.Common
@@ -54,14 +55,11 @@ namespace Multiplayer.Common
 
         private static void RegisterPacketHandler(ConnectionStateEnum state, MethodInfo method, PacketHandlerAttribute attr)
         {
-            if (method.GetParameters().Length != 1 || method.GetParameters()[0].ParameterType != typeof(ByteReader))
-                throw new Exception($"Bad packet handler signature for {method}");
-
             var packetHandlerInfo = packetHandlers[(int)state, (int)attr.packet];
             if (packetHandlerInfo == null)
             {
                 packetHandlers[(int)state, (int)attr.packet] =
-                    new PacketHandlerInfo(MethodInvoker.GetHandler(method), attr.allowFragmented);
+                    new PacketHandlerInfo(CreateInvoker(attr.packet, method), attr.allowFragmented);
                 return;
             }
             if (packetHandlerInfo.Method != null)
@@ -72,8 +70,23 @@ namespace Multiplayer.Common
 
             packetHandlers[(int)state, (int)attr.packet] = packetHandlerInfo with
             {
-                Method = MethodInvoker.GetHandler(method), Fragment = attr.allowFragmented
+                Method = CreateInvoker(attr.packet, method), Fragment = attr.allowFragmented
             };
+        }
+
+        private static PacketHandlerInvoker CreateInvoker(Packets packet, MethodInfo handler)
+        {
+            if (handler.GetParameters().Length != 1 || handler.GetParameters()[0].ParameterType != typeof(ByteReader))
+                throw new Exception($"Bad packet handler signature for {handler}");
+
+            DynamicMethod invoker = new DynamicMethod($"PacketHandlerInvoker_{packet}_{handler.Name}", typeof(void), [typeof(object), typeof(ByteReader)]);
+            var il = invoker.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, handler.DeclaringType ?? throw new InvalidOperationException());
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, handler);
+            il.Emit(OpCodes.Ret);
+            return (PacketHandlerInvoker)invoker.CreateDelegate(typeof(PacketHandlerInvoker));
         }
 
         private static void RegisterFragmentedPacketHandler(ConnectionStateEnum state, MethodInfo method, FragmentedPacketHandlerAttribute attr)

--- a/Source/Common/Networking/PacketHandlerAttribute.cs
+++ b/Source/Common/Networking/PacketHandlerAttribute.cs
@@ -19,5 +19,7 @@ namespace Multiplayer.Common
         public readonly Packets packet = packet;
     }
 
-    public record PacketHandlerInfo(FastInvokeHandler Method, bool Fragment, FastInvokeHandler? FragmentHandler = null);
+    public delegate void PacketHandlerInvoker(object target, ByteReader data);
+
+    public record PacketHandlerInfo(PacketHandlerInvoker Method, bool Fragment, FastInvokeHandler? FragmentHandler = null);
 }


### PR DESCRIPTION
Now the invoker's signature is actually truthful and the code to generate a delegate for it is more straightforward than with the MethodInvoker.