### PR TITLE
Normalize stack trace file locations

### DIFF
--- a/Source/Client/Multiplayer.csproj
+++ b/Source/Client/Multiplayer.csproj
@@ -64,6 +64,10 @@
     <ModOutputPath>..\..\</ModOutputPath>
   </PropertyGroup>
 
+  <PropertyGroup Label="Normalise stack trace file locations">
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=$(AssemblyName)/</PathMap>
+  </PropertyGroup>
+
   <Target Name="CopyToRimworld" AfterTargets="Build">
     <Copy SourceFiles="bin\Multiplayer.dll" DestinationFiles="$(ModOutputPath)\AssembliesCustom\Multiplayer.dll" />
     <Copy SourceFiles="bin\Multiplayer.pdb" DestinationFiles="$(ModOutputPath)\AssembliesCustom\Multiplayer.pdb" />

--- a/Source/Common/Common.csproj
+++ b/Source/Common/Common.csproj
@@ -27,4 +27,7 @@
     </PropertyGroup>
   </Target>
 
+  <PropertyGroup Label="Normalise stack trace file locations">
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=$(AssemblyName)/</PathMap>
+  </PropertyGroup>
 </Project>

--- a/Source/MultiplayerLoader/MultiplayerLoader.csproj
+++ b/Source/MultiplayerLoader/MultiplayerLoader.csproj
@@ -31,4 +31,7 @@
     </PropertyGroup>
   </Target>
 
+  <PropertyGroup Label="Normalise stack trace file locations">
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=$(AssemblyName)/</PathMap>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The stack traces paths are significantly shorter, and only show the relevant path fragment.
Before:
`/home/runner/work/Multiplayer/Multiplayer/Source/Client/Desyncs/DeferredStackTracing.cs:41`
After:
`Multiplayer/Client/Desyncs/DeferredStackTracing.cs:41`

See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/advanced#pathmap for docs. Despite the warning, breakpoints still do work (at least for me, using Rider as an IDE).