### PR TITLE
Add installation instructions to the continuous release

### DIFF
--- a/.github/workflows/alpha-notes.md
+++ b/.github/workflows/alpha-notes.md
@@ -1,0 +1,13 @@
+﻿### This 'alpha' release is an automatically generated snapshot of the current state of development. It is continuously updated with work-in-progress changes that may be broken, incomplete, or incompatible.
+
+#### Installation
+1. Download the `Multiplayer-beta.zip` file below.
+2. Open your RimWorld installation directory
+   * **Steam**: Right-click RimWorld in your Steam library → `Manage` → `Browse local Files`
+   * Or navigate directly to:
+     - Windows: `C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods`
+     - Mac: `~/Library/Application Support/Steam/steamapps/common/RimWorld/Mods`
+     - Linux: `~/.steam/steam/steamapps/common/RimWorld/Mods`
+3. Extract the zip file into the `Mods` folder.
+   * You should have a `Multiplayer` folder in the `Mods` folder (`Mods/Multiplayer`)
+   * Make sure you do not have this directory structure: `Mods/Multiplayer-beta/Multiplayer`. If you do, move the `Multiplayer` folder to the parent directory.

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -55,6 +55,6 @@ jobs:
     
     - name: Upload new release
       run: |
-        gh release create --target "${{ github.sha }}" --title "Continuous" --notes "This 'alpha' release is an automatically generated snapshot of the current state of development. It is continuously updated with work-in-progress changes that may be broken, incomplete, or incompatible." --draft "continuous"
+        gh release create --target "${{ github.sha }}" --title "Continuous" --notes-file ".github/workflows/alpha-notes.md" --draft "continuous"
         gh release upload "continuous" Multiplayer-beta.zip
         gh release edit "continuous" --draft=false


### PR DESCRIPTION
You can see a demo at: https://github.com/mibac138/Rimworld-Multiplayer/releases/tag/continuous