### PR TITLE
Fix PostLoadInit NullReferenceException

### DIFF
--- a/Source/Client/Persistent/SessionManager.cs
+++ b/Source/Client/Persistent/SessionManager.cs
@@ -221,10 +221,12 @@ public class SessionManager : IHasSessionData, ISessionManager
             for (int i = exposableSessions.Count - 1; i >= 0; i--)
             {
                 var session = exposableSessions[i];
-                if (!session.IsSessionValid)
+                if (session is { IsSessionValid: true }) continue;
+
+                // Removal from allSessions handled lower
+                exposableSessions.RemoveAt(i);
+                if (session != null)
                 {
-                    // Removal from allSessions handled lower
-                    exposableSessions.RemoveAt(i);
                     session.PostRemoveSession();
                     var sessionType = session.GetType();
                     if (!tempCleanupLoggingTypes.Add(sessionType))


### PR DESCRIPTION
I have found at least one cause of this - an ExposableSession without a constructor with a single Map parameter. There might be other causes.

Reported [here](https://discord.com/channels/524286515644203028/1071408557314035852/1419257105046700135) and present in the logs of this [report](https://discord.com/channels/524286515644203028/1420952075587686553/1420952075587686553) (this fix isn't the root cause of that report).

Exposable sessions that do not expose a valid constructor:
- CaravanFormingSession
- TransporterLoading
Additionally, while the exposable session CaravanSplittingSession does have the required constructor, it fails to load. That's because caravan splitting is a world-session, not a map session, so the Map argument used in this method call: `Scribe_Collections.Look(ref exposableSessions, "sessions", LookMode.Deep, Map)` is null. That wouldn't normally be an issue, however CaravanSplittingSession has another constructor with a single parameter (Caravan). Because of that, when trying to instantiate the CSSession, an exception is thrown: `AmbiguousMatchException: Ambiguous match found` as null could be used as a parameter to either of the constructors.