### PR TITLE
Remove world VTR branching for Gravship/TravellingTransporters

### DIFF
--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -43,11 +43,7 @@ namespace Multiplayer.Client.Patches
             if (Multiplayer.Client == null)
                 return true;
 
-            if (__instance is Gravship or TravellingTransporters)
-                __result = VTRSync.MinimumVtr;
-            else
-                __result = Multiplayer.AsyncWorldTime.VTR;
-
+            __result = Multiplayer.AsyncWorldTime.VTR;
             return false;
         }
     }


### PR DESCRIPTION
Due to changes from #802, the branching is no longer necessary. The branching existed to fix stuttering for gravships/transport pods, but changes from #802 fix this issue by properly handling world VTR.