### PR TITLE
Replace dependency on Harmony with a dependency on Prepatcher

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -16,10 +16,9 @@ Discord - https://discord.gg/S4bxXpv
   </description>
   <modDependencies>
     <li>
-      <packageId>brrainz.harmony</packageId>
-      <displayName>Harmony</displayName>
-      <downloadUrl>https://github.com/pardeike/HarmonyRimWorld/releases/</downloadUrl>
-      <steamWorkshopUrl>steam://url/CommunityFilePage/2009463077</steamWorkshopUrl>
+      <packageId>zetrith.prepatcher</packageId>
+      <displayName>Prepatcher</displayName>
+      <steamWorkshopUrl>steam://url/CommunityFilePage/2934420800</steamWorkshopUrl>
     </li>
   </modDependencies>
   <loadAfter>
@@ -29,6 +28,7 @@ Discord - https://discord.gg/S4bxXpv
     <li>Ludeon.RimWorld.Biotech</li>
     <li>Ludeon.RimWorld.Anomaly</li>
     <li>Ludeon.RimWorld.Odyssey</li>
+    <li>zetrith.prepatcher</li>
     <li>brrainz.harmony</li>
   </loadAfter>
   <loadBefore>


### PR DESCRIPTION
It's required for syncing a bunch of non-modded game state. Includes Harmony inside. Didn't remove loadAfter Harmony just in case someone uses only Harmony, to make sure the game still sorts the mods correctly