### PR TITLE
Initialize access to Steam relay network when opening the server browser

### DIFF
--- a/Source/Client/Windows/ServerBrowser.cs
+++ b/Source/Client/Windows/ServerBrowser.cs
@@ -27,6 +27,8 @@ namespace Multiplayer.Client
 
         public ServerBrowser()
         {
+            // establish a relay connection in the background, before connecting to speed up the handshake process
+            if (SteamManager.Initialized) SteamNetworkingUtils.InitRelayNetworkAccess();
             lanListener = new LanListener(expirationMillis: 5000);
             doCloseX = true;
         }


### PR DESCRIPTION
Reduces the time to initiate a connection.

[Docs](https://partner.steamgames.com/doc/api/ISteamNetworkingUtils#InitRelayNetworkAccess)