### PR TITLE
Change dependabot.yaml encoding to UTF-8 without BOM

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-﻿version: 2
+version: 2
 updates:
   - package-ecosystem: gitsubmodule
     directory: /


### PR DESCRIPTION
I now believe that the dependabot config issue is caused by the config file being encoded with UTF-8 BOM. Change the file to use UTF-8 (no BOM). Sorry for this back-and-forth with PRs regarding this. For reference, the previous PR: #705