### PR TITLE
Fix GetDisconnectBytes incorrect serialization

### DIFF
--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -275,7 +275,7 @@ namespace Multiplayer.Common
         {
             var writer = new ByteWriter();
             writer.WriteEnum(reason);
-            writer.WritePrefixedBytes(data ?? Array.Empty<byte>());
+            writer.WriteRaw(data ?? []);
             return writer.ToArray();
         }
     }


### PR DESCRIPTION
Broken since a0a69a3d98b783681f85de9879e941f65dfaa9ff which mistakenly changed the deserialization, but didn't update the serialization. This PR could also go the other direction and instead of adjusting serialization, reverse the changes in deserialization from that commit, however I believe that the logic is a bit simpler now and thus preferred over reverting to the previous state.

Likely fixes #763, which probably connected to a host with a different protocol version. The issue wasn't discovered earlier as most of the code paths in `ProcessDisconnectPacket` either call ReadString (which WritePrefixedBytes is similar to on the wire), or ReadEnum (which reads just a single byte, likely in the range of valid enum values for DisconnectReason, but doesn't trigger any checks in the code). Incorrect protocol version is the only code path that has enough logic (i.e. ReadString + ReadInt) to detect this and fail (ReadString reads all of the bytes in the packet, and ReadInt throws by not having any data left to read).