### PR TITLE
Fix [SyncWorker] attribute failing for typed ref parameters

### DIFF
--- a/Source/Common/Syncing/Worker/SyncWorkerEntry.cs
+++ b/Source/Common/Syncing/Worker/SyncWorkerEntry.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using Multiplayer.API;
@@ -12,6 +13,7 @@ public class SyncWorkerEntry
     delegate void SyncWorkerDelegateNoReturn(SyncWorker sync, ref object? obj);
 
     public Type type;
+    public MethodInfo addGenericMethod;
     public bool shouldConstruct;
     private List<SyncWorkerDelegate> syncWorkers;
     private List<SyncWorkerEntry> subclasses = [];
@@ -24,11 +26,20 @@ public class SyncWorkerEntry
         this.type = type;
         syncWorkers = new List<SyncWorkerDelegate>();
         this.shouldConstruct = shouldConstruct;
+
+        if (type != typeof(object)) {
+            var delegateType = typeof(SyncWorkerDelegate<>).MakeGenericType(type);
+            addGenericMethod = typeof(SyncWorkerEntry)
+                .GetMethods()
+                .First(m => m.Name == nameof(Add) && m.IsGenericMethodDefinition)
+                .MakeGenericMethod(type);
+        }
     }
 
     public SyncWorkerEntry(SyncWorkerEntry other)
     {
         type = other.type;
+        addGenericMethod = other.addGenericMethod;
         syncWorkers = other.syncWorkers;
         subclasses = other.subclasses;
         shouldConstruct = other.shouldConstruct;
@@ -41,12 +52,21 @@ public class SyncWorkerEntry
     {
         if (method.ReturnType == typeof(void))
         {
-            var func = (SyncWorkerDelegateNoReturn)Delegate.CreateDelegate(typeof(SyncWorkerDelegateNoReturn), method);
-            Add((SyncWorker sync, ref object obj) =>
+            if (type == typeof(object)) {
+                SyncWorkerDelegateNoReturn func = (SyncWorkerDelegateNoReturn)Delegate.CreateDelegate(typeof(SyncWorkerDelegateNoReturn), method);
+                Add((SyncWorker sync, ref object? obj) =>
+                {
+                    func(sync, ref obj);
+                    return true;
+                }, true);
+                return;
+            }
+            else
             {
-                func(sync, ref obj);
-                return true;
-            }, true);
+                var delegateType = typeof(SyncWorkerDelegate<>).MakeGenericType(this.type);
+                var func = Delegate.CreateDelegate(delegateType, method);
+                typeof(SyncWorkerEntry).GetMethods().First(m => m.Name == nameof(Add) && m.IsGenericMethod).MakeGenericMethod(type).Invoke(this, [func]);
+            }
         }
         else
         {


### PR DESCRIPTION

For me there are 2 ways to fix this:

1. Make SyncWorkerEntry.Add(MethodInfo) compatible with methods using ref T instead of ref object
2. Force it to call the generic version of RegisterSyncWorker while looping through [SyncWorker] attributes in RegisterAllAttributes

Chose the first one because:

- > Fix is at the right level where the incompatibility actually occurs
- > RegisterAllAttributes stays clean and readable
