### PR TITLE
SyncDebugPanel: fix text clipping when tiny font is disabled

### DIFF
--- a/Source/Client/UI/DebugPanel/SyncDebugPanel.cs
+++ b/Source/Client/UI/DebugPanel/SyncDebugPanel.cs
@@ -303,8 +303,8 @@ namespace Multiplayer.Client.DebugUi
 
                     float nonPerfInterval = PerformanceRecorder.NonPerfFrameIntervalSetting;
                     var nonPerfLabelRect = new Rect(x, currentY, width, lineHeight);
-                    Widgets.Label(nonPerfLabelRect, $"Non-performance metric sample interval: {nonPerfInterval}");
-                    currentY += lineHeight + 1;
+                    Widgets.Label(nonPerfLabelRect, ref currentY, $"Non-performance metric sample interval: {nonPerfInterval}");
+                    currentY += 1;
 
                     var nonPerfSliderRect = new Rect(x, currentY, width, lineHeight);
                     nonPerfInterval = Widgets.HorizontalSlider(nonPerfSliderRect, nonPerfInterval, 1f, 300f, roundTo: 0);
@@ -623,21 +623,25 @@ namespace Multiplayer.Client.DebugUi
             float labelWidth = width * LabelColumnWidth;
             float valueWidth = width * (1f - LabelColumnWidth);
 
+            float height = 0;
             // Label with right padding
             using (MpStyle.Set(GameFont.Tiny).Set(Color.white).Set(TextAnchor.MiddleLeft))
             {
-                Rect labelRect = new(x, y, labelWidth - 4f, LineHeight);
+                var labelRect = new Rect(x, y, labelWidth - 4f, LineHeight).FitToTextWithinWidth(label);
                 Widgets.Label(labelRect, label);
+                height = labelRect.height;
             }
 
             // Value with left padding
             using (MpStyle.Set(GameFont.Tiny).Set(valueColor).Set(TextAnchor.MiddleLeft))
             {
-                Rect valueRect = new(x + labelWidth + 4f, y, valueWidth - 4f, LineHeight);
+                var valueRect =
+                    new Rect(x + labelWidth + 4f, y, valueWidth - 8f, LineHeight).FitToTextWithinWidth(value);
                 Widgets.Label(valueRect, value);
+                height = Math.Max(height, valueRect.height);
             }
 
-            return y + LineHeight + 1f; // Small padding between lines
+            return y + height;
         }
     }
 }

--- a/Source/Client/Util/RectExtensions.cs
+++ b/Source/Client/Util/RectExtensions.cs
@@ -119,6 +119,13 @@ namespace Multiplayer.Client
             return rect;
         }
 
+        public static Rect FitToTextWithinWidth(this Rect rect, string text)
+        {
+            var height = Text.CalcHeight(text, rect.width);
+            rect.height = height;
+            return rect;
+        }
+
         public static Rect MarginLeft(this Rect rect, float margin)
         {
             rect.x += margin;


### PR DESCRIPTION
The increased spacing between entries is a side effect of the height calculation.

Before:
<img width="369" height="515" alt="image" src="https://github.com/user-attachments/assets/65d24e5b-5a27-4b4c-8719-26177ec785f0" />
<img width="381" height="459" alt="image" src="https://github.com/user-attachments/assets/d4f47656-d059-4ffe-811a-e01aef3f6591" />


After:
<img width="370" height="204" alt="image" src="https://github.com/user-attachments/assets/239322ad-5e2b-4e6f-8aba-a8f931b3fb4e" />
<img width="366" height="292" alt="image" src="https://github.com/user-attachments/assets/bb96386f-571c-4f46-9f61-c26ad7448f34" />
<img width="352" height="237" alt="image" src="https://github.com/user-attachments/assets/9e9e61c3-d119-42b3-b242-ff10487deac3" />
<img width="367" height="237" alt="image" src="https://github.com/user-attachments/assets/801668ee-0f40-4655-8740-af3161211789" />