### PR TITLE
Pod Launcher Autobuild gizmo sync

### DIFF
--- a/Source/Client/Syncing/Game/SyncDelegates.cs
+++ b/Source/Client/Syncing/Game/SyncDelegates.cs
@@ -122,7 +122,7 @@ namespace Multiplayer.Client
             SyncMethod.Lambda(typeof(ShipJob_Wait), nameof(ShipJob_Wait.GetJobGizmos), 1);  // Send loaded shuttle
 
             SyncMethod.Lambda(typeof(Building_PodLauncher), nameof(Building_PodLauncher.GetGizmos), 0);  // Pod launcher gizmo: Build pod
-            SyncMethod.Register(typeof(Building_PodLauncher), "ToggleAutoBuildTransportPods");  // Pod launcher gizmo: toggle auto build
+            SyncMethod.Register(typeof(Building_PodLauncher), nameof(Building_PodLauncher.ToggleAutoBuildTransportPods));  // Pod launcher gizmo: toggle auto build
 
             SyncMethod.Lambda(typeof(Pawn_CarryTracker), nameof(Pawn_CarryTracker.GetGizmos), 0)
                 .TransformTarget(Serializer.New(t => t.pawn, (Pawn p) => p.carryTracker));  // Drop carried pawn


### PR DESCRIPTION
Adding pod launcher toggle to the list of synced gizmos. Method in question (Building_PodLauncher.ToggleAutoBuildTransportPods) is private.

I tested with the change I made, and it seems working (async, multifaction) but still may be worth checking,