### PR TITLE
Incorrect map for multifaction events fix

### DIFF
--- a/Source/Client/Patches/MultifactionEvents.cs
+++ b/Source/Client/Patches/MultifactionEvents.cs
@@ -1,5 +1,4 @@
 using HarmonyLib;
-using Multiplayer.API;
 using RimWorld;
 using RimWorld.Planet;
 using Verse;
@@ -19,7 +18,7 @@ public static class Patch_SettlementDefeatUtility_IsDefeated
 	static bool Prefix(Faction faction, ref bool __result)
 	{
 		// We run original if's not MP, or faction owning the map is not any player
-		if (!MP.IsInMultiplayer || !faction.IsPlayer)
+		if (Multiplayer.Client == null || !faction.IsPlayer)
 			return true;
 
 		// We skip checking if "enemy" is defeated on any player base (because other players most likely are friendly)
@@ -41,7 +40,7 @@ public static class Patch_IncidentWorker_TryExecute_ForMultifactionTriggering
 	{
 		// We make some sanity checks and assume, that empty (without any player colonists)
 		// factionless maps (such as dungeons) are impossible and instantly abandoned.
-		if (!MP.IsInMultiplayer ||
+		if (Multiplayer.Client == null ||
 			parms.target is not Map map ||
 			map.ParentFaction == Faction.OfPlayer ||
 			map.mapPawns.AnyColonistSpawned)

--- a/Source/Client/Patches/MultifactionEvents.cs
+++ b/Source/Client/Patches/MultifactionEvents.cs
@@ -1,0 +1,73 @@
+using HarmonyLib;
+using Multiplayer.API;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace Multiplayer.Client;
+
+// Set of patches that forces events to play for a correct player on a correct map
+
+// First patch is for the "SettlementDefeatUtility.IsDefeated", in vanilla it's purpose
+// is to fire events on non-settled enemy faction bases, that player had defeated. 
+// But it doesn account situation where "enemy base" is actually an other player base,
+// who is friendly with you. Which (I assume) is the most common situation for MP.
+
+[HarmonyPatch(typeof(SettlementDefeatUtility), nameof(SettlementDefeatUtility.IsDefeated), typeof(Map), typeof(Faction))]
+public static class Patch_SettlementDefeatUtility_IsDefeated
+{
+	static bool Prefix(Faction faction, ref bool __result)
+	{
+		// We run original if's not MP, or faction owning the map is not any player
+		if (!MP.IsInMultiplayer || !faction.IsPlayer)
+			return true;
+
+		// We skip checking if "enemy" is defeated on any player base (beacuse other players could be friendly)
+		__result = false;
+		return false;
+	}
+}
+
+// Second patch forbids from firing an event on an incorrect map.
+// It's uses mostly vanilla logic for incorrect event by sending th "true"
+// as an output for shutdowning events. I left the debug log line to see how many 
+// incorrect events are "lost", but game storyteller should understand correctly
+// that these events were not fired, and will adapt by firing more (correct) events.
+
+[HarmonyPatch(typeof(IncidentWorker), nameof(IncidentWorker.TryExecute))]
+public static class Patch_IncidentWorker_TryExecute_ForMultifactionTriggering
+{
+	static bool Prefix(IncidentParms parms, ref bool __result)
+	{
+		// We make some sanity checks and assume, that empty (without any colonists)
+		// factionless maps (such as dungeones) are impossible and instantly abandoned.
+		if (!MP.IsInMultiplayer ||
+			parms.target is not Map map ||
+			map.ParentFaction == Faction.OfPlayer ||
+			map.mapPawns.AnyColonistSpawned)
+		{
+			//Log.Message($"[Multiplayer] Incident greenlit");
+			return true;
+		}
+
+		// Skip incidents if we couldn't do it
+		Log.Warning($"[Multiplayer] Incident shutdown on a {map}");
+		__result = true;
+		return false;
+	}
+}
+
+// This is (currently) purely debug patch. I used it to see for which faction
+// event was supposed to fire (and thus for whitch faction evetn letter will arrive).
+// I will leave its here just in case. It could be useful, as some event keep firing
+// for the "Spectator" player, but I didn't notice any gameplay effects from that.
+
+//[HarmonyPatch(typeof(LetterStack), nameof(LetterStack.ReceiveLetter), typeof(Letter), typeof(string), typeof(int), typeof(bool))]
+//static class LetterStackReceiveFactionDebug
+//{
+//	// todo the letter might get culled from the archive if it isn't in the stack and Sync depends on the archive
+//	static void Prefix()
+//	{
+//		Log.Message($"[StkMPPatch] Current Incident Faction: {Faction.OfPlayer}");
+//	}
+//}

--- a/Source/Client/Patches/MultifactionEvents.cs
+++ b/Source/Client/Patches/MultifactionEvents.cs
@@ -8,9 +8,9 @@ namespace Multiplayer.Client;
 
 // Set of patches that forces events to play for a correct player on a correct map
 
-// First patch is for the "SettlementDefeatUtility.IsDefeated", in vanilla it's purpose
-// is to fire events on non-settled enemy faction bases, that player had defeated. 
-// But it doesn account situation where "enemy base" is actually an other player base,
+// First patch is for the "SettlementDefeatUtility.IsDefeated". In vanilla it's purpose
+// is to fire events on a non-settled enemy faction bases that player had defeated. 
+// But it doesn't account for situations, where "enemy base" is actually an other player base,
 // who is friendly with you. Which (I assume) is the most common situation for MP.
 
 [HarmonyPatch(typeof(SettlementDefeatUtility), nameof(SettlementDefeatUtility.IsDefeated), typeof(Map), typeof(Faction))]
@@ -22,15 +22,15 @@ public static class Patch_SettlementDefeatUtility_IsDefeated
 		if (!MP.IsInMultiplayer || !faction.IsPlayer)
 			return true;
 
-		// We skip checking if "enemy" is defeated on any player base (beacuse other players could be friendly)
+		// We skip checking if "enemy" is defeated on any player base (because other players most likely are friendly)
 		__result = false;
 		return false;
 	}
 }
 
 // Second patch forbids from firing an event on an incorrect map.
-// It's uses mostly vanilla logic for incorrect event by sending th "true"
-// as an output for shutdowning events. I left the debug log line to see how many 
+// It's uses mostly vanilla logic for incorrect event by sending "true"
+// as an output to shutdown an event. I left the debug log line to see how many 
 // incorrect events are "lost", but game storyteller should understand correctly
 // that these events were not fired, and will adapt by firing more (correct) events.
 
@@ -39,8 +39,8 @@ public static class Patch_IncidentWorker_TryExecute_ForMultifactionTriggering
 {
 	static bool Prefix(IncidentParms parms, ref bool __result)
 	{
-		// We make some sanity checks and assume, that empty (without any colonists)
-		// factionless maps (such as dungeones) are impossible and instantly abandoned.
+		// We make some sanity checks and assume, that empty (without any player colonists)
+		// factionless maps (such as dungeons) are impossible and instantly abandoned.
 		if (!MP.IsInMultiplayer ||
 			parms.target is not Map map ||
 			map.ParentFaction == Faction.OfPlayer ||
@@ -50,16 +50,16 @@ public static class Patch_IncidentWorker_TryExecute_ForMultifactionTriggering
 			return true;
 		}
 
-		// Skip incidents if we couldn't do it
+		// Skip incidents if we fail previous check
 		Log.Warning($"[Multiplayer] Incident shutdown on a {map}");
 		__result = true;
 		return false;
 	}
 }
 
-// This is (currently) purely debug patch. I used it to see for which faction
-// event was supposed to fire (and thus for whitch faction evetn letter will arrive).
-// I will leave its here just in case. It could be useful, as some event keep firing
+// This is (currently) purely a debug patch. I used it to see for which faction
+// event was supposed to fire (and thus for which faction event notification will arrive).
+// I will leave it here just in case. It could be useful, as some events keep firing
 // for the "Spectator" player, but I didn't notice any gameplay effects from that.
 
 //[HarmonyPatch(typeof(LetterStack), nameof(LetterStack.ReceiveLetter), typeof(Letter), typeof(string), typeof(int), typeof(bool))]


### PR DESCRIPTION
https://github.com/rwmt/Multiplayer/issues/659
As that issue was not resolved, I will publish patch me and my friend used in our playthrough.
Is it ideal? Doubt. But it works, forcing all events to fire on a correct map.

I didn't notice any gameplay downsides, like: too few events, broken events, missing events etc. AI Storyteller should understand that event was broken and account for it by adding new ones instead, which are hopefully correct ones. It "tracks" incorrect attempts in the log and it shouldn't be spammy at all, we had like 1 incorrect events each ~30 minutes (highly random ofc, but could be useful to see if something wrong if it starts spamming warnings each tick)