### PR TITLE
Add list of save files to save window

### DIFF
--- a/Source/Client/Windows/SaveGameWindow.cs
+++ b/Source/Client/Windows/SaveGameWindow.cs
@@ -164,7 +164,7 @@ public class SaveGameWindow : Window
             {
                 if (Event.current.button == 0)
                 {
-                    UpdateText(ref curText, file.Name[..file.Name.IndexOf('.')]);
+                    UpdateText(ref curText, file.Name[..file.Name.LastIndexOf('.')]);
                     selectedFile = file;
                 }
             }


### PR DESCRIPTION
# Reasoning

When playing multiple sessions, I forget the name of the existing save file. I figured it might be nice to copy the list of save files like on the Host window, and use that on the Save window.

I copied just about everything from [ServerBrowser.cs `DrawHost()`](https://github.com/rwmt/Multiplayer/blob/dev/Source/Client/Windows/ServerBrowser.cs#L157).

## Example Host window
<img width="813" height="511" alt="image" src="https://github.com/user-attachments/assets/62db75d9-5b4f-42df-b0ac-7cc70318535f" />

## Existing MP Save window
<img width="365" height="191" alt="image" src="https://github.com/user-attachments/assets/1f78d574-e02d-4f34-8258-cd6a224caa8d" />

## New MP Save window
<img width="523" height="521" alt="image" src="https://github.com/user-attachments/assets/8adbf948-a089-4ccd-846f-e58ab7eb34a0" />
<img width="517" height="523" alt="image" src="https://github.com/user-attachments/assets/bb5623cd-1830-4af8-8b00-27ac38e7a578" />
