### PR TITLE
Fix for KeepAlive packets not going through

### DIFF
--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -1,8 +1,8 @@
+using System;
+using System.Collections.Generic;
 using Ionic.Zlib;
 using Multiplayer.Common;
 using RimWorld;
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 
@@ -32,14 +32,20 @@ namespace Multiplayer.Client
         [PacketHandler(Packets.Server_KeepAlive)]
         public void HandleKeepAlive(ByteReader data)
         {
+            var padding = data.ReadRaw(8);
             int id = data.ReadInt32();
+            var ending = data.ReadRaw(8);
             int ticksBehind = TickPatch.tickUntil - TickPatch.Timer;
 
-            connection.Send(
-                Packets.Client_KeepAlive,
-                ByteWriter.GetBytes(id, ticksBehind, TickPatch.Simulating, TickPatch.workTicks),
-                false
-            );
+            var writer = new ByteWriter();
+            writer.WriteRaw(padding);
+            writer.WriteInt32(id);
+            writer.WriteInt32(ticksBehind);
+            writer.WriteBool(TickPatch.Simulating);
+            writer.WriteInt32(TickPatch.workTicks);
+            writer.WriteRaw(ending);
+
+            connection.Send(Packets.Client_KeepAlive, writer.ToArray(), false);
         }
 
         [PacketHandler(Packets.Server_Command)]

--- a/Source/Common/Networking/State/ServerPlayingState.cs
+++ b/Source/Common/Networking/State/ServerPlayingState.cs
@@ -173,10 +173,12 @@ namespace Multiplayer.Common
         [PacketHandler(Packets.Client_KeepAlive)]
         public void HandleClientKeepAlive(ByteReader data)
         {
+            var padding = data.ReadRaw(8);
             int id = data.ReadInt32();
             int ticksBehind = data.ReadInt32();
             var simulating = data.ReadBool();
             var workTicks = data.ReadInt32();
+            var ending = data.ReadRaw(8);
 
             Player.ticksBehind = ticksBehind;
             Player.ticksBehindReceivedAt = Server.gameTimer;

--- a/Source/Common/ServerPlayer.cs
+++ b/Source/Common/ServerPlayer.cs
@@ -24,7 +24,7 @@ namespace Multiplayer.Common
 
         public int lastCursorTick = -1;
 
-        public int keepAliveId;
+        public int keepAliveId = 0xCAFE;
         public Stopwatch keepAliveTimer = new();
         public int keepAliveAt;
 
@@ -82,7 +82,17 @@ namespace Multiplayer.Common
             {
                 keepAliveTimer.Start();
             }
-            SendPacket(Packets.Server_KeepAlive, ByteWriter.GetBytes(keepAliveId), false);
+
+            var bytes = new byte[8];
+            var bytes2 = new byte[8];
+            var random = new Random();
+            random.NextBytes(bytes);
+            random.NextBytes(bytes2);
+            var writer = new ByteWriter(20);
+            writer.WriteRaw(bytes);
+            writer.WriteInt32(keepAliveId);
+            writer.WriteRaw(bytes2);
+            SendPacket(Packets.Server_KeepAlive, writer.ToArray(), false);
         }
 
         public void SendPacket(Packets packet, byte[] data, bool reliable = true)


### PR DESCRIPTION
.. and the game freezing because of it. This issue is very weird as it only affects steam connections. It started occurring ~7th October 2025 out of nowhere and only affected some players. I tried changing the packets id, but that did not help with the issue. Adding random padding for whatever reason makes the packet go through. As far as I know this is the only packet affected by this phenomena. I suspect this may be caused by some upstream network config change? Some kind of firewall or filter? Whatever the cause, obscuring the packet works.


Most of the reports for this issues were on 1.5, but there was at least one case of this issue on 1.6. This change probably should also be applied to the 1.6 branch (dev)

See: https://discord.com/channels/524286515644203028/526116932655775744/1425083051213586452 - the first reported case of this issue. Further discussion below