### PR TITLE
Fix inconsistent serialization of GlobalTargetInfo

### DIFF
--- a/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
+++ b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs
@@ -1,19 +1,16 @@
-using HarmonyLib;
-using Multiplayer.API;
-using Multiplayer.Client.Patches;
-using Multiplayer.Common;
-using RimWorld;
-using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
+using Multiplayer.API;
+using Multiplayer.Common;
+using RimWorld;
+using RimWorld.Planet;
 using Verse;
 using Verse.AI;
 using Verse.AI.Group;
 using static Multiplayer.Client.CompSerialization;
 using static Multiplayer.Client.SyncSerialization;
-using static UnityEngine.GraphicsBuffer;
+
 // ReSharper disable RedundantLambdaParameterType
 
 namespace Multiplayer.Client
@@ -1249,9 +1246,15 @@ namespace Multiplayer.Client
                         data.WriteByte(2);
                         WriteSync(data, info.WorldObject);
                     }
-                    else {
+                    else if (info.Tile.Valid) {
                         data.WriteByte(3);
                         WriteSync(data, info.Tile);
+                    }
+                    else
+                    {
+                        if (info.IsValid)
+                            throw new SerializationException($"Unable to serialize GlobalTargetInfo {info}");
+                        data.WriteByte(byte.MaxValue);
                     }
                 },
                 (ByteReader data) =>
@@ -1263,8 +1266,10 @@ namespace Multiplayer.Client
                             true) // True to prevent errors/warnings if synced map was null
                         ,
                         2 => new GlobalTargetInfo(ReadSync<WorldObject>(data)),
-                        3 => new GlobalTargetInfo(data.ReadInt32()),
-                        _ => GlobalTargetInfo.Invalid
+                        3 => new GlobalTargetInfo(ReadSync<PlanetTile>(data)),
+                        byte.MaxValue => GlobalTargetInfo.Invalid,
+                        var type =>
+                            throw new SerializationException($"Unable to deserialize GlobalTargetInfo with type {type}"),
                     };
                 }
             },


### PR DESCRIPTION
Found in https://github.com/rwmt/Multiplayer-Compatibility/pull/553
> Rewrite vehicle launch/flight sync to work around MP's broken GlobalTargetInfo serializer (PlanetTile 8-byte write vs 4-byte read in RW 1.6)

I believe this is just a simple omission that caused this issue. The cause of it is an asymmetry in reading vs writing. For reading, the code just did `ReadInt`, while for writing it called `WriteSync<PlanetTile>`, which consists of 2 ints.

cc @sviyh as you discovered the bug. With this patch merged, the work around you did should no longer be necessary. I'd appreciate it if you could verify it, as I'm not familiar with that mod