### PR TITLE
Remove technical reason for desync from desync window

### DIFF
--- a/Source/Client/Windows/DesyncedWindow.cs
+++ b/Source/Client/Windows/DesyncedWindow.cs
@@ -44,6 +44,7 @@ namespace Multiplayer.Client
             Text.Anchor = TextAnchor.UpperCenter;
             var label = "MpDesynced".Translate();
             if (MpVersion.IsDebug || Prefs.DevMode) label += "\n" + text;
+            else label += "\n" + "MpDesyncedSubtitle".Translate();
             Widgets.Label(new Rect(0, 0, inRect.width, 40), label);
             Text.Anchor = TextAnchor.UpperLeft;
 


### PR DESCRIPTION
This can be confusing and doesn't provide much value on it's own (e.g. when someone joins the Discord and just says they have Wrong random state on map). It can also lead users to mistakenly thinking a different issue is the same as their own because the headline is the same.

The text is still present in the log file.

@Zetrith @notfood @SokyranTheDragon thoughts?