### PR TITLE
Verify sessions are valid on startup

### DIFF
--- a/Source/Client/Persistent/CaravanFormingSession.cs
+++ b/Source/Client/Persistent/CaravanFormingSession.cs
@@ -1,8 +1,8 @@
+using System;
+using System.Collections.Generic;
 using Multiplayer.API;
 using RimWorld;
 using RimWorld.Planet;
-using System;
-using System.Collections.Generic;
 using Verse;
 
 namespace Multiplayer.Client
@@ -25,6 +25,14 @@ namespace Multiplayer.Client
         public bool uiDirty;
 
         public override Map Map => map;
+
+        public override bool IsSessionValid => map != null && faction != null;
+
+        // Used when saving and loading
+        private CaravanFormingSession(Map map) : base(map)
+        {
+            this.map = map;
+        }
 
         public CaravanFormingSession(Faction faction, Map map) : base(map)
         {
@@ -165,6 +173,7 @@ namespace Multiplayer.Client
         {
             base.ExposeData();
 
+            Scribe_References.Look(ref faction, "faction");
             Scribe_Values.Look(ref reform, "reform");
             Scribe_Values.Look(ref onClosed, "onClosed");
             Scribe_Values.Look(ref mapAboutToBeRemoved, "mapAboutToBeRemoved");

--- a/Source/Client/Persistent/CaravanSplittingPatches.cs
+++ b/Source/Client/Persistent/CaravanSplittingPatches.cs
@@ -1,7 +1,7 @@
-using Verse;
-using RimWorld.Planet;
 using HarmonyLib;
 using Multiplayer.API;
+using RimWorld.Planet;
+using Verse;
 
 namespace Multiplayer.Client.Persistent
 {
@@ -64,8 +64,7 @@ namespace Multiplayer.Client.Persistent
         [SyncMethod]
         public static void CreateSplittingSession(Caravan caravan)
         {
-            //Start caravan splitting session here by calling new session constructor
-            Multiplayer.WorldComp.sessionManager.AddSession(new CaravanSplittingSession(caravan));
+            Multiplayer.WorldComp.sessionManager.AddSession(CaravanSplittingSession.Of(caravan));
         }
     }
 }

--- a/Source/Client/Persistent/CaravanSplittingSession.cs
+++ b/Source/Client/Persistent/CaravanSplittingSession.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
-using Verse;
+using Multiplayer.API;
 using RimWorld;
 using RimWorld.Planet;
-using Multiplayer.API;
+using Verse;
 using Verse.Sound;
 
 namespace Multiplayer.Client.Persistent
@@ -12,6 +12,7 @@ namespace Multiplayer.Client.Persistent
     /// </summary>
     public class CaravanSplittingSession : ExposableSession, ISessionWithTransferables, ISessionWithCreationRestrictions
     {
+        // This session is only possible on the world, so the map is always null.
         public override Map Map => null;
 
         /// <summary>
@@ -27,13 +28,21 @@ namespace Multiplayer.Client.Persistent
         /// <summary>
         /// The caravan being split.
         /// </summary>
-        public Caravan Caravan { get; private set; }
+        public Caravan Caravan
+        {
+            get => caravan;
+            private set => caravan = value;
+        }
+        private Caravan caravan;
 
         /// <summary>
         /// Reference to the dialog that is being displayed.
         /// </summary>
         public CaravanSplittingProxy dialog;
 
+        public override bool IsSessionValid => Caravan != null;
+
+        // Used when saving and loading
         public CaravanSplittingSession(Map map) : base(null)
         {
         }
@@ -42,11 +51,12 @@ namespace Multiplayer.Client.Persistent
         /// Handles creation of new CaravanSplittingSession.
         /// </summary>
         /// <param name="caravan"></param>
-        public CaravanSplittingSession(Caravan caravan) : base(null)
+        public static CaravanSplittingSession Of(Caravan caravan)
         {
-            Caravan = caravan;
-
-            AddItems();
+            var session = new CaravanSplittingSession(null);
+            session.Caravan = caravan;
+            session.AddItems();
+            return session;
         }
 
         private void AddItems()
@@ -106,6 +116,7 @@ namespace Multiplayer.Client.Persistent
         public override void ExposeData()
         {
             base.ExposeData();
+            Scribe_References.Look(ref caravan, "caravan");
             Scribe_Collections.Look(ref transferables, "transferables", LookMode.Deep);
         }
 

--- a/Source/Client/Persistent/MapPortalSession.cs
+++ b/Source/Client/Persistent/MapPortalSession.cs
@@ -13,16 +13,19 @@ public class MapPortalSession : ExposableSession, ISessionWithTransferables, ISe
 
     public override Map Map => portal.Map;
 
+    public override bool IsSessionValid => portal != null;
+
     public MapPortalSession(Map _) : base(null)
     {
         // Mandatory constructor
     }
 
-    public MapPortalSession(MapPortal portal) : base(null)
+    public static MapPortalSession Of(MapPortal portal)
     {
-        this.portal = portal;
-
-        AddItems();
+        var session = new MapPortalSession(null);
+        session.portal = portal;
+        session.AddItems();
+        return session;
     }
 
     private void AddItems()
@@ -65,7 +68,7 @@ public class MapPortalSession : ExposableSession, ISessionWithTransferables, ISe
     {
         var map = portal.Map;
         var manager = map.MpComp().sessionManager;
-        var session = manager.GetOrAddSession(new MapPortalSession(portal));
+        var session = manager.GetOrAddSession(Of(portal));
 
         // Shouldn't happen and is here for safety.
         if (session == null)

--- a/Source/Client/Persistent/SessionManager.cs
+++ b/Source/Client/Persistent/SessionManager.cs
@@ -188,6 +188,11 @@ public class SessionManager : IHasSessionData, ISessionManager
             }
 
             var objType = ApiSerialization.sessions[typeIndex];
+            if (!typeof(SemiPersistentSession).IsAssignableFrom(objType))
+            {
+                Log.Error($"Received data for ISession type {objType} (index {typeIndex}) that is not a semi persistent session");
+                continue;
+            }
 
             try
             {

--- a/Source/Client/Persistent/TransporterLoadingSession.cs
+++ b/Source/Client/Persistent/TransporterLoadingSession.cs
@@ -20,6 +20,14 @@ namespace Multiplayer.Client
 
         public bool uiDirty;
 
+        public override bool IsSessionValid => map != null && faction != null;
+
+        // Used when saving and loading
+        public TransporterLoading(Map map) : base(map)
+        {
+            this.map = map;
+        }
+
         public TransporterLoading(Faction faction, Map map) : base(map)
         {
             this.map = map;
@@ -95,6 +103,7 @@ namespace Multiplayer.Client
         {
             base.ExposeData();
 
+            Scribe_References.Look(ref faction, "faction");
             Scribe_Collections.Look(ref transferables, "transferables", LookMode.Deep);
             Scribe_Collections.Look(ref pods, "transporters", LookMode.Reference);
 

--- a/Source/Client/Syncing/ApiSerialization.cs
+++ b/Source/Client/Syncing/ApiSerialization.cs
@@ -2,7 +2,6 @@
 using System.Reflection;
 using Multiplayer.API;
 using Multiplayer.Client.Util;
-using Multiplayer.Common;
 using Verse;
 
 namespace Multiplayer.Client;
@@ -17,8 +16,6 @@ public static class ApiSerialization
         syncSimples = TypeCache.AllInterfaceImplementationsOrdered(typeof(ISyncSimple));
         sessions = TypeCache.AllSubclassesNonAbstractOrdered(typeof(Session));
 
-        // TODO enable once all the built-in session types are fixed. Disabled for releases to avoid worrying players
-        if (!MpVersion.IsDebug) return;
         foreach (var sessionType in sessions)
         {
             // The docs don't require the Session's ctor(Map) to be public, and it's not required for an ExposableSession.

--- a/Source/Client/Syncing/ApiSerialization.cs
+++ b/Source/Client/Syncing/ApiSerialization.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Reflection;
 using Multiplayer.API;
 using Multiplayer.Client.Util;
+using Multiplayer.Common;
+using Verse;
 
 namespace Multiplayer.Client;
 
@@ -13,5 +16,59 @@ public static class ApiSerialization
     {
         syncSimples = TypeCache.AllInterfaceImplementationsOrdered(typeof(ISyncSimple));
         sessions = TypeCache.AllSubclassesNonAbstractOrdered(typeof(Session));
+
+        // TODO enable once all the built-in session types are fixed. Disabled for releases to avoid worrying players
+        if (!MpVersion.IsDebug) return;
+        foreach (var sessionType in sessions)
+        {
+            // The docs don't require the Session's ctor(Map) to be public, and it's not required for an ExposableSession.
+            // Only a SemiPersistentSession requires for the constructor to be public
+            if (sessionType.GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, [typeof(Map)], []) == null)
+            {
+                // Required by the docs of the Session type. Further checks are just more specific variations of this
+                // check.
+                Log.Error(
+                    $"[Multiplayer] Session type {sessionType.FullName} is invalid!\n" +
+                    $"It does not have a constructor with a single parameter of type {nameof(Map)}. This will cause " +
+                    $"issues with the session");
+                continue;
+            }
+
+            try
+            {
+                if (typeof(SemiPersistentSession).IsAssignableFrom(sessionType))
+                {
+                    // Used by SessionManager.ReadSessionData
+                    Activator.CreateInstance(sessionType, [null]);
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(
+                    $"[Multiplayer] Session type {sessionType.FullName} is invalid!\n" +
+                    $"It cannot be instantiated with a single null parameter. This will cause issues when the " +
+                    $"session is attached to the world (as opposed to a map). This is likely caused by another " +
+                    $"single-param constructor which cannot be differentiated from the other constructor when the " +
+                    $"value passed is null. In that case consider creating a static factory method instead.\n\n{e}");
+            }
+
+            try
+            {
+                if (typeof(ExposableSession).IsAssignableFrom(sessionType))
+                {
+                    // Used by SessionManager.ExposeSessions (through Scribe_Deep.Look)
+                    ScribeExtractor.CreateInstance(sessionType, [null]);
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(
+                    $"[Multiplayer] Session type {sessionType.FullName} is invalid!\n" +
+                    $"It cannot be instantiated with a single null parameter. This will cause issues when the " +
+                    $"session is attached to the world (as opposed to a map). This is likely caused by another " +
+                    $"single-param constructor which cannot be differentiated from the other constructor when the " +
+                    $"value passed is null. In that case consider creating a static factory method instead.\n\n{e}");
+            }
+        }
     }
 }


### PR DESCRIPTION
Now all ExposableSessions can survive a save-load cycle.

Related: #724