### PR TITLE
Fix sending transporters from other player-faction's faction base to use correct faction

### DIFF
--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -866,6 +866,39 @@ namespace Multiplayer.Client
                     table.SetDirty();
             }
         }
+        [HarmonyPatch(typeof(FlyShipLeaving), nameof(FlyShipLeaving.LeaveMap))]
+        static class FlyShipLeaving_LeaveMap_Patch
+        {
+            //When launch transporter, should try to use pawn inside's faction instead of Faction.OfPlayer
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
+            {
+                var ofPlayerGetter = AccessTools.PropertyGetter(typeof(Faction), nameof(Faction.OfPlayer));
+                var replacement = AccessTools.Method(typeof(FlyShipLeaving_LeaveMap_Patch),
+                    nameof(GetFactionFromContents));
+
+                foreach (var ci in insts)
+                {
+                    if (ci.Calls(ofPlayerGetter))
+                    {
+                        yield return new CodeInstruction(OpCodes.Ldarg_0);
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = replacement;
+                    }
+                    yield return ci;
+                }
+            }
+
+            static Faction GetFactionFromContents(FlyShipLeaving flyShip)
+            {
+                foreach (Thing t in flyShip.Contents.innerContainer)
+                {
+                    Pawn pawn = t as Pawn;
+                    if (pawn?.Faction != null && pawn.Faction.IsPlayer)
+                        return pawn.Faction;
+                }
+                return Faction.OfPlayer; // fallback
+            }
+        }
     }
 
 }

--- a/Source/Client/Syncing/Game/SyncMethods.cs
+++ b/Source/Client/Syncing/Game/SyncMethods.cs
@@ -902,7 +902,6 @@ namespace Multiplayer.Client
                 return Faction.OfPlayer; // fallback
             }
         }
-    }
 
         [HarmonyPatch(typeof(ITab_ContentsBooks), nameof(ITab_ContentsBooks.DoRow))]
         static class ITab_ContentsBooks_DoRow_Patch


### PR DESCRIPTION
fix #848 
this allows you send transporters with pawns from your friend's faction-base to world-map tile form caravan instead of missing.
this is not fully fixing transporter's logic because I'm detecting inside pawn's faction and assigin it to the transporter flying on the sky, means if there's no pawn inside this will fall back to faction.OfPlayer, so you can't send gift to other factions or it'll calculated as the faction-base-owner's gift.

Use the building with complaunchable's faction should works better than this PR, but that changes a lot, I tried to pass faction info   like compTansporter.faction->flyShipLeaving.faction->travellingTransporters.faction , but flyShipLeaving.def.CanHaveFaction is False. 