### PR TITLE
Removing the during-load condition duplication fix

### DIFF
--- a/Source/Client/AsyncTime/SetMapTime.cs
+++ b/Source/Client/AsyncTime/SetMapTime.cs
@@ -188,19 +188,6 @@ namespace Multiplayer.Client
         }
     }
 
-    // This exists purely to fix load issues. Some fake ticks cause condition duplication on load.
-    [HarmonyPatch(typeof(CompCauseGameCondition), nameof(CompCauseGameCondition.CompTick))]
-    public static class Patch_CompCauseGameCondition_CompTick
-    {
-        public static bool Prefix()
-        {
-            if (Multiplayer.Client == null || !Multiplayer.GameComp.asyncTime)
-                return true; // vanilla
-
-            return Multiplayer.LocalServer.FullyStarted;
-        }
-    }
-
     [HarmonyPatch(typeof(CompCauseGameCondition), nameof(CompCauseGameCondition.EnforceConditionOn))]
     static class MapConditionCauserMapTime
     {


### PR DESCRIPTION
Apparently, part that was suppose to prevent condition duplication **during the initial load** desyncs on new client connect when condition causers present.
Main part of the fix still works fine. 

Ideally, I want help here, as `Multiplayer.LocalServer.FullyStarted` doesn't do correct job for stopping conditions from duplicating (as it affects only 1 client locally). It needs something to return false during that stop-time "Creating join-point" and similar ones.

But simple removal works too, as that patch fixed only first 5 seconds after the launch and is far less important.