### PR TITLE
Refactor latency update handling

### DIFF
--- a/Source/Client/Networking/NetworkingSteam.cs
+++ b/Source/Client/Networking/NetworkingSteam.cs
@@ -1,6 +1,7 @@
 using Multiplayer.Common;
 using Steamworks;
 using System;
+using System.Diagnostics;
 using Verse;
 
 namespace Multiplayer.Client.Networking
@@ -89,6 +90,14 @@ namespace Multiplayer.Client.Networking
 
     public class SteamServerConn(CSteamID remoteId, ushort clientChannel) : SteamBaseConn(remoteId, 0, clientChannel)
     {
+        private readonly Stopwatch keepAliveTimer = new();
+
+        public override void Send(Packets id, byte[] message, bool reliable = true)
+        {
+            if (id == Packets.Server_KeepAlive) keepAliveTimer.Restart();
+            base.Send(id, message, reliable);
+        }
+
         protected override void HandleReceiveMsg(int msgId, int fragState, ByteReader reader, bool reliable)
         {
             if (msgId == (int)Packets.Special_Steam_Disconnect)
@@ -103,6 +112,15 @@ namespace Multiplayer.Client.Networking
         public override void OnError(EP2PSessionError error)
         {
             OnDisconnect();
+        }
+
+        public override void OnKeepAliveArrived(bool idMatched)
+        {
+            if (!idMatched) return;
+            // We are ticking network logic every ~30ms, which means that effectively the lowest ping achievable is
+            // ~15ms.
+            Latency = (Latency * 4 + (int)keepAliveTimer.ElapsedMilliseconds / 2) / 5;
+            keepAliveTimer.Reset();
         }
 
         private void OnDisconnect()

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -24,6 +24,7 @@ namespace Multiplayer.Common
         public const int MaxUsernameLength = 15;
         public const int MinUsernameLength = 3;
         public const char EndpointSeparator = '&';
+        public const int NetTicksPerSecond = 30; // Not an exact amount. The net loop isn't particularly precise.
 
         public static readonly Regex UsernamePattern = new(@"^[a-zA-Z0-9_]+$");
 
@@ -133,8 +134,8 @@ namespace Multiplayer.Common
                         ServerLog.Log($"Server tick took {tickTime.ElapsedMillisDouble()}ms");
 
                     // On Windows, the clock ticks 64 times a second and sleep durations too close to a multiple of 15.625ms
-                    // tend to be rounded up so we sleep for a bit less
-                    int sleepFor = (int)Math.Floor((1000 / 30f - tickTime.ElapsedMillisDouble()) * 0.9f);
+                    // tend to be rounded up, so we sleep for a bit less
+                    int sleepFor = (int)Math.Floor((1000d / NetTicksPerSecond - tickTime.ElapsedMillisDouble()) * 0.9f);
                     if (sleepFor > 0)
                         Thread.Sleep(sleepFor);
                 }
@@ -158,11 +159,11 @@ namespace Multiplayer.Common
         {
             NetTimer++;
 
-            // We aim to tick 30 times a second, so this is once per second.
-            if (NetTimer % 30 == 0)
+            if (NetTimer % NetTicksPerSecond == 0)
                 playerManager.SendLatencies();
 
-            if (NetTimer % 6 == 0)
+
+            if (NetTimer % (NetTicksPerSecond / 5) == 0)
             {
                 foreach (var player in JoinedPlayers) {
                     player.SendKeepAlivePacket();

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -258,6 +258,11 @@ namespace Multiplayer.Common
 
         public abstract void Close(MpDisconnectReason reason, byte[]? data = null);
 
+        /// Invoked after a keep alive timer arrives. Only used by the server
+        public virtual void OnKeepAliveArrived(bool idMatched)
+        {
+        }
+
         public static byte[] GetDisconnectBytes(MpDisconnectReason reason, byte[]? data = null)
         {
             var writer = new ByteWriter();

--- a/Source/Common/Networking/LiteNetConnection.cs
+++ b/Source/Common/Networking/LiteNetConnection.cs
@@ -22,6 +22,13 @@ namespace Multiplayer.Common
             peer.NetManager.DisconnectPeer(peer, GetDisconnectBytes(reason, data));
         }
 
+        public override void OnKeepAliveArrived(bool idMatched)
+        {
+            // Latency already handled by LiteNetLib. This can be as low as 0ms because LNL spawns its own thread for
+            // receiving packets and immediately processes its own internal keep alive packet (called Ping-Pong).
+            // This is handled only on the server-side in MpServerNetListener
+        }
+
         public override string ToString()
         {
             return $"NetConnection ({peer.EndPoint}) ({username})";

--- a/Source/Common/Networking/State/ServerPlayingState.cs
+++ b/Source/Common/Networking/State/ServerPlayingState.cs
@@ -190,19 +190,9 @@ namespace Multiplayer.Common
             if (Player.IsHost)
                 Server.workTicks = workTicks;
 
-            // Latency already handled by LiteNetLib. This can be as low as 0ms because LNL spawns its own thread for
-            // receiving packets and immediately processes its own internal keep alive packet (called Ping-Pong).
-            if (connection is LiteNetConnection) return;
-
-            if (Player.keepAliveId == id)
-            {
-                // We are ticking network logic every ~30ms, which means that effectively the lowest ping achievable is
-                // ~15ms.
-                connection.Latency = (connection.Latency * 4 + (int)Player.keepAliveTimer.ElapsedMilliseconds / 2) / 5;
-
-                Player.keepAliveId++;
-                Player.keepAliveTimer.Reset();
-            }
+            var idMatched = Player.keepAliveId == id;
+            connection.OnKeepAliveArrived(idMatched);
+            if (idMatched) Player.keepAliveId++;
         }
 
         [PacketHandler(Packets.Client_SyncInfo, allowFragmented: true)]

--- a/Source/Common/ServerPlayer.cs
+++ b/Source/Common/ServerPlayer.cs
@@ -25,12 +25,11 @@ namespace Multiplayer.Common
         public int lastCursorTick = -1;
 
         public int keepAliveId;
-        public Stopwatch keepAliveTimer = new();
         public int keepAliveAt;
 
         public bool frozen;
         public int unfrozenAt;
-        
+
         // Track which map the player is currently on (from cursor updates)
         public int currentMap = -1;
 
@@ -74,14 +73,8 @@ namespace Multiplayer.Common
             Server.playerManager.SetDisconnected(conn, reason);
         }
 
-        public void SendKeepAlivePacket()
-        {
-            if (!keepAliveTimer.IsRunning)
-            {
-                keepAliveTimer.Start();
-            }
+        public void SendKeepAlivePacket() =>
             SendPacket(Packets.Server_KeepAlive, ByteWriter.GetBytes(keepAliveId), false);
-        }
 
         public void SendPacket(Packets packet, byte[] data, bool reliable = true)
         {


### PR DESCRIPTION
The way to update latency depends on the connection type, so the related
 code should live in the connection, instead of being a leaky abstraction
 and seeping into the connection state and the server player
 (keepAliveTimer).