### PR TITLE
Fix: Uncontrollable spam of some condition causers (weather, climate, psy drone) 

### DIFF
--- a/Source/Client/AsyncTime/SetMapTime.cs
+++ b/Source/Client/AsyncTime/SetMapTime.cs
@@ -164,6 +164,43 @@ namespace Multiplayer.Client
         }
     }
 
+    // Patch to remove endless (every tick!) condition duplicates from the condition causers
+    [HarmonyPatch(typeof(CompCauseGameCondition), nameof(CompCauseGameCondition.GetConditionInstance))]
+    public static class Patch_CompCauseGameCondition_GetConditionInstance
+    {
+        public static void Postfix(Map map, CompCauseGameCondition __instance, ref GameCondition __result)
+        {
+            // Sanity and MP checks. We only checking for conditions that are able to stack
+            if (Multiplayer.Client == null
+                    || __instance.Props.preventConditionStacking
+                    || __result != null
+                    || map == null)
+                return;
+
+            // Look for an existing active condition on this map that matches both def and causer
+            var active = map.GameConditionManager.ActiveConditions
+                .FirstOrDefault(c =>
+                    c.def == __instance.Props.conditionDef &&
+                    c.conditionCauser == __instance.parent);
+
+            if (active != null)
+                __result = active;
+        }
+    }
+
+    // This exists purely to fix load issues. Some fake ticks cause condition duplication on load.
+    [HarmonyPatch(typeof(CompCauseGameCondition), nameof(CompCauseGameCondition.CompTick))]
+    public static class Patch_CompCauseGameCondition_CompTick
+    {
+        public static bool Prefix()
+        {
+            if (Multiplayer.Client == null || !Multiplayer.GameComp.asyncTime)
+                return true; // vanilla
+
+            return Multiplayer.LocalServer.FullyStarted;
+        }
+    }
+
     [HarmonyPatch(typeof(CompCauseGameCondition), nameof(CompCauseGameCondition.EnforceConditionOn))]
     static class MapConditionCauserMapTime
     {


### PR DESCRIPTION
I must say, vanilla "CompCauseGameCondition" is absolute garbage for optimisation.

Currently in async MP game-breaking bug exists that insta-scorches or deep-freezes you from a single climate adjuster, because it spams new condition each tick. I've fixed that, by ensuring same source wouldn't spam endless conditions to the map. 

Small bug still persist, somewhere in the `CompCauseGameCondition.PostExposeData`, where game cannot rebuild info about the condition source on load (YEAH, SAVE FILE DOESN'T CONTAIN INFO ABOUT IT, LOL), which causes every stackable condition to duplicate once (and also loses source info about every other condition). It clears itself after 5 seconds and never present outside of hosting the save file, so shouldn't be a big deal overall.

Without the `Patch_CompCauseGameCondition_CompTick` conditions duplicate on load quite a few times, while with that patch its just doubles once on the first real tick (from the source loss on originals).