### PR TITLE
Fog clearing and Slave warnings in Multifaction

### DIFF
--- a/Source/Client/Patches/StkMultiplayerPatch_Fog.cs
+++ b/Source/Client/Patches/StkMultiplayerPatch_Fog.cs
@@ -1,32 +1,19 @@
 using HarmonyLib;
 using Verse;
 using RimWorld;
-using Multiplayer.API;
 
 namespace Multiplayer.Client;
 
 [HarmonyPatch(typeof(FogGrid), nameof(FogGrid.Notify_PawnEnteringDoor))]
-public static class Patch_FogGrid_Notify_PawnEnteringDoor
+public static class Patch_FogGrid_Faction
 {
-	public static bool Prefix(FogGrid __instance, Building_Door door, Pawn pawn)
+	static void Prefix(FogGrid __instance, Building_Door door, Pawn pawn)
 	{
-		if (!MP.IsInMultiplayer) return true;
-
-		if (IsPlayerControlledFaction(pawn.Faction) || IsPlayerControlledFaction(pawn.HostFaction))
-			__instance.FloodUnfogAdjacent(door.Position, false);
-
-		return false;
+		FactionContext.Push(pawn.Faction);
 	}
 
-	private static bool IsPlayerControlledFaction(Faction faction)
+	static void Finalizer()
 	{
-		if (faction == null) return false;
-
-		// Vanilla single-player
-		if (faction == Faction.OfPlayer) return true;
-
-		// Multiplayer: works for the original host faction FOR SURE, need more testing for clients
-		return faction.IsPlayer;
+		FactionContext.Pop();
 	}
-
 }

--- a/Source/Client/Patches/StkMultiplayerPatch_Fog.cs
+++ b/Source/Client/Patches/StkMultiplayerPatch_Fog.cs
@@ -1,0 +1,31 @@
+using HarmonyLib;
+using Verse;
+using RimWorld;
+using Multiplayer.API;
+
+namespace StkMultiplayerPatch;
+
+[HarmonyPatch(typeof(FogGrid), nameof(FogGrid.Notify_PawnEnteringDoor))]
+public static class Patch_FogGrid_Notify_PawnEnteringDoor
+{
+	public static bool Prefix(FogGrid __instance, Building_Door door, Pawn pawn)
+	{
+		if (!MP.IsInMultiplayer) return true;
+
+		if (IsPlayerControlledFaction(pawn.Faction) || IsPlayerControlledFaction(pawn.HostFaction))
+			__instance.FloodUnfogAdjacent(door.Position, false);
+
+		return false;
+	}
+
+	private static bool IsPlayerControlledFaction(Faction faction)
+	{
+		if (faction == null) return false;
+
+		// Vanilla single-player
+		if (faction == Faction.OfPlayer) return true;
+
+		// Multiplayer: works for the original host faction FOR SURE, need more testing for clients
+		return faction.IsPlayer;
+	}
+}

--- a/Source/Client/Patches/StkMultiplayerPatch_Fog.cs
+++ b/Source/Client/Patches/StkMultiplayerPatch_Fog.cs
@@ -3,7 +3,7 @@ using Verse;
 using RimWorld;
 using Multiplayer.API;
 
-namespace StkMultiplayerPatch;
+namespace Multiplayer.Client;
 
 [HarmonyPatch(typeof(FogGrid), nameof(FogGrid.Notify_PawnEnteringDoor))]
 public static class Patch_FogGrid_Notify_PawnEnteringDoor
@@ -28,4 +28,5 @@ public static class Patch_FogGrid_Notify_PawnEnteringDoor
 		// Multiplayer: works for the original host faction FOR SURE, need more testing for clients
 		return faction.IsPlayer;
 	}
+
 }

--- a/Source/Client/Patches/StkMultiplayerPatch_SlaveWarning.cs
+++ b/Source/Client/Patches/StkMultiplayerPatch_SlaveWarning.cs
@@ -4,7 +4,7 @@ using Multiplayer.API;
 using System.Collections.Generic;
 using RimWorld;
 
-namespace StkMultiplayerPatch;
+namespace Multiplayer.Client;
 
 // Fixing "slaves unattended" warning when other faction has slaves
 [HarmonyPatch(typeof(SlaveRebellionUtility), nameof(SlaveRebellionUtility.IsUnattendedByColonists))]
@@ -66,4 +66,5 @@ public static class Patch_Alert_SlavesUnsuppressed_Targets
 		__result = result;
 		return false;
 	}
+
 }

--- a/Source/Client/Patches/StkMultiplayerPatch_SlaveWarning.cs
+++ b/Source/Client/Patches/StkMultiplayerPatch_SlaveWarning.cs
@@ -1,0 +1,69 @@
+using HarmonyLib;
+using Verse;
+using Multiplayer.API;
+using System.Collections.Generic;
+using RimWorld;
+
+namespace StkMultiplayerPatch;
+
+// Fixing "slaves unattended" warning when other faction has slaves
+[HarmonyPatch(typeof(SlaveRebellionUtility), nameof(SlaveRebellionUtility.IsUnattendedByColonists))]
+public static class Patch_SlaveRebellionUtility_IsUnattendedByColonists
+{
+	public static bool Prefix(Map map, ref bool __result)
+	{
+		if (!MP.IsInMultiplayer) return true;
+
+		foreach (Pawn slave in map.mapPawns.SlavesOfColonySpawned)
+		{
+			if (slave.Faction == Faction.OfPlayer)
+			{
+				foreach (Pawn pawn in map.mapPawns.FreeColonistsSpawned)
+				{
+					if (!pawn.IsSlave && !pawn.Downed && !pawn.Dead)
+					{
+						// Player faction free pawn can attend the slaves
+						__result = false;
+						return false;
+					}
+				}
+				// Player faction slaves unattended
+				__result = true;
+				return false;
+			}
+		}
+		// No player faction slaves
+		__result = false;
+		return false;
+	}
+}
+
+// Also fix for the "Alert_SlavesUnsuppressed" as it doesnt check faction
+[HarmonyPatch(typeof(Alert_SlavesUnsuppressed), nameof(Alert_SlavesUnsuppressed.Targets), MethodType.Getter)]
+public static class Patch_Alert_SlavesUnsuppressed_Targets
+{
+	public static bool Prefix(ref List<Pawn> __result)
+	{
+		if (!MP.IsInMultiplayer) return true;
+
+		var result = new List<Pawn>();
+
+		foreach (var map in Find.Maps)
+		{
+			foreach (var pawn in map.mapPawns.FreeColonistsSpawned)
+			{
+				if (pawn.IsSlave &&
+					!pawn.Suspended &&
+					pawn.Faction == Faction.OfPlayer &&
+					pawn.needs.TryGetNeed(out Need_Suppression need_Suppression) &&
+					need_Suppression.IsHigh)
+				{
+					result.Add(pawn);
+				}
+			}
+		}
+
+		__result = result;
+		return false;
+	}
+}


### PR DESCRIPTION
2 of my patches, They work perfectly for my multifaction gameplay, should be safe in any other scenario too.

Fog of war uncovering is the major one, fixes a lot of frustrating problems on the combat maps.
Slave warning is a minor fix, but also quite safe and disables an annoying, (almost) always presented warning.

I tested them as a part of a separate mod! I have no idea what I'm doing with github, so I just placed both patches into "Source/Client/Patches" as a separate files and changed the namespace to multiplayer one. I think that should work, but please check as I could break something.

I changed fog clearing patch to what Tick has suggested, tested it and it was working fine.
