### PR TITLE
VersionChecker: ignore dirty Git hashes for continuous releases

### DIFF
--- a/Source/Client/Util/VersionChecker.cs
+++ b/Source/Client/Util/VersionChecker.cs
@@ -37,7 +37,8 @@ public static class VersionChecker
 
     private static bool isContinuousRelease =
         Multiplayer.modContentPack.ModMetaData.Source == ContentSource.ModsFolder &&
-        MpVersion.GitDescription?.StartsWith("continuous") == true;
+        MpVersion.GitDescription?.StartsWith("continuous") == true &&
+        MpVersion.GitHash?.EndsWith("dirty") == false;
 
     private static async Task<Release?> GetLatestContinuousRelease()
     {


### PR DESCRIPTION
When git hash ends with dirty, it means that some files were modified during compilation and the changes weren't committed. Release artifacts are not supposed to be dirty, so this hides the dialog only during local development (even if running in release mode).