### PR TITLE
ScheduledCommand: client-side issuedBySelf

### DIFF
--- a/Source/Client/AsyncTime/AsyncTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncTimeComp.cs
@@ -260,7 +260,7 @@ namespace Multiplayer.Client
             Current.Game.currentMapIndex = (sbyte)map.Index;
 
             executingCmdMap = map;
-            TickPatch.currentExecutingCmdIssuedBySelf = cmd.issuedBySelf && !TickPatch.Simulating;
+            TickPatch.currentExecutingCmdIssuedBySelf = cmd.IsIssuedBySelf() && !TickPatch.Simulating;
             TickPatch.currentExecutingCmdType = cmdType;
 
             PreContext();

--- a/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
@@ -171,7 +171,7 @@ public class AsyncWorldTimeComp : IExposable, ITickable
         LoggingByteReader data = new LoggingByteReader(cmd.data);
         data.Log.Node($"{cmdType} Global");
 
-        TickPatch.currentExecutingCmdIssuedBySelf = cmd.issuedBySelf && !TickPatch.Simulating;
+        TickPatch.currentExecutingCmdIssuedBySelf = cmd.IsIssuedBySelf() && !TickPatch.Simulating;
         TickPatch.currentExecutingCmdType = cmdType;
 
         PreContext();
@@ -289,7 +289,7 @@ public class AsyncWorldTimeComp : IExposable, ITickable
         {
             SetTimeEverywhere(speed);
 
-            if (!cmd.issuedBySelf)
+            if (!cmd.IsIssuedBySelf())
                 lastSpeedChange = Time.realtimeSinceStartup;
         }
 

--- a/Source/Client/Networking/HostUtil.cs
+++ b/Source/Client/Networking/HostUtil.cs
@@ -196,6 +196,8 @@ namespace Multiplayer.Client
             var server = Multiplayer.LocalServer;
             var player = server.playerManager.OnConnected(serverConnection);
             server.playerManager.MakeHost(player);
+            // Normally set during ClientJoiningState, but when hosting we skip straight through to the playing state.
+            Multiplayer.session.playerId = player.id;
         }
 
         private static void StartLocalServer()

--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -21,7 +21,6 @@ namespace Multiplayer.Client
         public void HandleCommand(ByteReader data)
         {
             ScheduledCommand cmd = ScheduledCommand.Deserialize(data);
-            cmd.issuedBySelf = data.ReadBool();
             Session.ScheduleCommand(cmd);
 
             Multiplayer.session.receivedCmds++;

--- a/Source/Client/Util/Extensions.cs
+++ b/Source/Client/Util/Extensions.cs
@@ -96,7 +96,7 @@ namespace Multiplayer.Client
             SendCommand(conn, type, mapId, ByteWriter.GetBytes(data));
         }
 
-        public static bool IsIssuedBySelf(this ScheduledCommand cmd) => cmd.playerId == Multiplayer.session.playerId;
+        public static bool IsIssuedBySelf(this ScheduledCommand cmd) => cmd.playerId == Multiplayer.session?.playerId;
 
         public static MpContext MpContext(this ByteReader data)
         {

--- a/Source/Client/Util/Extensions.cs
+++ b/Source/Client/Util/Extensions.cs
@@ -96,6 +96,8 @@ namespace Multiplayer.Client
             SendCommand(conn, type, mapId, ByteWriter.GetBytes(data));
         }
 
+        public static bool IsIssuedBySelf(this ScheduledCommand cmd) => cmd.playerId == Multiplayer.session.playerId;
+
         public static MpContext MpContext(this ByteReader data)
         {
             if (data.context == null)

--- a/Source/Common/CommandHandler.cs
+++ b/Source/Common/CommandHandler.cs
@@ -33,7 +33,7 @@ namespace Multiplayer.Common
                     return;
             }
 
-            byte[] toSave = ScheduledCommand.Serialize(
+            byte[] serialized = ScheduledCommand.Serialize(
                 new ScheduledCommand(
                     cmd,
                     server.gameTimer,
@@ -43,19 +43,9 @@ namespace Multiplayer.Common
                     data));
 
             // todo cull target players if not global
-            server.worldData.mapCmds.GetOrAddNew(mapId).Add(toSave);
-            server.worldData.tmpMapCmds?.GetOrAddNew(mapId).Add(toSave);
-
-            byte[] toSend = toSave.Append(new byte[] { 0 });
-            byte[] toSendSource = toSave.Append(new byte[] { 1 });
-
-            foreach (var player in server.PlayingPlayers)
-            {
-                player.conn.Send(
-                    Packets.Server_Command,
-                    sourcePlayer == player ? toSendSource : toSend
-                );
-            }
+            server.worldData.mapCmds.GetOrAddNew(mapId).Add(serialized);
+            server.worldData.tmpMapCmds?.GetOrAddNew(mapId).Add(serialized);
+            server.SendToPlaying(Packets.Server_Command, serialized);
 
             SentCmds++;
         }

--- a/Source/Common/ScheduledCommand.cs
+++ b/Source/Common/ScheduledCommand.cs
@@ -15,9 +15,6 @@ namespace Multiplayer.Common
         public readonly int playerId;
         public readonly byte[] data;
 
-        // Client only, not serialized
-        public bool issuedBySelf;
-
         public ScheduledCommand(CommandType type, int ticks, int factionId, int mapId, int playerId, byte[] data)
         {
             this.type = type;

--- a/Source/Common/ScheduledCommand.cs
+++ b/Source/Common/ScheduledCommand.cs
@@ -2,28 +2,21 @@
 
 namespace Multiplayer.Common
 {
-    public class ScheduledCommand
+    public class ScheduledCommand(CommandType type, int ticks, int factionId, int mapId, int playerId, byte[] data)
     {
         public const int NoFaction = -1;
         public const int Global = -1;
         public const int NoPlayer = -1;
 
-        public readonly CommandType type;
-        public readonly int ticks;
-        public readonly int factionId;
-        public readonly int mapId;
-        public readonly int playerId;
-        public readonly byte[] data;
+        public readonly CommandType type = type;
+        public readonly int ticks = ticks;
+        public readonly int factionId = factionId;
+        public readonly int mapId = mapId;
+        public readonly int playerId = playerId;
+        public readonly byte[] data = data;
 
-        public ScheduledCommand(CommandType type, int ticks, int factionId, int mapId, int playerId, byte[] data)
-        {
-            this.type = type;
-            this.ticks = ticks;
-            this.factionId = factionId;
-            this.mapId = mapId;
-            this.playerId = playerId;
-            this.data = data;
-        }
+        public override string ToString() =>
+            $"Cmd: {type}, faction: {factionId}, map: {mapId}, ticks: {ticks}, player: {playerId}";
 
         public static byte[] Serialize(ScheduledCommand cmd)
         {
@@ -48,11 +41,6 @@ namespace Multiplayer.Common
             byte[] extraBytes = data.ReadPrefixedBytes()!;
 
             return new ScheduledCommand(cmd, ticks, factionId, mapId, playerId, extraBytes);
-        }
-
-        public override string ToString()
-        {
-            return $"Cmd: {type}, faction: {factionId}, map: {mapId}, ticks: {ticks}, player: {playerId}";
         }
 
         public static List<ScheduledCommand> DeserializeCmds(byte[] data)


### PR DESCRIPTION
The server has been sending command packets with `issuedBySelf` info since e52de8d866e992d42b3d28c73b7ea44f60132d86 (2018) when the responsible class was `MultiplayerServer`. About half a year later the client has gained knowledge about their own id in af1928e2d9749bf13d12cfe2aef4f380d5545807. With that change the client can now determine on it's own whether a given command was issued by itself, making the `issuedBySelf` field redundant.