### PR TITLE
Add button to open mod compatibility sheet in browser

### DIFF
--- a/Source/Client/Windows/ModCompatWindow.cs
+++ b/Source/Client/Windows/ModCompatWindow.cs
@@ -122,6 +122,12 @@ namespace Multiplayer.Client
             );
             inRect.yMin += CheckboxesHeight;
 
+            if (MpUI.ButtonTextWithTip(inRect.Width(300).Height(CheckboxesHeight), "MpOpenModCompatSheet".Translate(), null))
+            {
+                Application.OpenURL("https://docs.google.com/spreadsheets/d/1jaDxV8F7bcz4E9zeIRmZGKuaX7d0kvWWq28aKckISaY/");
+            }
+            inRect.yMin += CheckboxesHeight;
+
             // Mod search field
             var nameField = inRect.Width(300).Height(CheckboxesHeight);
             var prevNameField = nameFieldStr;


### PR DESCRIPTION
Provides user with a manual option in case the compatibility endpoint goes down.
<img width="877" height="693" alt="image" src="https://github.com/user-attachments/assets/8e4d6361-4c1e-4e37-bc80-df7f0bd3eec2" />
