### PR TITLE
Simplify method name normalization

### DIFF
--- a/Source/Client/Debug/DebugActions.cs
+++ b/Source/Client/Debug/DebugActions.cs
@@ -277,6 +277,20 @@ namespace Multiplayer.Client
             Debug.Log(__originalMethod.FullDescription());
         }
 
+        [DebugAction(MultiplayerLocalCategory, "Dump addr info table", allowedGameStates = /* all */ AllowedGameStates.Invalid)]
+        public static void DumpAddrInfoTable()
+        {
+            Log.Message($"Dumping address info table {DeferredStackTracingImpl.hashTable.Entries}");
+            foreach (var addrInfo in DeferredStackTracingImpl.hashTable)
+            {
+                if (addrInfo.nameHash == 0) continue;
+                var normalized = $"`{Native.MethodNameNormalizedFromAddr(addrInfo.addr, true)}`";
+                var normal = Native.MethodNameFromAddr(addrInfo.addr, true);
+                var hash = addrInfo.nameHash;
+                Log.Message($"NORM: {normalized,-130} H:{hash,14} R:`{normal}`");
+            }
+        }
+
 #if DEBUG
 
         [DebugOutput]

--- a/Source/Common/DeferredStackTracingImpl.cs
+++ b/Source/Common/DeferredStackTracingImpl.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using HarmonyLib;
@@ -6,7 +9,7 @@ using Multiplayer.Common;
 
 namespace Multiplayer.Client.Desyncs;
 
-public struct AddrTable()
+public struct AddrTable() : IEnumerable<AddrInfo>
 {
     private const int StartingN = 10; // 1024
     private const int StartingShift = 64 - StartingN;
@@ -70,6 +73,20 @@ public struct AddrTable()
                 newInfo.stackUsage = oldInfo.stackUsage;
                 newInfo.nameHash = oldInfo.nameHash;
             }
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IEnumerator<AddrInfo> GetEnumerator()
+    {
+        // AsEnumerable needed to get a generic IEnumerable<AddrInfo>
+        using var enumerator = hashtable.AsEnumerable().GetEnumerator();
+        while (enumerator.MoveNext())
+        {
+            var addr = enumerator.Current;
+            if (addr.addr == 0) continue;
+            yield return addr;
         }
     }
 }

--- a/Source/Common/Native.cs
+++ b/Source/Common/Native.cs
@@ -74,44 +74,36 @@ namespace Multiplayer.Client
             }
         }
 
-        public static string? MethodNameFromAddr(long addr, bool harmonyOriginals)
+        private static IntPtr MaybeFindHarmonyOriginalMethod(long addr, bool harmonyOriginals)
         {
-            var domain = DomainPtr;
-            var ji = mono_jit_info_table_find(domain, (IntPtr)addr);
+            var ji = mono_jit_info_table_find(DomainPtr, (IntPtr)addr);
+            if (ji == IntPtr.Zero) return IntPtr.Zero;
 
-            if (ji == IntPtr.Zero) return null;
-
-            var ptrToPrint = mono_jit_info_get_method(ji);
+            var ptr = mono_jit_info_get_method(ji);
             var codeStart = (long)mono_jit_info_get_code_start(ji);
 
             if (harmonyOriginals && HarmonyOriginalGetter != null)
             {
                 var original = HarmonyOriginalGetter(codeStart);
                 if (original != null)
-                    ptrToPrint = original.MethodHandle.Value;
+                    ptr = original.MethodHandle.Value;
             }
 
-            var name = mono_debug_print_stack_frame(ptrToPrint, -1, domain);
+            return ptr;
+        }
 
+        public static string? MethodNameFromAddr(long addr, bool harmonyOriginals)
+        {
+            var ptr = MaybeFindHarmonyOriginalMethod(addr, harmonyOriginals);
+            if (ptr == IntPtr.Zero) return null;
+            var name = mono_debug_print_stack_frame(ptr, -1, DomainPtr);
             return string.IsNullOrEmpty(name) ? null : name;
         }
 
         public static string? MethodNameNormalizedFromAddr(long addr, bool harmonyOriginals)
         {
-            var name = MethodNameFromAddr(addr, harmonyOriginals);
-
-            if (name == null) return null;
-            if (name.Length == 0) return name;
-
-            int ilOffsetIndex = name.IndexOf(" [0x", StringComparison.Ordinal);
-            if (ilOffsetIndex >= 0)
-                name = name.Substring(0, ilOffsetIndex);
-
-            int mvidIndex = name.IndexOf(" in <", StringComparison.Ordinal);
-            if (mvidIndex >= 0)
-                name = name.Substring(0, mvidIndex);
-
-            return name.TrimEnd();
+            var ptr = MaybeFindHarmonyOriginalMethod(addr, harmonyOriginals);
+            return ptr == IntPtr.Zero ? null : mono_method_get_reflection_name(ptr);
         }
 
         private static ConstructorInfo runtimeMethodHandleCtor = AccessTools.Constructor(typeof(RuntimeMethodHandle), new[]{typeof(IntPtr)});


### PR DESCRIPTION
Instead of using `mono_debug_print_stack_frame` for trace method names, just use `mono_method_get_reflection_name` which is internally [used by the first method anyway](https://github.com/Unity-Technologies/mono/blob/60122c5a5d7a4f3aa52dcb24860b5d80c5d2bf5e/mono/metadata/mono-debug.c#L959). The method normalization that is performed is mostly just removing the extra stuff that `debug_print_stack_frame` adds and converting it back to `get_reflection_name`. It's simpler and less brittle to just use the method directly. `debug_print_stack_frame` is still used for stack traces in desyncs, this only changes the way we get the method name used by trace hashes.

Example output of the new `Dump addr info table` debug action that shows: in the first column (`NORM:`) the normalized name (using `get_reflection_name`), the hash (`H:`), and the full name (`R:` using `debug_print_stack_frame`)
```
NORM: `Verse.AI.WanderUtility+<>c__DisplayClass6_0.<GetHerdWanderRoot>b__0(Verse.Thing)`                                                 H:    1639916516 R:`at Verse.AI.WanderUtility/<>c__DisplayClass6_0.<GetHerdWanderRoot>b__0 (Verse.Thing) [0x0004a] in <24d25868955f4df08b02c73b55f389fe>:0`
NORM: `RimWorld.Pawn_FilthTracker.GainFilth(Verse.ThingDef)`                                                                             H:   -1324417192 R:`at RimWorld.Pawn_FilthTracker.GainFilth (Verse.ThingDef) [0x0001d] in <24d25868955f4df08b02c73b55f389fe>:0`
NORM: `Verse.Pawn.TickInterval(int)`                                                                                                     H:    1499760298 R:`at Verse.Pawn.TickInterval (int) [0x00355] in <24d25868955f4df08b02c73b55f389fe>:0`
NORM: `Verse.AI.JobGiver_Wander.TryGiveJob(Verse.Pawn)`                                                                                  H:    -624169555 R:`at Verse.AI.JobGiver_Wander.TryGiveJob (Verse.Pawn) [0x00143] in <24d25868955f4df08b02c73b55f389fe>:0`
NORM: `Verse.AI.JobDriver.Notify_PatherArrived()`                                                                                        H:    -990082523 R:`at Verse.AI.JobDriver.Notify_PatherArrived () [0x0001e] in <24d25868955f4df08b02c73b55f389fe>:0`
NORM: `Verse.AI.JobDriver.TryActuallyStartNextToil()`                                                                                    H:     911940829 R:`at Verse.AI.JobDriver.TryActuallyStartNextToil () [0x00217] in <24d25868955f4df08b02c73b55f389fe>:0`
```