### PR TITLE
Fix SP feedback in `FloatMenuOptionProvider_DraftedMove:PawnGotoAction`

### DIFF
--- a/Source/Client/Patches/Feedback.cs
+++ b/Source/Client/Patches/Feedback.cs
@@ -250,7 +250,7 @@ namespace Multiplayer.Client.Patches
         static bool CustomTryTakeOrderedJob(Pawn_JobTracker self, Job job, JobTag? tag = JobTag.Misc,
             bool requestQueueing = false)
         {
-            if (self.TryTakeOrderedJob(job, tag, requestQueueing) && TickPatch.currentExecutingCmdIssuedBySelf)
+            if (self.TryTakeOrderedJob(job, tag, requestQueueing) && (TickPatch.currentExecutingCmdIssuedBySelf || Multiplayer.Client == null))
                 FleckMaker.Static(job.targetA.Cell, self.pawn.Map, FleckDefOf.FeedbackGoto);
             return false;
         }


### PR DESCRIPTION
When right-clicking in SP, the FeedbackGoto fleck wouldn't appear unless clicking on a tile that the pawn was moving towards. This fixes this issue.