### PR TITLE
Delay syncing of world object caravan actions to prevent mod errors

### DIFF
--- a/Source/Client/Syncing/Game/SyncActions.cs
+++ b/Source/Client/Syncing/Game/SyncActions.cs
@@ -25,8 +25,12 @@ namespace Multiplayer.Client
 
             if (CaravanActionConfirmationType == null) Error($"Could not find type: {nameof(CaravanArrivalActionUtility)}.<>c__DisplayClass0_1<T>");
 
-            SyncWorldObjCaravanMenus = RegisterActions((WorldObject obj, Caravan c) => obj.GetFloatMenuOptions(c), ActionGetter, WorldObjectCaravanMenuWrapper);
-            SyncWorldObjCaravanMenus.PatchAll(nameof(WorldObject.GetFloatMenuOptions));
+            // Patch in a long event, otherwise it causes errors with mods that are loading resources
+            LongEventHandler.ExecuteWhenFinished(() =>
+            {
+                SyncWorldObjCaravanMenus = RegisterActions((WorldObject obj, Caravan c) => obj.GetFloatMenuOptions(c), ActionGetter, WorldObjectCaravanMenuWrapper);
+                SyncWorldObjCaravanMenus.PatchAll(nameof(WorldObject.GetFloatMenuOptions));
+            });
         }
 
         private static ref Action ActionGetter(FloatMenuOption o) => ref o.action;


### PR DESCRIPTION
Loading non-vanilla world objects too early can cause us to do stuff like loading graphics or accessing defs too early. This can cause bugs and errors in mods, so I've delayed patching of those objects using `LongEventHandler.ExecuteWhenFinished`.

This is fixing the same issue as #526, but the fix is much simpler and cleaner.