### PR TITLE
PerformanceRecorder: fix saving exception

### DIFF
--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -68,6 +68,7 @@ namespace Multiplayer.Client
 
         public static string ReplaysDir => GenFilePaths.FolderUnderSaveData("MpReplays");
         public static string DesyncsDir => GenFilePaths.FolderUnderSaveData("MpDesyncs");
+        public static string LogsDir => GenFilePaths.FolderUnderSaveData("MpLogs");
 
         public static Stopwatch clock = Stopwatch.StartNew();
 

--- a/Source/Client/UI/DebugPanel/PerformanceRecorder.cs
+++ b/Source/Client/UI/DebugPanel/PerformanceRecorder.cs
@@ -428,8 +428,8 @@ public static class PerformanceRecorder
     {
         try
         {
-            var fileName = $"MpLogs/MpPerf-{results.StartTime:MMddHHmmss}.txt";
-            var filePath = Path.Combine(GenFilePaths.SaveDataFolderPath, fileName);
+            var fileName = $"MpPerf-{results.StartTime:MMddHHmmss}.txt";
+            var filePath = Path.Combine(Multiplayer.LogsDir, fileName);
 
             var sb = new StringBuilder();
             sb.AppendLine("MULTIPLAYER PERFORMANCE RECORDING RESULTS");


### PR DESCRIPTION
The MpLogs directory was not created automatically anywhere, which
caused an exception that the file could not be saved.