### PR TITLE
DebugModeLabel: fix cut off text when Disable tiny font is enabled

### DIFF
--- a/Source/Client/UI/IngameDebug.cs
+++ b/Source/Client/UI/IngameDebug.cs
@@ -143,17 +143,19 @@ public static class IngameDebug
 
     internal static float DoDebugModeLabel(float y)
     {
-        float x = UI.screenWidth - BtnWidth - BtnMargin;
+        const float width = 90f;
+        float x = UI.screenWidth - width - BtnMargin;
 
         if (Multiplayer.Client != null && Multiplayer.GameComp.debugMode)
         {
             var text = "Debug mode\n";
             if (Multiplayer.LocalServer != null) text += "Host";
             else text += "Client";
+            var height = Text.CalcHeight(text, width);
             using (MpStyle.Set(GameFont.Tiny).Set(TextAnchor.MiddleCenter))
-                Widgets.Label(new Rect(x, y, BtnWidth, 30f), text);
+                Widgets.Label(new Rect(x, y, width, height), text);
 
-            return BtnHeight;
+            return height;
         }
 
         return 0;


### PR DESCRIPTION
Before: 
<img width="171" height="225" alt="image" src="https://github.com/user-attachments/assets/7beeef48-c681-489c-a586-d29490ba3643" />
After:
<img width="183" height="250" alt="image" src="https://github.com/user-attachments/assets/c4645514-104a-4a6a-8d61-cdb0f18a4a1b" />
