### PR TITLE
Fix Quests involving lending colonists via a Shuttle cannot be completed, the shuttle will never register as fully loaded and cannot leave. 

### DIFF
--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -741,3 +741,37 @@ static class CharacterCardUtilityDontDrawIdeoPlate
         return Multiplayer.Client != null && generating;
     }
 }
+
+[HarmonyPatch(typeof(CompShuttle), "ContainedColonistCount", MethodType.Getter)]
+static class CompShuttle_ContainedColonistCount_Patch
+{
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
+    {
+        var isFreeColonist = AccessTools.PropertyGetter(typeof(Pawn), nameof(Pawn.IsFreeColonist));
+        var replacement = AccessTools.Method(typeof(CompShuttle_ContainedColonistCount_Patch),
+            nameof(IsFreeColonistAnyPlayerFaction));
+
+        foreach (var ci in insts)
+        {
+            if (ci.Calls(isFreeColonist))
+            {
+                ci.opcode = OpCodes.Call;
+                ci.operand = replacement;
+            }
+            yield return ci;
+        }
+    }
+    static bool IsFreeColonistAnyPlayerFaction(Pawn pawn)
+    {
+        if (Multiplayer.Client == null || !Multiplayer.GameComp.multifaction)
+            return pawn.IsFreeColonist;
+
+        return pawn.Faction != null &&
+               pawn.Faction.IsPlayer &&
+               pawn.RaceProps.Humanlike &&
+               (!pawn.IsSlave || pawn.guest.SlaveIsSecure) &&
+               !pawn.IsSubhuman &&
+               pawn.HostFaction == null; 
+    }
+
+}


### PR DESCRIPTION
Shuttle not launching becase it's counting inside pawn with CompShuttle.ContainedColonistCount. This function only calculate pawn that isFreeColonist and which is replaced checking of Faction.IsPlayer inside with Faction.OfPlayer by MP's patch, and seems it's running when faction-context is none of the player's faction(maybe spectator‘s faction, didn't check though).

I wonder this should check with faction-context that actually who accept the mission or just allow all player's pawn to join?

This solution choose to allow all player's pawn. I think it can be more free for players to coop on such missions.