### PR TITLE
Clean up stack traces by removing useless info and shortening paths

### DIFF
--- a/Source/Client/Desyncs/StackTraceLogItem.cs
+++ b/Source/Client/Desyncs/StackTraceLogItem.cs
@@ -64,7 +64,7 @@ namespace Multiplayer.Client
                     if (!methodNameCache.TryGetValue(addr, out string method))
                         methodNameCache[addr] = method = Native.MethodNameFromAddr(raw[i], false);
 
-                    builder.AppendLine(method != null ? SyncCoordinator.CleanedMethodName(method) : "Null");
+                    builder.AppendLine(method != null ? SyncCoordinator.PossiblyCleanedMethodName(method) : "Null");
                 }
 
                 return builder.ToString();

--- a/Source/Client/Desyncs/SyncCoordinator.cs
+++ b/Source/Client/Desyncs/SyncCoordinator.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using LudeonTK;
 using RimWorld;
 using Verse;
 using Multiplayer.Client.Desyncs;
@@ -243,9 +244,14 @@ namespace Multiplayer.Client
             OpinionInBuilding.desyncStackTraceHashes.Add(hash);
         }
 
-        private static readonly Regex RemoveUnknownSourceInfoRegex = new(@"in <([a-zA-Z0-9]+)>:0");
-        public static string CleanedMethodName(string rawName)
+        [TweakValue("Multiplayer")]
+        public static bool cleanMethodNames = false;
+
+        private static readonly Regex RemoveUnknownSourceInfoRegex = new("in <([a-zA-Z0-9]+)>:0");
+        public static string PossiblyCleanedMethodName(string rawName)
         {
+            if (!cleanMethodNames) return MethodNameWithIL(rawName);
+
             // at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.RimWorld.UniqueIDsManager.GetNextID_Patch2  ...
             // =>
             // at (wrapper dynamic-method) RimWorld.UniqueIDsManager.GetNextID_Patch2  ...


### PR DESCRIPTION
The traces are easier to mentally parse when there isn't as much going on.