### PR TITLE
Extra null safety for faction data, fix errors with #670

### DIFF
--- a/Source/Client/Comp/Map/FactionMapData.cs
+++ b/Source/Client/Comp/Map/FactionMapData.cs
@@ -57,6 +57,14 @@ public class FactionMapData : IExposable
         Scribe_Deep.Look(ref zoneManager, "zoneManager", map);
         Scribe_Deep.Look(ref planManager, "planManager", map);
 
+        if (Scribe.mode == LoadSaveMode.LoadingVars)
+        {
+            designationManager = new DesignationManager(map);
+            areaManager = new AreaManager(map);
+            zoneManager = new ZoneManager(map);
+            planManager = new PlanManager(map);
+        }
+
         ExposeActor.OnPostInit(() => map.PopFaction());
     }
 

--- a/Source/Client/Comp/World/FactionWorldData.cs
+++ b/Source/Client/Comp/World/FactionWorldData.cs
@@ -35,6 +35,12 @@ public class FactionWorldData : IExposable
 
         if (Scribe.mode == LoadSaveMode.LoadingVars)
         {
+            researchManager ??= new ResearchManager();
+            drugPolicyDatabase ??= new DrugPolicyDatabase();
+            outfitDatabase ??= new OutfitDatabase();
+            foodRestrictionDatabase ??= new FoodRestrictionDatabase();
+            playSettings ??= new PlaySettings();
+
             history ??= new History();
             storyteller ??= new Storyteller(Find.Storyteller.def, Find.Storyteller.difficultyDef,
                 Find.Storyteller.difficulty);


### PR DESCRIPTION
#670 was causing errors due to the `planManager` field being null when exposing data, so to fix it I've made sure it's created if null.

However, I've decided to initialize all relevant map/world faction fields if null for all factions in case of any weird errors or issues.