### PR TITLE
Fix game freeze when game window is too small

### DIFF
--- a/Source/Client/AsyncTime/TimeControlUI.cs
+++ b/Source/Client/AsyncTime/TimeControlUI.cs
@@ -317,7 +317,7 @@ public static class ColonistBarTimeControl
         if (Multiplayer.Client == null) return;
 
         ColonistBar bar = Find.ColonistBar;
-        if (bar.Entries.Count == 0) return;
+        if (!bar.Visible || bar.Entries.Count == 0) return;
 
         int curGroup = -1;
         foreach (var entry in bar.Entries)


### PR DESCRIPTION
Accessing ColonistBar.Entries causes an infinite loop when the screen width is less than 800px or height is less than 500px