### PR TITLE
Sync changing the target fuel level

### DIFF
--- a/Source/Client/Syncing/Game/SyncFields.cs
+++ b/Source/Client/Syncing/Game/SyncFields.cs
@@ -94,6 +94,7 @@ namespace Multiplayer.Client
         public static ISyncField SyncActivityCompSuppression;
 
         public static ISyncField SyncCompRefuelableValue;
+        public static ISyncField SyncCompRefuelableTargetFuelLevel;
 
         public static void Init()
         {
@@ -239,6 +240,7 @@ namespace Multiplayer.Client
             SyncActivityCompSuppression = Sync.Field(typeof(CompActivity), nameof(CompActivity.suppressionEnabled));
 
             SyncCompRefuelableValue = Sync.Field(typeof(CompRefuelable), nameof(CompRefuelable.allowAutoRefuel)).SetBufferChanges();
+            SyncCompRefuelableTargetFuelLevel = Sync.Field(typeof(CompRefuelable), nameof(CompRefuelable.TargetFuelLevel)).SetBufferChanges();
 
             InitFishingZone();
         }
@@ -618,7 +620,7 @@ namespace Multiplayer.Client
         }
 
         [MpPrefix(typeof(Gizmo_Slider), nameof(Gizmo_Slider.GizmoOnGUI))]
-        static void SyncGeneResourceChange(Gizmo_Slider __instance)
+        static void SyncGizmoSlider(Gizmo_Slider __instance)
         {
             if (__instance is GeneGizmo_Resource geneGizmo)
             {
@@ -640,6 +642,7 @@ namespace Multiplayer.Client
             {
                 var refuelable = fuelGizmo.refuelable;
                 SyncCompRefuelableValue.Watch(refuelable);
+                SyncCompRefuelableTargetFuelLevel.Watch(refuelable);
             }
         }
 

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -129,7 +129,8 @@ namespace Multiplayer.Client
             SyncMethod.Register(typeof(CompTransporter), nameof(CompTransporter.CancelLoad), Array.Empty<SyncType>());
             SyncMethod.Register(typeof(MapPortal), nameof(MapPortal.CancelLoad));
             SyncMethod.Register(typeof(StorageSettings), nameof(StorageSettings.CopyFrom)).ExposeParameter(0);
-            SyncMethod.Lambda(typeof(Command_SetTargetFuelLevel), nameof(Command_SetTargetFuelLevel.ProcessInput), 2); // Set target fuel level from Dialog_Slider
+            // Set target fuel level from Dialog_Slider. This only handles changing the fuel level for multiple buildings at once (by shift-clicking to select multiple)
+            SyncMethod.Lambda(typeof(Command_SetTargetFuelLevel), nameof(Command_SetTargetFuelLevel.ProcessInput), 2);
             SyncMethod.Register(typeof(ITab_Pawn_Gear), nameof(ITab_Pawn_Gear.InterfaceDrop)).SetContext(SyncContext.MapSelected | SyncContext.QueueOrder_Down).CancelIfAnyArgNull().CancelIfNoSelectedMapObjects();
             SyncMethod.Register(typeof(FoodUtility), nameof(FoodUtility.IngestFromInventoryNow)).SetContext(SyncContext.MapSelected | SyncContext.QueueOrder_Down).CancelIfAnyArgNull().CancelIfNoSelectedMapObjects();
 


### PR DESCRIPTION
Fixes #798 

Tested with: Pod launcher, Passenger shuttle, Large/Small chemfuel tank (so everything that has configurable target fuel levels)