### PR TITLE
Add standalone server bootstrap flow

### DIFF
--- a/Source/Client/Comp/BootstrapCoordinator.cs
+++ b/Source/Client/Comp/BootstrapCoordinator.cs
@@ -1,0 +1,36 @@
+using Verse;
+
+namespace Multiplayer.Client.Comp;
+
+public class BootstrapCoordinator : GameComponent
+{
+    private int nextCheckTick;
+    private const int CheckIntervalTicks = 15;
+
+    public BootstrapCoordinator(Game game)
+    {
+    }
+
+    public override void GameComponentTick()
+    {
+        base.GameComponentTick();
+
+        var window = BootstrapConfiguratorWindow.Instance;
+        if (window == null)
+            return;
+
+        if (Find.TickManager != null && Find.TickManager.TicksGame < nextCheckTick)
+            return;
+
+        if (Find.TickManager != null)
+            nextCheckTick = Find.TickManager.TicksGame + CheckIntervalTicks;
+
+        window.BootstrapCoordinatorTick();
+    }
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+        Scribe_Values.Look(ref nextCheckTick, "mp_bootstrap_nextCheckTick", 0);
+    }
+}

--- a/Source/Client/MultiplayerStatic.cs
+++ b/Source/Client/MultiplayerStatic.cs
@@ -86,6 +86,7 @@ namespace Multiplayer.Client
             MpConnectionState.SetImplementation(ConnectionStateEnum.ClientJoining, typeof(ClientJoiningState));
             MpConnectionState.SetImplementation(ConnectionStateEnum.ClientLoading, typeof(ClientLoadingState));
             MpConnectionState.SetImplementation(ConnectionStateEnum.ClientPlaying, typeof(ClientPlayingState));
+            MpConnectionState.SetImplementation(ConnectionStateEnum.ClientBootstrap, typeof(ClientBootstrapState));
 
             MultiplayerData.CollectCursorIcons();
 

--- a/Source/Client/Networking/State/ClientBaseState.cs
+++ b/Source/Client/Networking/State/ClientBaseState.cs
@@ -29,7 +29,7 @@ public abstract class ClientBaseState(ConnectionBase connection) : MpConnectionS
     }
 
     [TypedPacketHandler]
-    public void HandleDisconnected(ServerDisconnectPacket packet)
+    public virtual void HandleDisconnected(ServerDisconnectPacket packet)
     {
         ConnectionStatusListeners.TryNotifyAll_Disconnected(SessionDisconnectInfo.From(packet.reason,
             new ByteReader(packet.data)));

--- a/Source/Client/Networking/State/ClientBootstrapState.cs
+++ b/Source/Client/Networking/State/ClientBootstrapState.cs
@@ -1,9 +1,42 @@
 using Multiplayer.Common;
 using Multiplayer.Common.Networking.Packet;
+using RimWorld;
+using Verse;
 
 namespace Multiplayer.Client;
 
 [PacketHandlerClass(inheritHandlers: true)]
 public class ClientBootstrapState(ConnectionBase connection) : ClientBaseState(connection)
 {
+	[TypedPacketHandler]
+	public void HandleBootstrap(ServerBootstrapPacket packet)
+	{
+		Multiplayer.session?.ApplyBootstrapState(packet);
+
+		OnMainThread.Enqueue(() => BootstrapConfiguratorWindow.Instance?.ApplyBootstrapState(BootstrapServerState.FromPacket(packet)));
+	}
+
+	[TypedPacketHandler]
+	public override void HandleDisconnected(ServerDisconnectPacket packet)
+	{
+		if (packet.reason == MpDisconnectReason.BootstrapCompleted)
+		{
+			OnMainThread.Enqueue(() => Messages.Message(
+				"Bootstrap configuration completed. The server will now shut down; please restart it manually to start normally.",
+				MessageTypeDefOf.PositiveEvent, false));
+		}
+
+		OnMainThread.Enqueue(() =>
+		{
+			var window = Find.WindowStack.WindowOfType<BootstrapConfiguratorWindow>();
+			Multiplayer.session?.ClearBootstrapState();
+			if (window != null)
+			{
+				window.ResetTransientUiState(resetServerDrivenState: true);
+				Find.WindowStack.TryRemove(window);
+			}
+		});
+
+		base.HandleDisconnected(packet);
+	}
 }

--- a/Source/Client/Networking/State/ClientBootstrapState.cs
+++ b/Source/Client/Networking/State/ClientBootstrapState.cs
@@ -1,3 +1,6 @@
+using Multiplayer.Common;
+using Multiplayer.Common.Networking.Packet;
+
 namespace Multiplayer.Client;
 
 [PacketHandlerClass(inheritHandlers: true)]

--- a/Source/Client/Networking/State/ClientBootstrapState.cs
+++ b/Source/Client/Networking/State/ClientBootstrapState.cs
@@ -1,0 +1,6 @@
+namespace Multiplayer.Client;
+
+[PacketHandlerClass(inheritHandlers: true)]
+public class ClientBootstrapState(ConnectionBase connection) : ClientBaseState(connection)
+{
+}

--- a/Source/Client/Networking/State/ClientJoiningState.cs
+++ b/Source/Client/Networking/State/ClientJoiningState.cs
@@ -20,6 +20,13 @@ namespace Multiplayer.Client
         [TypedPacketHandler]
         public new void HandleDisconnected(ServerDisconnectPacket packet) => base.HandleDisconnected(packet);
 
+        [TypedPacketHandler]
+        public void HandleBootstrap(ServerBootstrapPacket packet)
+        {
+            Multiplayer.session.serverIsInBootstrap = packet.bootstrap;
+            Multiplayer.session.serverBootstrapSettingsMissing = packet.settingsMissing;
+        }
+
         public override void StartState()
         {
             connection.Send(ClientProtocolPacket.Current());
@@ -120,6 +127,13 @@ namespace Multiplayer.Client
 
                 void StartDownloading()
                 {
+                    if (Multiplayer.session.serverIsInBootstrap)
+                    {
+                        connection.ChangeState(ConnectionStateEnum.ClientBootstrap);
+                        Find.WindowStack.Add(new BootstrapConfiguratorWindow(connection));
+                        return;
+                    }
+
                     connection.Send(Packets.Client_WorldRequest);
                     connection.ChangeState(ConnectionStateEnum.ClientLoading);
                 }

--- a/Source/Client/Networking/State/ClientJoiningState.cs
+++ b/Source/Client/Networking/State/ClientJoiningState.cs
@@ -23,8 +23,7 @@ namespace Multiplayer.Client
         [TypedPacketHandler]
         public void HandleBootstrap(ServerBootstrapPacket packet)
         {
-            Multiplayer.session.serverIsInBootstrap = packet.bootstrap;
-            Multiplayer.session.serverBootstrapSettingsMissing = packet.settingsMissing;
+            Multiplayer.session.ApplyBootstrapState(packet);
         }
 
         public override void StartState()
@@ -127,7 +126,7 @@ namespace Multiplayer.Client
 
                 void StartDownloading()
                 {
-                    if (Multiplayer.session.serverIsInBootstrap)
+                    if (Multiplayer.session.bootstrapState.Enabled)
                     {
                         connection.ChangeState(ConnectionStateEnum.ClientBootstrap);
                         Find.WindowStack.Add(new BootstrapConfiguratorWindow(connection));

--- a/Source/Client/Patches/BootstrapMapInitPatch.cs
+++ b/Source/Client/Patches/BootstrapMapInitPatch.cs
@@ -1,0 +1,16 @@
+using HarmonyLib;
+using Verse;
+
+namespace Multiplayer.Client;
+
+[HarmonyPatch(typeof(MapComponentUtility), nameof(MapComponentUtility.FinalizeInit))]
+static class BootstrapMapInitPatch
+{
+    static void Postfix(Map map)
+    {
+        if (!BootstrapConfiguratorWindow.AwaitingBootstrapMapInit || BootstrapConfiguratorWindow.Instance == null)
+            return;
+
+        OnMainThread.Enqueue(() => BootstrapConfiguratorWindow.Instance.OnBootstrapMapInitialized());
+    }
+}

--- a/Source/Client/Patches/BootstrapRootPlayPatch.cs
+++ b/Source/Client/Patches/BootstrapRootPlayPatch.cs
@@ -1,0 +1,13 @@
+using HarmonyLib;
+using Verse;
+
+namespace Multiplayer.Client;
+
+[HarmonyPatch(typeof(Root_Play), nameof(Root_Play.Start))]
+static class BootstrapRootPlayPatch
+{
+    static void Postfix()
+    {
+        BootstrapConfiguratorWindow.Instance?.TryArmAwaitingBootstrapMapInit_FromRootPlay();
+    }
+}

--- a/Source/Client/Patches/BootstrapRootPlayUpdatePatch.cs
+++ b/Source/Client/Patches/BootstrapRootPlayUpdatePatch.cs
@@ -1,0 +1,24 @@
+using HarmonyLib;
+using Verse;
+
+namespace Multiplayer.Client;
+
+[HarmonyPatch(typeof(Root_Play), nameof(Root_Play.Update))]
+static class BootstrapRootPlayUpdatePatch
+{
+    private static int nextCheckFrame;
+    private const int CheckEveryFrames = 10;
+
+    static void Postfix()
+    {
+        var window = BootstrapConfiguratorWindow.Instance;
+        if (window == null)
+            return;
+
+        if (UnityEngine.Time.frameCount < nextCheckFrame)
+            return;
+
+        nextCheckFrame = UnityEngine.Time.frameCount + CheckEveryFrames;
+        window.TryArmAwaitingBootstrapMapInit_FromRootPlayUpdate();
+    }
+}

--- a/Source/Client/Patches/BootstrapStartedNewGamePatch.cs
+++ b/Source/Client/Patches/BootstrapStartedNewGamePatch.cs
@@ -1,0 +1,18 @@
+using HarmonyLib;
+using Verse;
+
+namespace Multiplayer.Client;
+
+[HarmonyPatch(typeof(GameComponentUtility), nameof(GameComponentUtility.StartedNewGame))]
+static class BootstrapStartedNewGamePatch
+{
+    static void Postfix()
+    {
+        var window = BootstrapConfiguratorWindow.Instance;
+        if (window == null)
+            return;
+
+        BootstrapConfiguratorWindow.AwaitingBootstrapMapInit = true;
+        OnMainThread.Enqueue(window.OnBootstrapMapInitialized);
+    }
+}

--- a/Source/Client/Session/BootstrapServerState.cs
+++ b/Source/Client/Session/BootstrapServerState.cs
@@ -1,0 +1,14 @@
+using Multiplayer.Common.Networking.Packet;
+
+namespace Multiplayer.Client;
+
+public readonly record struct BootstrapServerState(bool Enabled, bool SettingsMissing, bool SaveMissing)
+{
+    public static BootstrapServerState None => new(false, false, false);
+
+    public bool RequiresSettingsUpload => Enabled && SettingsMissing;
+    public bool RequiresSaveUpload => Enabled && !SettingsMissing && SaveMissing;
+
+    public static BootstrapServerState FromPacket(ServerBootstrapPacket packet) =>
+        new(packet.bootstrap, packet.settingsMissing, packet.saveMissing);
+}

--- a/Source/Client/Session/MultiplayerSession.cs
+++ b/Source/Client/Session/MultiplayerSession.cs
@@ -4,6 +4,7 @@ using LudeonTK;
 using Multiplayer.Client.Networking;
 using Multiplayer.Client.Util;
 using Multiplayer.Common;
+using Multiplayer.Common.Networking.Packet;
 using RimWorld;
 using Steamworks;
 using UnityEngine;
@@ -54,8 +55,12 @@ namespace Multiplayer.Client
         public bool ArbiterPlaying => players.Any(p => p.type == PlayerType.Arbiter && p.status == PlayerStatus.Playing);
 
         public IConnector connector;
-        public bool serverIsInBootstrap;
-        public bool serverBootstrapSettingsMissing;
+        public BootstrapServerState bootstrapState = BootstrapServerState.None;
+
+        public void ApplyBootstrapState(ServerBootstrapPacket packet) =>
+            bootstrapState = BootstrapServerState.FromPacket(packet);
+
+        public void ClearBootstrapState() => bootstrapState = BootstrapServerState.None;
 
         public void Stop()
         {

--- a/Source/Client/Session/MultiplayerSession.cs
+++ b/Source/Client/Session/MultiplayerSession.cs
@@ -54,6 +54,8 @@ namespace Multiplayer.Client
         public bool ArbiterPlaying => players.Any(p => p.type == PlayerType.Arbiter && p.status == PlayerStatus.Playing);
 
         public IConnector connector;
+        public bool serverIsInBootstrap;
+        public bool serverBootstrapSettingsMissing;
 
         public void Stop()
         {

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
@@ -1,0 +1,405 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using Multiplayer.Client.Comp;
+using Multiplayer.Common;
+using Multiplayer.Common.Networking.Packet;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace Multiplayer.Client;
+
+public partial class BootstrapConfiguratorWindow
+{
+    private const string BootstrapSaveName = "MpBootstrapSave";
+    private const float PostMapEnterSaveDelaySeconds = 1.5f;
+
+    private bool hideWindowDuringMapGen;
+    private bool autoAdvanceArmed;
+    private bool bootstrapSaveQueued;
+    private bool awaitingControllablePawns;
+    private bool saveReady;
+    private bool isUploadingSave;
+    private bool saveUploadAutoStarted;
+    private string savedReplayPath;
+    private string saveUploadStatus;
+    private float saveUploadProgress;
+    private float postMapEnterSaveDelayRemaining;
+
+    private float GetGenerateMapStepHeight()
+    {
+        var contentHeight = Text.CalcHeight(statusText ?? string.Empty, 500f) + 14f;
+
+        if (ShouldShowGenerateMapControls())
+            contentHeight += 110f;
+
+        if (!string.IsNullOrEmpty(saveUploadStatus))
+            contentHeight += Text.CalcHeight(saveUploadStatus, 500f) + 8f;
+
+        if (autoAdvanceArmed || isUploadingSave)
+            contentHeight += 24f;
+
+        contentHeight += 55f;
+        return contentHeight;
+    }
+
+    private void DrawGenerateMap(Rect entry, Rect inRect)
+    {
+        var statusHeight = Text.CalcHeight(statusText ?? string.Empty, entry.width);
+        Widgets.Label(entry.Height(statusHeight), statusText ?? string.Empty);
+        entry = entry.Down(statusHeight + 10f);
+
+        if (ShouldShowGenerateMapControls())
+        {
+            DrawFactionOwnershipNotice(entry.Height(100f));
+            entry = entry.Down(110f);
+        }
+
+        if (!string.IsNullOrEmpty(saveUploadStatus))
+        {
+            var saveStatusHeight = Text.CalcHeight(saveUploadStatus, entry.width);
+            Widgets.Label(entry.Height(saveStatusHeight), saveUploadStatus);
+            entry = entry.Down(saveStatusHeight + 4f);
+        }
+
+        if (autoAdvanceArmed || isUploadingSave)
+        {
+            var barRect = entry.Height(18f);
+            Widgets.FillableBar(barRect, isUploadingSave ? saveUploadProgress : 0.1f);
+            entry = entry.Down(24f);
+        }
+
+        if (ShouldAutoUploadSave())
+        {
+            saveUploadAutoStarted = true;
+            StartUploadSaveZip();
+        }
+
+        if (ShouldShowGenerateMapButton() && Widgets.ButtonText(new Rect((inRect.width - 200f) / 2f, inRect.height - 45f, 200f, 40f), "Create game and upload save"))
+        {
+            saveUploadAutoStarted = false;
+            StartVanillaNewColonyFlow();
+        }
+    }
+
+    private void DrawFactionOwnershipNotice(Rect noticeRect)
+    {
+        GUI.color = new Color(1f, 0.85f, 0.5f);
+        Widgets.DrawBoxSolid(noticeRect, new Color(0.3f, 0.25f, 0.1f, 0.5f));
+        GUI.color = Color.white;
+
+        var noticeTextRect = noticeRect.ContractedBy(8f);
+        Text.Font = GameFont.Tiny;
+        GUI.color = new Color(1f, 0.9f, 0.6f);
+        Widgets.Label(noticeTextRect,
+            "IMPORTANT: The user who generates this map will own the main faction (colony).\n" +
+            "Make sure this user's username is listed as the host when the final server starts.");
+        GUI.color = Color.white;
+        Text.Font = GameFont.Small;
+    }
+
+    private bool ShouldShowGenerateMapButton() =>
+        saveUploadRequestedByServer && !saveGenerationStarted && !autoAdvanceArmed && !AwaitingBootstrapMapInit && !saveReady && !isUploadingSave;
+
+    private bool ShouldShowGenerateMapControls() => ShouldShowGenerateMapButton();
+
+    private bool ShouldAutoUploadSave() =>
+        saveReady && !isUploadingSave && !saveUploadAutoStarted && connection.State == ConnectionStateEnum.ClientBootstrap;
+
+    private void StartVanillaNewColonyFlow()
+    {
+        if (Multiplayer.session != null)
+        {
+            Multiplayer.session.Stop();
+            Multiplayer.session = null;
+        }
+
+        Current.Game ??= new Game();
+        Current.Game.InitData ??= new GameInitData { startedFromEntry = true };
+
+        if (Current.Game.components.All(component => component is not BootstrapCoordinator))
+            Current.Game.components.Add(new BootstrapCoordinator(Current.Game));
+
+        retainInstanceOnClose = true;
+        hideWindowDuringMapGen = true;
+        saveGenerationStarted = true;
+        saveUploadRequestedByServer = false;
+        saveReady = false;
+        savedReplayPath = null;
+        autoAdvanceArmed = true;
+        AwaitingBootstrapMapInit = true;
+        saveUploadStatus = "Generating map...";
+        Find.WindowStack.TryRemove(this);
+
+        var scenarioPage = new Page_SelectScenario();
+        Find.WindowStack.Add(PageUtility.StitchedPages([scenarioPage]));
+    }
+
+    private void TryArmAwaitingBootstrapMapInit()
+    {
+        if (AwaitingBootstrapMapInit)
+            return;
+
+        if (Multiplayer.Client != null || bootstrapSaveQueued || saveReady || isUploadingSave || saveUploadAutoStarted)
+            return;
+
+        if (Current.ProgramState != ProgramState.Playing || Find.Maps == null || Find.Maps.Count == 0)
+            return;
+
+        AwaitingBootstrapMapInit = true;
+        autoAdvanceArmed = false;
+        saveUploadStatus = "Entered map. Waiting for initialization to complete...";
+    }
+
+    internal void TryArmAwaitingBootstrapMapInit_FromRootPlay() => TryArmAwaitingBootstrapMapInit();
+
+    internal void TryArmAwaitingBootstrapMapInit_FromRootPlayUpdate()
+    {
+        TryArmAwaitingBootstrapMapInit();
+        TickPostMapEnterSaveDelayAndMaybeSave();
+    }
+
+    internal void BootstrapCoordinatorTick() => TickPostMapEnterSaveDelayAndMaybeSave();
+
+    public void OnBootstrapMapInitialized()
+    {
+        if (!AwaitingBootstrapMapInit)
+            return;
+
+        hideWindowDuringMapGen = false;
+        retainInstanceOnClose = false;
+        AwaitingBootstrapMapInit = false;
+        postMapEnterSaveDelayRemaining = PostMapEnterSaveDelaySeconds;
+        awaitingControllablePawns = true;
+        bootstrapSaveQueued = false;
+        saveUploadStatus = "Map initialized. Waiting before saving...";
+
+        if (Find.WindowStack.WindowOfType<BootstrapConfiguratorWindow>() == null)
+            Find.WindowStack.Add(this);
+    }
+
+    private void TickPostMapEnterSaveDelayAndMaybeSave()
+    {
+        if (hideWindowDuringMapGen || bootstrapSaveQueued || saveReady || isUploadingSave)
+            return;
+
+        if (postMapEnterSaveDelayRemaining <= 0f && !awaitingControllablePawns)
+            return;
+
+        postMapEnterSaveDelayRemaining -= Time.deltaTime;
+        if (postMapEnterSaveDelayRemaining > 0f)
+            return;
+
+        if (!WaitForControllableColonists())
+            return;
+
+        postMapEnterSaveDelayRemaining = 0f;
+        bootstrapSaveQueued = true;
+        saveUploadStatus = "Map initialized. Starting hosted MP session...";
+
+        LongEventHandler.QueueLongEvent(StartHostedBootstrapSaveCreation, "Starting host", false, null);
+    }
+
+    private bool WaitForControllableColonists()
+    {
+        if (!awaitingControllablePawns)
+            return true;
+
+        if (Current.ProgramState == ProgramState.Playing && Find.CurrentMap != null)
+        {
+            var anyColonist = Find.CurrentMap.mapPawns?.FreeColonistsSpawned != null &&
+                              Find.CurrentMap.mapPawns.FreeColonistsSpawned.Count > 0;
+
+            if (anyColonist)
+            {
+                awaitingControllablePawns = false;
+                Find.TickManager.CurTimeSpeed = TimeSpeed.Paused;
+            }
+        }
+
+        if (!awaitingControllablePawns)
+            return true;
+
+        saveUploadStatus = "Waiting for controllable colonists to spawn...";
+        return false;
+    }
+
+    private void StartHostedBootstrapSaveCreation()
+    {
+        try
+        {
+            var hostSettings = new ServerSettings
+            {
+                gameName = settings.gameName,
+                maxPlayers = 2,
+                direct = false,
+                lan = false,
+                steam = false,
+                arbiter = false,
+                asyncTime = settings.asyncTime,
+                multifaction = settings.multifaction,
+                debugMode = settings.debugMode,
+                desyncTraces = settings.desyncTraces,
+                syncConfigs = settings.syncConfigs,
+                autoJoinPoint = settings.autoJoinPoint,
+                devModeScope = settings.devModeScope,
+                pauseOnLetter = settings.pauseOnLetter,
+                pauseOnJoin = settings.pauseOnJoin,
+                pauseOnDesync = settings.pauseOnDesync,
+                timeControl = settings.timeControl
+            };
+
+            if (!HostWindow.HostProgrammatically(hostSettings))
+            {
+                OnMainThread.Enqueue(() =>
+                {
+                    saveUploadStatus = "Failed to host MP session.";
+                    bootstrapSaveQueued = false;
+                });
+                return;
+            }
+
+            OnMainThread.Enqueue(() =>
+            {
+                saveUploadStatus = "Hosted. Saving replay...";
+                LongEventHandler.QueueLongEvent(CreateBootstrapReplaySave, "Saving", false, null);
+            });
+        }
+        catch (Exception exception)
+        {
+            OnMainThread.Enqueue(() =>
+            {
+                saveUploadStatus = $"Host failed: {exception.GetType().Name}: {exception.Message}";
+                Log.Error($"Bootstrap host exception: {exception}");
+                bootstrapSaveQueued = false;
+            });
+        }
+    }
+
+    private void CreateBootstrapReplaySave()
+    {
+        try
+        {
+            Autosaving.SaveGameToFile_Overwrite(BootstrapSaveName, currentReplay: false);
+            var path = Path.Combine(Multiplayer.ReplaysDir, $"{BootstrapSaveName}.zip");
+            OnMainThread.Enqueue(() => FinalizeBootstrapSave(path));
+        }
+        catch (Exception exception)
+        {
+            OnMainThread.Enqueue(() =>
+            {
+                saveUploadStatus = $"Save failed: {exception.GetType().Name}: {exception.Message}";
+                Log.Error($"Bootstrap save failed: {exception}");
+                bootstrapSaveQueued = false;
+            });
+        }
+    }
+
+    private void FinalizeBootstrapSave(string path)
+    {
+        savedReplayPath = path;
+        saveReady = File.Exists(savedReplayPath);
+
+        if (!saveReady)
+        {
+            saveUploadStatus = $"Save finished but file not found: {path}";
+            Log.Error($"Bootstrap save finished but file was missing: {path}");
+            bootstrapSaveQueued = false;
+            return;
+        }
+
+        pendingUploadState = new PendingUploadState
+        {
+            Settings = MpUtil.ShallowCopy(settings, new ServerSettings()),
+            SavePath = savedReplayPath,
+            StatusText = statusText ?? string.Empty
+        };
+
+        saveUploadStatus = "Save created. Returning to menu...";
+        LongEventHandler.QueueLongEvent(ReturnToMenuAndReconnect, "Returning to menu", false, null);
+    }
+
+    private void ReturnToMenuAndReconnect()
+    {
+        GenScene.GoToMainMenu();
+        OnMainThread.Enqueue(() =>
+        {
+            saveUploadStatus = "Reconnecting to upload save...";
+            Multiplayer.StopMultiplayer();
+
+            if (reconnectConnector == null)
+            {
+                saveUploadStatus = "No connector available to reconnect to the bootstrap server.";
+                return;
+            }
+
+            ClientUtil.TryConnectWithWindow(reconnectConnector, false);
+        });
+    }
+
+    private void StartUploadSaveZip()
+    {
+        if (string.IsNullOrWhiteSpace(savedReplayPath) || !File.Exists(savedReplayPath))
+        {
+            saveUploadStatus = "Can't upload: autosave file not found.";
+            return;
+        }
+
+        isUploadingSave = true;
+        saveUploadProgress = 0f;
+        saveUploadStatus = "Uploading save.zip...";
+
+        byte[] bytes;
+        try
+        {
+            bytes = File.ReadAllBytes(savedReplayPath);
+        }
+        catch (Exception exception)
+        {
+            isUploadingSave = false;
+            saveUploadStatus = $"Failed to read autosave: {exception.GetType().Name}: {exception.Message}";
+            return;
+        }
+
+        new System.Threading.Thread(() =>
+        {
+            try
+            {
+                connection.Send(new ClientBootstrapSaveStartPacket("save.zip", bytes.Length));
+
+                const int chunkSize = 256 * 1024;
+                var sent = 0;
+                while (sent < bytes.Length)
+                {
+                    var len = Math.Min(chunkSize, bytes.Length - sent);
+                    var part = new byte[len];
+                    Buffer.BlockCopy(bytes, sent, part, 0, len);
+                    connection.SendFragmented(new ClientBootstrapSaveDataPacket(part).Serialize());
+                    sent += len;
+                    var progress = bytes.Length == 0 ? 1f : (float)sent / bytes.Length;
+                    OnMainThread.Enqueue(() => saveUploadProgress = Mathf.Clamp01(progress));
+                }
+
+                byte[] hash;
+                using (var hasher = SHA256.Create())
+                    hash = hasher.ComputeHash(bytes);
+
+                connection.Send(new ClientBootstrapSaveEndPacket(hash));
+                OnMainThread.Enqueue(() =>
+                {
+                    saveUploadStatus = "Upload finished. Waiting for server to confirm and shut down...";
+                });
+            }
+            catch (Exception exception)
+            {
+                OnMainThread.Enqueue(() =>
+                {
+                    isUploadingSave = false;
+                    saveUploadStatus = $"Failed to upload save.zip: {exception.GetType().Name}: {exception.Message}";
+                });
+            }
+        }) { IsBackground = true, Name = "MP Bootstrap save upload" }.Start();
+    }
+}

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.SettingsUi.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.SettingsUi.cs
@@ -150,11 +150,12 @@ public partial class BootstrapConfiguratorWindow
                     isUploadingToml = false;
                     uploadProgress = 1f;
                     settingsUploaded = true;
-                    statusText = "Server settings uploaded. Map generation will be enabled in the next slice.";
+                    statusText = "Server settings uploaded. Waiting for the server to request save.zip generation.";
                     step = Step.GenerateMap;
+                    saveUploadRequestedByServer = false;
 
                     if (Multiplayer.session != null)
-                        Multiplayer.session.serverBootstrapSettingsMissing = false;
+                        Multiplayer.session.bootstrapState = Multiplayer.session.bootstrapState with { SettingsMissing = false, SaveMissing = false };
                 });
             }
             catch (System.Exception e)

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.SettingsUi.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.SettingsUi.cs
@@ -1,0 +1,194 @@
+using Multiplayer.Client.Util;
+using Multiplayer.Common.Networking.Packet;
+using Multiplayer.Common.Util;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace Multiplayer.Client;
+
+public partial class BootstrapConfiguratorWindow
+{
+    private void DrawSettings(Rect entry, Rect inRect)
+    {
+        if (!string.IsNullOrEmpty(statusText))
+        {
+            var statusHeight = Text.CalcHeight(statusText, entry.width);
+            Widgets.Label(entry.Height(statusHeight), statusText);
+            entry = entry.Down(statusHeight + 4);
+        }
+
+        if (isUploadingToml)
+        {
+            var barRect = entry.Height(20f);
+            Widgets.FillableBar(barRect, uploadProgress);
+            entry = entry.Down(24f);
+        }
+
+        using (MpStyle.Set(TextAnchor.MiddleLeft))
+        {
+            DoTabButton(entry.Width(140f).Height(40f), Tab.Connecting);
+            DoTabButton(entry.Down(50f).Width(140f).Height(40f), Tab.Gameplay);
+            if (Prefs.DevMode)
+                DoTabButton(entry.Down(100f).Width(140f).Height(40f), Tab.Preview);
+        }
+
+        var contentRect = entry.MinX(entry.xMin + 150f);
+        var buffers = new ServerSettingsUI.BufferSet
+        {
+            MaxPlayersBuffer = settingsUiBuffers.MaxPlayersBuffer,
+            AutosaveBuffer = settingsUiBuffers.AutosaveBuffer
+        };
+
+        if (tab == Tab.Connecting)
+            ServerSettingsUI.DrawNetworkingSettings(contentRect, settings, buffers);
+        else if (tab == Tab.Gameplay)
+            ServerSettingsUI.DrawGameplaySettingsOnly(contentRect, settings, buffers);
+        else if (tab == Tab.Preview)
+            DrawPreviewTab(contentRect, inRect.height);
+
+        settingsUiBuffers.MaxPlayersBuffer = buffers.MaxPlayersBuffer;
+        settingsUiBuffers.AutosaveBuffer = buffers.AutosaveBuffer;
+
+        DrawSettingsButtons(new Rect(0f, inRect.height - 40f, inRect.width, 35f));
+    }
+
+    private void DrawPreviewTab(Rect contentRect, float windowHeight)
+    {
+        RebuildTomlPreview();
+        var previewRect = new Rect(contentRect.x, contentRect.y, contentRect.width, windowHeight - contentRect.y - 50f);
+        DrawTomlPreview(previewRect);
+    }
+
+    private void DoTabButton(Rect rect, Tab tabToDraw)
+    {
+        Widgets.DrawOptionBackground(rect, tabToDraw == tab);
+        if (Widgets.ButtonInvisible(rect, true))
+        {
+            tab = tabToDraw;
+            SoundDefOf.Click.PlayOneShotOnCamera();
+        }
+
+        float x = rect.x + 10f;
+        Texture2D icon = null;
+        string label;
+
+        if (tabToDraw == Tab.Connecting)
+        {
+            icon = MultiplayerStatic.OptionsGeneral;
+            label = "MpHostTabConnecting".Translate();
+        }
+        else if (tabToDraw == Tab.Gameplay)
+        {
+            icon = MultiplayerStatic.OptionsGameplay;
+            label = "MpHostTabGameplay".Translate();
+        }
+        else
+        {
+            label = "Preview";
+        }
+
+        if (icon != null)
+        {
+            var iconRect = new Rect(x, rect.y + (rect.height - 20f) / 2f, 20f, 20f);
+            GUI.DrawTexture(iconRect, icon);
+            x += 30f;
+        }
+
+        Widgets.Label(new Rect(x, rect.y, rect.width - x, rect.height), label);
+    }
+
+    private void DrawSettingsButtons(Rect inRect)
+    {
+        Rect nextRect;
+        if (Prefs.DevMode)
+        {
+            var copyRect = new Rect(inRect.x, inRect.y, 150f, inRect.height);
+            if (Widgets.ButtonText(copyRect, "Copy TOML"))
+            {
+                RebuildTomlPreview();
+                GUIUtility.systemCopyBuffer = tomlPreview;
+                Messages.Message("Copied settings.toml to clipboard", MessageTypeDefOf.SilentInput, false);
+            }
+
+            nextRect = new Rect(inRect.xMax - 150f, inRect.y, 150f, inRect.height);
+        }
+        else
+        {
+            nextRect = new Rect((inRect.width - 150f) / 2f, inRect.y, 150f, inRect.height);
+        }
+
+        var nextEnabled = !isUploadingToml && !settingsUploaded;
+        var previousColor = GUI.color;
+        if (!nextEnabled)
+            GUI.color = new Color(1f, 1f, 1f, 0.5f);
+
+        if (Widgets.ButtonText(nextRect, settingsUploaded ? "Uploaded" : "Next") && nextEnabled)
+        {
+            RebuildTomlPreview();
+            StartUploadSettingsToml();
+        }
+
+        GUI.color = previousColor;
+    }
+
+    private void StartUploadSettingsToml()
+    {
+        isUploadingToml = true;
+        uploadProgress = 0f;
+        statusText = "Uploading server settings...";
+
+        new System.Threading.Thread(() =>
+        {
+            try
+            {
+                connection.Send(new ClientBootstrapSettingsPacket(settings));
+
+                OnMainThread.Enqueue(() =>
+                {
+                    isUploadingToml = false;
+                    uploadProgress = 1f;
+                    settingsUploaded = true;
+                    statusText = "Server settings uploaded. Map generation will be enabled in the next slice.";
+                    step = Step.GenerateMap;
+
+                    if (Multiplayer.session != null)
+                        Multiplayer.session.serverBootstrapSettingsMissing = false;
+                });
+            }
+            catch (System.Exception e)
+            {
+                Log.Error($"Bootstrap settings upload failed: {e}");
+                OnMainThread.Enqueue(() =>
+                {
+                    isUploadingToml = false;
+                    statusText = $"Failed to upload settings: {e.GetType().Name}: {e.Message}";
+                });
+            }
+        }) { IsBackground = true, Name = "MP Bootstrap settings upload" }.Start();
+    }
+
+    private void DrawTomlPreview(Rect inRect)
+    {
+        Widgets.DrawMenuSection(inRect);
+        var inner = inRect.ContractedBy(10f);
+
+        Text.Font = GameFont.Small;
+        Widgets.Label(inner.TopPartPixels(22f), "settings.toml preview");
+
+        var previewRect = new Rect(inner.x, inner.y + 26f, inner.width, inner.height - 26f);
+        var content = tomlPreview ?? string.Empty;
+        var contentHeight = Text.CalcHeight(content, previewRect.width - 16f) + 20f;
+        var viewRect = new Rect(0f, 0f, previewRect.width - 16f, Mathf.Max(previewRect.height, contentHeight));
+
+        Widgets.BeginScrollView(previewRect, ref tomlScroll, viewRect);
+        Widgets.Label(new Rect(0f, 0f, viewRect.width, viewRect.height), content);
+        Widgets.EndScrollView();
+    }
+
+    private void RebuildTomlPreview()
+    {
+        tomlPreview = "# Generated by Multiplayer bootstrap configurator\n\n" + TomlSettingsCommon.Serialize(settings);
+    }
+}

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.cs
@@ -1,0 +1,36 @@
+using Multiplayer.Common;
+using UnityEngine;
+using Verse;
+
+namespace Multiplayer.Client;
+
+public class BootstrapConfiguratorWindow : Window
+{
+    private readonly ConnectionBase connection;
+
+    public override Vector2 InitialSize => new(480f, 220f);
+
+    public BootstrapConfiguratorWindow(ConnectionBase connection)
+    {
+        this.connection = connection;
+        doCloseX = true;
+        closeOnClickedOutside = false;
+        absorbInputAroundWindow = true;
+    }
+
+    public override void DoWindowContents(Rect inRect)
+    {
+        Text.Font = GameFont.Medium;
+        Widgets.Label(inRect.TopPartPixels(35f), "Server Bootstrap");
+
+        Text.Font = GameFont.Small;
+        var bodyRect = new Rect(inRect.x, inRect.y + 45f, inRect.width, inRect.height - 90f);
+        var message = Multiplayer.session.serverBootstrapSettingsMissing
+            ? "Bootstrap mode detected. The dedicated configurator flow will be added in the next push."
+            : "Bootstrap mode detected. This slice only wires protocol detection and state routing.";
+        Widgets.Label(bodyRect, message);
+
+        if (Widgets.ButtonText(new Rect((inRect.width - 160f) / 2f, inRect.height - 40f, 160f, 35f), "Close"))
+            Close();
+    }
+}

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Multiplayer.Client.Util;
 using Multiplayer.Common;
 using Multiplayer.Common.Util;
@@ -9,9 +10,15 @@ namespace Multiplayer.Client;
 
 public partial class BootstrapConfiguratorWindow : Window
 {
+    public static BootstrapConfiguratorWindow Instance { get; private set; }
+    public static bool AwaitingBootstrapMapInit { get; set; }
+
     private readonly ConnectionBase connection;
+    private readonly IConnector reconnectConnector;
+    private float height = 620f;
 
     private ServerSettings settings;
+    private bool retainInstanceOnClose;
 
     private enum Step
     {
@@ -37,40 +44,121 @@ public partial class BootstrapConfiguratorWindow : Window
     private float uploadProgress;
     private string statusText;
     private bool settingsUploaded;
+    private bool saveUploadRequestedByServer;
+    private bool saveGenerationStarted;
 
-    private const float LabelWidth = 110f;
-    private const int MaxGameNameLength = 70;
+    private static PendingUploadState pendingUploadState;
 
-    public override Vector2 InitialSize => new(550f, 620f);
+    public override Vector2 InitialSize => new(550f, height);
 
     public BootstrapConfiguratorWindow(ConnectionBase connection)
     {
         this.connection = connection;
+        reconnectConnector = Multiplayer.session?.connector;
         doCloseX = true;
         closeOnClickedOutside = false;
         absorbInputAroundWindow = true;
+
+        Instance = this;
 
         settings = MpUtil.ShallowCopy(Multiplayer.settings.PreferredLocalServerSettings, new ServerSettings());
         settings.gameName ??= $"{Multiplayer.username}'s Server";
         if (settings.gameName.NullOrEmpty())
             settings.gameName = $"{Multiplayer.username}'s Server";
         settings.lanAddress = Endpoints.GetLocalIpAddress() ?? settings.lanAddress ?? "127.0.0.1";
+        settings.direct = true;
+        settings.lan = false;
+        if (settings.directAddress.NullOrEmpty())
+            settings.directAddress = $"0.0.0.0:{MultiplayerServer.DefaultPort}";
         settings.steam = false;
         settings.arbiter = false;
 
         settingsUiBuffers.MaxPlayersBuffer = settings.maxPlayers.ToString();
         settingsUiBuffers.AutosaveBuffer = settings.autosaveInterval.ToString();
 
-        step = Multiplayer.session?.serverBootstrapSettingsMissing == true ? Step.Settings : Step.GenerateMap;
-        statusText = step == Step.Settings
-            ? "Server settings.toml is missing. Configure it and upload it first."
-            : "Server settings.toml is already configured. Map generation will be enabled in the next slice.";
+        saveGenerationStarted = false;
+
+        if (pendingUploadState == null && Current.ProgramState != ProgramState.Playing)
+            ResetTransientUiState();
+
+        ApplyBootstrapState(Multiplayer.session?.bootstrapState ?? BootstrapServerState.None, preserveTransientState: false);
+
+        if (pendingUploadState != null && File.Exists(pendingUploadState.SavePath))
+        {
+            settings = pendingUploadState.Settings;
+            step = Step.GenerateMap;
+            settingsUploaded = true;
+            saveReady = true;
+            savedReplayPath = pendingUploadState.SavePath;
+            statusText = pendingUploadState.StatusText;
+            saveUploadStatus = "Save created. Reconnected to upload save.zip...";
+            pendingUploadState = null;
+        }
 
         RebuildTomlPreview();
     }
 
+    public override void PostClose()
+    {
+        base.PostClose();
+
+        if (!retainInstanceOnClose)
+            ResetTransientUiState();
+
+        if (ReferenceEquals(Instance, this) && !retainInstanceOnClose)
+            Instance = null;
+    }
+
+    internal void ResetTransientUiState(bool resetServerDrivenState = false)
+    {
+        AwaitingBootstrapMapInit = false;
+        hideWindowDuringMapGen = false;
+        autoAdvanceArmed = false;
+        bootstrapSaveQueued = false;
+        awaitingControllablePawns = false;
+        isUploadingSave = false;
+        saveUploadAutoStarted = false;
+        postMapEnterSaveDelayRemaining = 0f;
+
+        if (resetServerDrivenState)
+        {
+            saveUploadRequestedByServer = false;
+            saveGenerationStarted = false;
+            Multiplayer.session?.ClearBootstrapState();
+        }
+    }
+
+    internal void ApplyBootstrapState(BootstrapServerState state, bool preserveTransientState = true)
+    {
+        saveUploadRequestedByServer = state.RequiresSaveUpload;
+
+        if (state.RequiresSettingsUpload)
+        {
+            step = Step.Settings;
+            settingsUploaded = false;
+            statusText = "Server settings.toml is missing. Configure it and upload it first.";
+            return;
+        }
+
+        step = Step.GenerateMap;
+
+        if (preserveTransientState && (saveReady || isUploadingSave || saveGenerationStarted || autoAdvanceArmed || AwaitingBootstrapMapInit || bootstrapSaveQueued || awaitingControllablePawns))
+            return;
+
+        statusText = saveUploadRequestedByServer
+            ? "Server settings.toml already exists. Review the warning below, then create and upload save.zip."
+            : "Waiting for the server to request save.zip generation.";
+    }
+
     public override void DoWindowContents(Rect inRect)
     {
+        var desiredHeight = GetDesiredWindowHeight();
+        if (Event.current.type == EventType.Layout && !Mathf.Approximately(height, desiredHeight))
+        {
+            height = desiredHeight;
+            SetInitialSizeAndPosition();
+        }
+
         Text.Font = GameFont.Medium;
         Text.Anchor = TextAnchor.UpperCenter;
         Widgets.Label(inRect.Down(0f), "Server Bootstrap Configuration");
@@ -80,24 +168,69 @@ public partial class BootstrapConfiguratorWindow : Window
         var entry = new Rect(0f, 45f, inRect.width, 30f);
         entry.xMin += 4f;
 
-        settings.gameName = MpUI.TextEntryLabeled(entry, $"{"MpGameName".Translate()}:  ", settings.gameName, LabelWidth);
-        if (settings.gameName.Length > MaxGameNameLength)
-            settings.gameName = settings.gameName.Substring(0, MaxGameNameLength);
-
-        entry = entry.Down(40f);
-
         if (step == Step.Settings)
             DrawSettings(entry, inRect);
         else
             DrawGenerateMap(entry, inRect);
     }
 
-    private void DrawGenerateMap(Rect entry, Rect inRect)
+    private float GetDesiredWindowHeight()
     {
-        var statusHeight = Text.CalcHeight(statusText ?? string.Empty, entry.width);
-        Widgets.Label(entry.Height(statusHeight), statusText ?? string.Empty);
+        const float topPadding = 45f;
+        const float bottomPadding = 55f;
+        const float minHeight = 240f;
+        const float maxHeight = 700f;
 
-        var noticeRect = new Rect(0f, inRect.height - 55f, inRect.width, 40f);
-        Widgets.Label(noticeRect, "The world generation and save upload flow will be added in the next slice.");
+        var desired = topPadding + bottomPadding;
+
+        if (step == Step.Settings)
+            desired += 40f;
+
+        if (step == Step.GenerateMap)
+        {
+            desired += GetGenerateMapStepHeight();
+        }
+        else
+        {
+            desired += GetSettingsStepHeight();
+        }
+
+        return Mathf.Clamp(desired, minHeight, maxHeight);
     }
+
+    private float GetSettingsStepHeight()
+    {
+        var contentHeight = 0f;
+
+        if (!string.IsNullOrEmpty(statusText))
+            contentHeight += Text.CalcHeight(statusText, 500f) + 4f;
+
+        if (isUploadingToml)
+            contentHeight += 24f;
+
+        contentHeight += 140f;
+        contentHeight += Mathf.Max(GetActiveTabContentHeight(), 150f);
+        contentHeight += 40f;
+
+        return contentHeight;
+    }
+
+    private float GetActiveTabContentHeight()
+    {
+        if (tab == Tab.Connecting)
+            return 5 * 30f;
+
+        if (tab == Tab.Gameplay)
+            return (MpVersion.IsDebug ? 9 : 8) * 30f;
+
+        return 260f;
+    }
+
+    private sealed class PendingUploadState
+    {
+        public ServerSettings Settings;
+        public string SavePath;
+        public string StatusText;
+    }
+
 }

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.cs
@@ -1,14 +1,47 @@
+using Multiplayer.Client.Util;
 using Multiplayer.Common;
+using Multiplayer.Common.Util;
+using RimWorld;
 using UnityEngine;
 using Verse;
 
 namespace Multiplayer.Client;
 
-public class BootstrapConfiguratorWindow : Window
+public partial class BootstrapConfiguratorWindow : Window
 {
     private readonly ConnectionBase connection;
 
-    public override Vector2 InitialSize => new(480f, 220f);
+    private ServerSettings settings;
+
+    private enum Step
+    {
+        Settings,
+        GenerateMap
+    }
+
+    private enum Tab
+    {
+        Connecting,
+        Gameplay,
+        Preview
+    }
+
+    private Step step;
+    private Tab tab;
+    private readonly ServerSettingsUI.BufferSet settingsUiBuffers = new();
+
+    private string tomlPreview;
+    private Vector2 tomlScroll;
+
+    private bool isUploadingToml;
+    private float uploadProgress;
+    private string statusText;
+    private bool settingsUploaded;
+
+    private const float LabelWidth = 110f;
+    private const int MaxGameNameLength = 70;
+
+    public override Vector2 InitialSize => new(550f, 620f);
 
     public BootstrapConfiguratorWindow(ConnectionBase connection)
     {
@@ -16,21 +49,55 @@ public class BootstrapConfiguratorWindow : Window
         doCloseX = true;
         closeOnClickedOutside = false;
         absorbInputAroundWindow = true;
+
+        settings = MpUtil.ShallowCopy(Multiplayer.settings.PreferredLocalServerSettings, new ServerSettings());
+        settings.gameName ??= $"{Multiplayer.username}'s Server";
+        if (settings.gameName.NullOrEmpty())
+            settings.gameName = $"{Multiplayer.username}'s Server";
+        settings.lanAddress = Endpoints.GetLocalIpAddress() ?? settings.lanAddress ?? "127.0.0.1";
+        settings.steam = false;
+        settings.arbiter = false;
+
+        settingsUiBuffers.MaxPlayersBuffer = settings.maxPlayers.ToString();
+        settingsUiBuffers.AutosaveBuffer = settings.autosaveInterval.ToString();
+
+        step = Multiplayer.session?.serverBootstrapSettingsMissing == true ? Step.Settings : Step.GenerateMap;
+        statusText = step == Step.Settings
+            ? "Server settings.toml is missing. Configure it and upload it first."
+            : "Server settings.toml is already configured. Map generation will be enabled in the next slice.";
+
+        RebuildTomlPreview();
     }
 
     public override void DoWindowContents(Rect inRect)
     {
         Text.Font = GameFont.Medium;
-        Widgets.Label(inRect.TopPartPixels(35f), "Server Bootstrap");
+        Text.Anchor = TextAnchor.UpperCenter;
+        Widgets.Label(inRect.Down(0f), "Server Bootstrap Configuration");
+        Text.Anchor = TextAnchor.UpperLeft;
 
         Text.Font = GameFont.Small;
-        var bodyRect = new Rect(inRect.x, inRect.y + 45f, inRect.width, inRect.height - 90f);
-        var message = Multiplayer.session.serverBootstrapSettingsMissing
-            ? "Bootstrap mode detected. The dedicated configurator flow will be added in the next push."
-            : "Bootstrap mode detected. This slice only wires protocol detection and state routing.";
-        Widgets.Label(bodyRect, message);
+        var entry = new Rect(0f, 45f, inRect.width, 30f);
+        entry.xMin += 4f;
 
-        if (Widgets.ButtonText(new Rect((inRect.width - 160f) / 2f, inRect.height - 40f, 160f, 35f), "Close"))
-            Close();
+        settings.gameName = MpUI.TextEntryLabeled(entry, $"{"MpGameName".Translate()}:  ", settings.gameName, LabelWidth);
+        if (settings.gameName.Length > MaxGameNameLength)
+            settings.gameName = settings.gameName.Substring(0, MaxGameNameLength);
+
+        entry = entry.Down(40f);
+
+        if (step == Step.Settings)
+            DrawSettings(entry, inRect);
+        else
+            DrawGenerateMap(entry, inRect);
+    }
+
+    private void DrawGenerateMap(Rect entry, Rect inRect)
+    {
+        var statusHeight = Text.CalcHeight(statusText ?? string.Empty, entry.width);
+        Widgets.Label(entry.Height(statusHeight), statusText ?? string.Empty);
+
+        var noticeRect = new Rect(0f, inRect.height - 55f, inRect.width, 40f);
+        Widgets.Label(noticeRect, "The world generation and save upload flow will be added in the next slice.");
     }
 }

--- a/Source/Client/Windows/HostWindow.cs
+++ b/Source/Client/Windows/HostWindow.cs
@@ -463,6 +463,23 @@ namespace Multiplayer.Client
             return invalidEndpoint == null;
         }
 
+        public static bool HostProgrammatically(ServerSettings sourceSettings)
+        {
+            var settings = MpUtil.ShallowCopy(sourceSettings, new ServerSettings());
+
+            if (settings.direct && !TryParseEndpoints(settings))
+                return false;
+
+            if (settings.gameName.NullOrEmpty())
+                return false;
+
+            if (!TryStartLocalServer(settings))
+                return false;
+
+            HostUtil.HostServer(settings, false);
+            return true;
+        }
+
         static bool TryStartLocalServer(ServerSettings settings)
         {
             var localServer = new MultiplayerServer(settings);

--- a/Source/Client/Windows/ServerSettingsUI.cs
+++ b/Source/Client/Windows/ServerSettingsUI.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Multiplayer.Client.Util;
+using Multiplayer.Common;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+using Verse.Steam;
+
+namespace Multiplayer.Client;
+
+public static class ServerSettingsUI
+{
+    private const float LabelWidth = 110f;
+    private const float CheckboxWidth = LabelWidth + 30f;
+    private static readonly Color CustomButtonColor = new(0.15f, 0.15f, 0.15f);
+
+    public class BufferSet
+    {
+        public string MaxPlayersBuffer;
+        public string AutosaveBuffer;
+    }
+
+    public static void DrawNetworkingSettings(Rect entry, ServerSettings settings, BufferSet buffers)
+    {
+        MpUI.TextFieldNumericLabeled(entry.Width(LabelWidth + 35f), $"{"MpMaxPlayers".Translate()}:  ", ref settings.maxPlayers,
+            ref buffers.MaxPlayersBuffer, LabelWidth, 0, 999);
+        entry = entry.Down(30);
+
+        MpUI.CheckboxLabeled(entry.Width(CheckboxWidth), $"{"MpHostGamePassword".Translate()}:  ", ref settings.hasPassword,
+            order: ElementOrder.Right);
+        if (settings.hasPassword)
+            MpUI.DoPasswordField(entry.Right(CheckboxWidth + 10).MaxX(entry.xMax), "PasswordField", ref settings.password);
+        entry = entry.Down(30);
+
+        var directLabel = $"{"MpHostDirect".Translate()}:  ";
+        MpUI.CheckboxLabeled(entry.Width(CheckboxWidth), directLabel, ref settings.direct, order: ElementOrder.Right);
+        TooltipHandler.TipRegion(entry.Width(LabelWidth), MpUtil.TranslateWithDoubleNewLines("MpHostDirectDesc", 4));
+        if (settings.direct)
+            settings.directAddress = Widgets.TextField(entry.Right(CheckboxWidth + 10).MaxX(entry.xMax), settings.directAddress);
+
+        entry = entry.Down(30);
+
+        var lanRect = entry.Width(CheckboxWidth);
+        MpUI.CheckboxLabeled(lanRect, $"{"MpLan".Translate()}:  ", ref settings.lan, order: ElementOrder.Right);
+        TooltipHandler.TipRegion(lanRect, $"{"MpLanDesc1".Translate()}\n\n{"MpLanDesc2".Translate(settings.lanAddress)}");
+
+        entry = entry.Down(30);
+
+        var steamRect = entry.Width(CheckboxWidth);
+        if (!SteamManager.Initialized) settings.steam = false;
+        MpUI.CheckboxLabeled(steamRect, $"{"MpSteam".Translate()}:  ", ref settings.steam, order: ElementOrder.Right,
+            disabled: !SteamManager.Initialized);
+        if (!SteamManager.Initialized)
+            TooltipHandler.TipRegion(steamRect, "MpSteamNotAvailable".Translate());
+        entry = entry.Down(30);
+
+        TooltipHandler.TipRegion(entry.Width(CheckboxWidth), MpUtil.TranslateWithDoubleNewLines("MpSyncConfigsDescNew", 3));
+        MpUI.CheckboxLabeled(entry.Width(CheckboxWidth), $"{"MpSyncConfigs".Translate()}:  ", ref settings.syncConfigs,
+            order: ElementOrder.Right);
+    }
+
+    public static void DrawGameplaySettingsOnly(Rect entry, ServerSettings settings, BufferSet buffers) =>
+        DrawGameplaySettings(entry, settings, buffers);
+
+    public static void DrawGameplaySettings(Rect entry, ServerSettings settings, BufferSet buffers,
+        bool asyncTimeLocked = false, bool multifactionLocked = false)
+    {
+        var autosaveUnitKey = settings.autosaveUnit == AutosaveUnit.Days ? "MpAutosavesDays" : "MpAutosavesMinutes";
+        var changeAutosaveUnit = false;
+
+        LeftLabel(entry, $"{"MpAutosaves".Translate()}:  ");
+        TooltipHandler.TipRegion(entry.Width(LabelWidth), MpUtil.TranslateWithDoubleNewLines("MpAutosavesDesc", 3));
+
+        using (MpStyle.Set(TextAnchor.MiddleRight))
+            DoRow(
+                entry.Right(LabelWidth + 10),
+                rect => MpUI.LabelFlexibleWidth(rect, "MpAutosavesEvery".Translate()) + 6,
+                rect =>
+                {
+                    Widgets.TextFieldNumeric(rect.Width(50f), ref settings.autosaveInterval, ref buffers.AutosaveBuffer, 0, 999);
+                    return 56f;
+                },
+                rect =>
+                {
+                    changeAutosaveUnit = CustomButton(rect, autosaveUnitKey.Translate(), out var width);
+                    return width;
+                });
+
+        if (changeAutosaveUnit)
+        {
+            settings.autosaveUnit = settings.autosaveUnit.Cycle();
+            settings.autosaveInterval *= settings.autosaveUnit == AutosaveUnit.Minutes ? 8f : 0.125f;
+            buffers.AutosaveBuffer = settings.autosaveInterval.ToString();
+        }
+
+        entry = entry.Down(30);
+
+        MpUI.CheckboxLabeled(entry.Width(CheckboxWidth), "Multifaction:  ", ref settings.multifaction,
+            order: ElementOrder.Right, disabled: multifactionLocked);
+        entry = entry.Down(30);
+
+        TooltipHandler.TipRegion(entry.Width(CheckboxWidth), $"{"MpAsyncTimeDesc".Translate()}\n\n{"MpExperimentalFeature".Translate()}");
+        MpUI.CheckboxLabeled(entry.Width(CheckboxWidth), $"{"MpAsyncTime".Translate()}:  ", ref settings.asyncTime,
+            order: ElementOrder.Right, disabled: asyncTimeLocked);
+        entry = entry.Down(30);
+
+        LeftLabel(entry, $"{"MpTimeControl".Translate()}:  ");
+        DoTimeControl(entry.Right(LabelWidth + 10), settings);
+        entry = entry.Down(30);
+
+        MpUI.CheckboxLabeledWithTipNoHighlight(entry.Width(CheckboxWidth), $"{"MpLogDesyncTraces".Translate()}:  ",
+            MpUtil.TranslateWithDoubleNewLines("MpLogDesyncTracesDesc", 2), ref settings.desyncTraces,
+            placeTextNearCheckbox: true);
+        entry = entry.Down(30);
+
+        if (MpVersion.IsDebug)
+        {
+            TooltipHandler.TipRegion(entry.Width(CheckboxWidth), "MpArbiterDesc".Translate());
+            MpUI.CheckboxLabeled(entry.Width(CheckboxWidth), $"{"MpRunArbiter".Translate()}:  ", ref settings.arbiter,
+                order: ElementOrder.Right);
+            entry = entry.Down(30);
+        }
+
+        MpUI.CheckboxLabeledWithTipNoHighlight(entry.Width(CheckboxWidth), $"{"MpHostingDevMode".Translate()}:  ",
+            MpUtil.TranslateWithDoubleNewLines("MpHostingDevModeDesc", 2), ref settings.debugMode,
+            placeTextNearCheckbox: true);
+
+        if (settings.debugMode && CustomButton(entry.Right(CheckboxWidth + 10f), $"MpHostingDevMode{settings.devModeScope}".Translate()))
+        {
+            settings.devModeScope = settings.devModeScope.Cycle();
+            SoundDefOf.Checkbox_TurnedOn.PlayOneShotOnCamera();
+        }
+
+        entry = entry.Down(30);
+
+        DrawJoinPointOptions(entry, settings);
+        entry = entry.Down(30);
+
+        LeftLabel(entry, $"{"MpPauseOnLetter".Translate()}:  ");
+        DoPauseOnLetter(entry.Right(LabelWidth + 10), settings);
+        entry = entry.Down(30);
+
+        LeftLabel(entry, $"{"MpPauseOn".Translate()}:  ");
+        DoRow(
+            entry.Right(LabelWidth + 10),
+            rect => MpUI.CheckboxLabeled(rect.Width(CheckboxWidth), "MpPauseOnJoin".Translate(), ref settings.pauseOnJoin,
+                size: 20f, order: ElementOrder.Left).width + 15,
+            rect => MpUI.CheckboxLabeled(rect.Width(CheckboxWidth), "MpPauseOnDesync".Translate(), ref settings.pauseOnDesync,
+                size: 20f, order: ElementOrder.Left).width);
+    }
+
+    private static void DoTimeControl(Rect entry, ServerSettings settings)
+    {
+        if (CustomButton(entry, $"MpTimeControl{settings.timeControl}".Translate()))
+            Find.WindowStack.Add(new FloatMenu(Options(settings).ToList()));
+
+        IEnumerable<FloatMenuOption> Options(ServerSettings source)
+        {
+            foreach (var opt in Enum.GetValues(typeof(TimeControl)).OfType<TimeControl>())
+                yield return new FloatMenuOption($"MpTimeControl{opt}".Translate(), () => source.timeControl = opt);
+        }
+    }
+
+    private static void DoPauseOnLetter(Rect entry, ServerSettings settings)
+    {
+        if (CustomButton(entry, $"MpPauseOnLetter{settings.pauseOnLetter}".Translate()))
+            Find.WindowStack.Add(new FloatMenu(Options(settings).ToList()));
+
+        IEnumerable<FloatMenuOption> Options(ServerSettings source)
+        {
+            foreach (var opt in Enum.GetValues(typeof(PauseOnLetter)).OfType<PauseOnLetter>())
+                yield return new FloatMenuOption($"MpPauseOnLetter{opt}".Translate(), () => source.pauseOnLetter = opt);
+        }
+    }
+
+    private static void DrawJoinPointOptions(Rect entry, ServerSettings settings)
+    {
+        LeftLabel(entry, $"{"MpAutoJoinPoints".Translate()}:  ", MpUtil.TranslateWithDoubleNewLines("MpAutoJoinPointsDesc", 3));
+
+        var flags = Enum.GetValues(typeof(AutoJoinPointFlags))
+            .OfType<AutoJoinPointFlags>()
+            .Where(flag => settings.autoJoinPoint.HasFlag(flag))
+            .Select(flag => $"MpAutoJoinPoints{flag}".Translate())
+            .Join(", ");
+        if (flags.Length == 0)
+            flags = "Off";
+
+        if (CustomButton(entry.Right(LabelWidth + 10), flags))
+            Find.WindowStack.Add(new FloatMenu(FlagOptions(settings).ToList()));
+
+        IEnumerable<FloatMenuOption> FlagOptions(ServerSettings source)
+        {
+            foreach (var flag in Enum.GetValues(typeof(AutoJoinPointFlags)).OfType<AutoJoinPointFlags>())
+                yield return new FloatMenuOption($"MpAutoJoinPoints{flag}".Translate(), () =>
+                {
+                    if (source.autoJoinPoint.HasFlag(flag))
+                        source.autoJoinPoint &= ~flag;
+                    else
+                        source.autoJoinPoint |= flag;
+                });
+        }
+    }
+
+    private static float LeftLabel(Rect entry, string text, string desc = null)
+    {
+        using (MpStyle.Set(TextAnchor.MiddleRight))
+            MpUI.LabelWithTip(entry.Width(LabelWidth + 1), text, desc);
+        return Text.CalcSize(text).x;
+    }
+
+    private static void DoRow(Rect inRect, params Func<Rect, float>[] drawers)
+    {
+        foreach (var drawer in drawers)
+            inRect.xMin += drawer(inRect);
+    }
+
+    private static bool CustomButton(Rect rect, string label) => CustomButton(rect, label, out _);
+
+    private static bool CustomButton(Rect rect, string label, out float width)
+    {
+        using var _ = MpStyle.Set(TextAnchor.MiddleLeft);
+        var labelWidth = Text.CalcSize(label).x;
+        const float btnMargin = 5f;
+
+        var buttonRect = rect.Width(labelWidth + btnMargin * 2);
+        Widgets.DrawRectFast(buttonRect.Height(24).Down(3), CustomButtonColor);
+        Widgets.DrawHighlightIfMouseover(buttonRect.Height(24).Down(3));
+        MpUI.Label(rect.Right(btnMargin).Width(labelWidth), label);
+
+        width = buttonRect.width;
+        return Widgets.ButtonInvisible(buttonRect);
+    }
+}

--- a/Source/Common/LiteNetManager.cs
+++ b/Source/Common/LiteNetManager.cs
@@ -54,7 +54,8 @@ namespace Multiplayer.Common
 
         public void Tick()
         {
-            foreach (var (_, man) in netManagers) man.PollEvents();
+            var managersSnapshot = netManagers.ToArray();
+            foreach (var (_, man) in managersSnapshot) man.PollEvents();
         }
 
         public void Stop()

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -16,6 +16,7 @@ namespace Multiplayer.Common
         {
             MpConnectionState.SetImplementation(ConnectionStateEnum.ServerSteam, typeof(ServerSteamState));
             MpConnectionState.SetImplementation(ConnectionStateEnum.ServerJoining, typeof(ServerJoiningState));
+            MpConnectionState.SetImplementation(ConnectionStateEnum.ServerBootstrap, typeof(ServerBootstrapState));
             MpConnectionState.SetImplementation(ConnectionStateEnum.ServerLoading, typeof(ServerLoadingState));
             MpConnectionState.SetImplementation(ConnectionStateEnum.ServerPlaying, typeof(ServerPlayingState));
         }
@@ -253,6 +254,8 @@ namespace Multiplayer.Common
         public void HandleChatCmd(IChatSource source, string cmd) => chatCmdManager.Handle(source, cmd);
 
         public Task<ServerInitData?> InitDataTask() => initDataSource.Task;
+
+        public bool BootstrapMode { get; set; }
 
         /// Can only start one init data at a time. A StartInitData is considered complete once
         /// TaskCompletionResult.SetResult is called. Until that time no new calls to StartInitData will succeed.

--- a/Source/Common/Networking/ConnectionStateEnum.cs
+++ b/Source/Common/Networking/ConnectionStateEnum.cs
@@ -6,11 +6,13 @@ public enum ConnectionStateEnum : byte
     ClientLoading,
     ClientPlaying,
     ClientSteam,
+    ClientBootstrap,
 
     ServerJoining,
     ServerLoading,
     ServerPlaying,
     ServerSteam, // unused
+    ServerBootstrap,
 
     Count,
     Disconnected
@@ -19,8 +21,8 @@ public enum ConnectionStateEnum : byte
 public static class ConnectionStateEnumExt
 {
     public static bool IsClient(this ConnectionStateEnum state) =>
-        state is >= ConnectionStateEnum.ClientJoining and <= ConnectionStateEnum.ClientSteam;
+        state is >= ConnectionStateEnum.ClientJoining and <= ConnectionStateEnum.ClientBootstrap;
 
     public static bool IsServer(this ConnectionStateEnum state) =>
-        state is >= ConnectionStateEnum.ServerJoining and <= ConnectionStateEnum.ServerSteam;
+        state is >= ConnectionStateEnum.ServerJoining and <= ConnectionStateEnum.ServerBootstrap;
 }

--- a/Source/Common/Networking/MpDisconnectReason.cs
+++ b/Source/Common/Networking/MpDisconnectReason.cs
@@ -19,7 +19,8 @@
         Internal,
         ServerStarting,
         BadGamePassword,
-        StateException
+        StateException,
+        BootstrapCompleted
     }
 
 }

--- a/Source/Common/Networking/Packet/BootstrapPacket.cs
+++ b/Source/Common/Networking/Packet/BootstrapPacket.cs
@@ -1,14 +1,16 @@
 namespace Multiplayer.Common.Networking.Packet;
 
 [PacketDefinition(Packets.Server_Bootstrap)]
-public record struct ServerBootstrapPacket(bool bootstrap, bool settingsMissing = false) : IPacket
+public record struct ServerBootstrapPacket(bool bootstrap, bool settingsMissing = false, bool saveMissing = false) : IPacket
 {
     public bool bootstrap = bootstrap;
     public bool settingsMissing = settingsMissing;
+    public bool saveMissing = saveMissing;
 
     public void Bind(PacketBuffer buf)
     {
         buf.Bind(ref bootstrap);
         buf.Bind(ref settingsMissing);
+        buf.Bind(ref saveMissing);
     }
 }

--- a/Source/Common/Networking/Packet/BootstrapPacket.cs
+++ b/Source/Common/Networking/Packet/BootstrapPacket.cs
@@ -1,0 +1,14 @@
+namespace Multiplayer.Common.Networking.Packet;
+
+[PacketDefinition(Packets.Server_Bootstrap)]
+public record struct ServerBootstrapPacket(bool bootstrap, bool settingsMissing = false) : IPacket
+{
+    public bool bootstrap = bootstrap;
+    public bool settingsMissing = settingsMissing;
+
+    public void Bind(PacketBuffer buf)
+    {
+        buf.Bind(ref bootstrap);
+        buf.Bind(ref settingsMissing);
+    }
+}

--- a/Source/Common/Networking/Packet/BootstrapUploadPackets.cs
+++ b/Source/Common/Networking/Packet/BootstrapUploadPackets.cs
@@ -1,0 +1,43 @@
+namespace Multiplayer.Common.Networking.Packet;
+
+[PacketDefinition(Packets.Client_BootstrapSettingsUploadStart)]
+public record struct ClientBootstrapSettingsPacket(ServerSettings settings) : IPacket
+{
+    public ServerSettings settings = settings;
+
+    public void Bind(PacketBuffer buf)
+    {
+        ServerSettingsPacketBinder.Bind(buf, ref settings);
+    }
+}
+
+internal static class ServerSettingsPacketBinder
+{
+    public static void Bind(PacketBuffer buf, ref ServerSettings settings)
+    {
+        settings ??= new ServerSettings();
+
+        buf.Bind(ref settings.gameName, maxLength: 256);
+        buf.Bind(ref settings.directAddress, maxLength: 256);
+        buf.Bind(ref settings.maxPlayers);
+        buf.Bind(ref settings.autosaveInterval);
+        buf.BindEnum(ref settings.autosaveUnit);
+        buf.Bind(ref settings.steam);
+        buf.Bind(ref settings.direct);
+        buf.Bind(ref settings.lan);
+        buf.Bind(ref settings.arbiter);
+        buf.Bind(ref settings.asyncTime);
+        buf.Bind(ref settings.multifaction);
+        buf.Bind(ref settings.debugMode);
+        buf.Bind(ref settings.desyncTraces);
+        buf.Bind(ref settings.syncConfigs);
+        buf.BindEnum(ref settings.autoJoinPoint);
+        buf.BindEnum(ref settings.devModeScope);
+        buf.Bind(ref settings.hasPassword);
+        buf.Bind(ref settings.password, maxLength: 256);
+        buf.BindEnum(ref settings.pauseOnLetter);
+        buf.Bind(ref settings.pauseOnJoin);
+        buf.Bind(ref settings.pauseOnDesync);
+        buf.BindEnum(ref settings.timeControl);
+    }
+}

--- a/Source/Common/Networking/Packet/BootstrapUploadPackets.cs
+++ b/Source/Common/Networking/Packet/BootstrapUploadPackets.cs
@@ -11,6 +11,41 @@ public record struct ClientBootstrapSettingsPacket(ServerSettings settings) : IP
     }
 }
 
+[PacketDefinition(Packets.Client_BootstrapUploadStart)]
+public record struct ClientBootstrapSaveStartPacket(string fileName, int length) : IPacket
+{
+    public string fileName = fileName;
+    public int length = length;
+
+    public void Bind(PacketBuffer buf)
+    {
+        buf.Bind(ref fileName, maxLength: 256);
+        buf.Bind(ref length);
+    }
+}
+
+[PacketDefinition(Packets.Client_BootstrapUploadData, allowFragmented: true)]
+public record struct ClientBootstrapSaveDataPacket(byte[] data) : IPacket
+{
+    public byte[] data = data;
+
+    public void Bind(PacketBuffer buf)
+    {
+        buf.BindBytes(ref data, maxLength: -1);
+    }
+}
+
+[PacketDefinition(Packets.Client_BootstrapUploadFinish)]
+public record struct ClientBootstrapSaveEndPacket(byte[] sha256Hash) : IPacket
+{
+    public byte[] sha256Hash = sha256Hash;
+
+    public void Bind(PacketBuffer buf)
+    {
+        buf.BindBytes(ref sha256Hash, maxLength: 32);
+    }
+}
+
 internal static class ServerSettingsPacketBinder
 {
     public static void Bind(PacketBuffer buf, ref ServerSettings settings)

--- a/Source/Common/Networking/Packets.cs
+++ b/Source/Common/Networking/Packets.cs
@@ -67,6 +67,9 @@ public enum Packets : byte
 
     // Bootstrap
     Client_BootstrapSettingsUploadStart,
+    Client_BootstrapUploadStart,
+    Client_BootstrapUploadData,
+    Client_BootstrapUploadFinish,
     Server_Bootstrap,
 
     Count,

--- a/Source/Common/Networking/Packets.cs
+++ b/Source/Common/Networking/Packets.cs
@@ -65,6 +65,9 @@ public enum Packets : byte
     // All states (Joining, Loading, Playing)
     Server_Disconnect,
 
+    // Bootstrap
+    Server_Bootstrap,
+
     Count,
     Max = 63 // max packet id
 }

--- a/Source/Common/Networking/Packets.cs
+++ b/Source/Common/Networking/Packets.cs
@@ -66,6 +66,7 @@ public enum Packets : byte
     Server_Disconnect,
 
     // Bootstrap
+    Client_BootstrapSettingsUploadStart,
     Server_Bootstrap,
 
     Count,

--- a/Source/Common/Networking/State/ServerBootstrapState.cs
+++ b/Source/Common/Networking/State/ServerBootstrapState.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
 using Multiplayer.Common.Networking.Packet;
 using Multiplayer.Common.Util;
 
@@ -9,6 +11,9 @@ namespace Multiplayer.Common;
 public class ServerBootstrapState(ConnectionBase connection) : MpConnectionState(connection)
 {
     private static string? configuratorUsername;
+    private static string? pendingFileName;
+    private static int pendingLength;
+    private static byte[]? pendingZipBytes;
 
     public override void StartState()
     {
@@ -20,19 +25,26 @@ public class ServerBootstrapState(ConnectionBase connection) : MpConnectionState
 
         if (configuratorUsername != null && configuratorUsername != connection.username)
         {
-            connection.Send(new ServerBootstrapPacket(true, SettingsMissing()));
+            connection.Send(new ServerBootstrapPacket(true, SettingsMissing(), SaveMissing()));
             return;
         }
 
         configuratorUsername = connection.username;
-        connection.Send(new ServerBootstrapPacket(true, SettingsMissing()));
-        ServerLog.Log($"Bootstrap: configurator '{connection.username}' connected.");
+        connection.Send(new ServerBootstrapPacket(true, SettingsMissing(), SaveMissing()));
+
+        var savePath = Path.Combine(AppContext.BaseDirectory, "save.zip");
+        if (SettingsMissing())
+            ServerLog.Log($"Bootstrap: configurator '{connection.username}' connected. Waiting for settings.toml upload.");
+        else if (!File.Exists(savePath))
+            ServerLog.Log($"Bootstrap: configurator '{connection.username}' connected. Waiting for save.zip upload.");
+        else
+            ServerLog.Log($"Bootstrap: configurator '{connection.username}' connected. All files already exist.");
     }
 
     public override void OnDisconnect()
     {
         if (configuratorUsername == connection.username)
-            configuratorUsername = null;
+            ResetUploadState();
     }
 
     [TypedPacketHandler]
@@ -51,10 +63,103 @@ public class ServerBootstrapState(ConnectionBase connection) : MpConnectionState
 
         File.Move(tempPath, settingsPath);
         ServerLog.Log("Bootstrap: wrote settings.toml. Waiting for save upload.");
-        connection.Send(new ServerBootstrapPacket(true, false));
+        connection.Send(new ServerBootstrapPacket(true, false, true));
+    }
+
+    [TypedPacketHandler]
+    public void HandleSaveStart(ClientBootstrapSaveStartPacket packet)
+    {
+        if (!IsConfigurator())
+            return;
+
+        if (SettingsMissing())
+            throw new PacketReadException("Bootstrap requires settings.toml before save.zip upload");
+
+        if (packet.length <= 0)
+            throw new PacketReadException("Bootstrap upload has invalid length");
+
+        pendingFileName = packet.fileName;
+        pendingLength = packet.length;
+        pendingZipBytes = null;
+
+        ServerLog.Log($"Bootstrap: upload start '{pendingFileName}' ({pendingLength} bytes)");
+    }
+
+    [TypedPacketHandler]
+    public void HandleSaveData(ClientBootstrapSaveDataPacket packet)
+    {
+        if (!IsConfigurator())
+            return;
+
+        if (pendingZipBytes == null)
+        {
+            pendingZipBytes = packet.data;
+        }
+        else
+        {
+            var oldLength = pendingZipBytes.Length;
+            var combined = new byte[oldLength + packet.data.Length];
+            Buffer.BlockCopy(pendingZipBytes, 0, combined, 0, oldLength);
+            Buffer.BlockCopy(packet.data, 0, combined, oldLength, packet.data.Length);
+            pendingZipBytes = combined;
+        }
+    }
+
+    [TypedPacketHandler]
+    public void HandleSaveEnd(ClientBootstrapSaveEndPacket packet)
+    {
+        if (!IsConfigurator())
+            return;
+
+        if (SettingsMissing())
+            throw new PacketReadException("Bootstrap requires settings.toml before save.zip upload");
+
+        if (pendingZipBytes == null)
+            throw new PacketReadException("Bootstrap upload finish without data");
+
+        if (pendingLength > 0 && pendingZipBytes.Length != pendingLength)
+            ServerLog.Log($"Bootstrap: warning - expected {pendingLength} bytes but got {pendingZipBytes.Length}");
+
+        using var hasher = SHA256.Create();
+        var actualHash = hasher.ComputeHash(pendingZipBytes);
+        if (packet.sha256Hash != null && packet.sha256Hash.Length > 0 && !actualHash.SequenceEqual(packet.sha256Hash))
+            throw new PacketReadException($"Bootstrap upload hash mismatch. expected={packet.sha256Hash.ToHexString()} actual={actualHash.ToHexString()}");
+
+        var targetPath = Path.Combine(AppContext.BaseDirectory, "save.zip");
+        var tempPath = targetPath + ".tmp";
+        File.WriteAllBytes(tempPath, pendingZipBytes);
+        if (File.Exists(targetPath))
+            File.Delete(targetPath);
+        File.Move(tempPath, targetPath);
+
+        ServerLog.Log("Bootstrap: wrote save.zip. Configuration complete; stopping server.");
+
+        foreach (var player in Server.JoinedPlayers.ToList())
+            player.conn.Send(new ServerDisconnectPacket { reason = MpDisconnectReason.BootstrapCompleted, data = Array.Empty<byte>() });
+
+        ResetUploadState();
+        Server.running = false;
+        Server.TryStop();
+    }
+
+    [PacketHandler(Packets.Client_Cursor)]
+    public void HandleCursor(ByteReader data)
+    {
+        data.ReadByte();
+        data.ReadByte();
     }
 
     private static bool SettingsMissing() => !File.Exists(Path.Combine(AppContext.BaseDirectory, "settings.toml"));
 
+    private static bool SaveMissing() => !File.Exists(Path.Combine(AppContext.BaseDirectory, "save.zip"));
+
     private bool IsConfigurator() => configuratorUsername == connection.username;
+
+    private static void ResetUploadState()
+    {
+        configuratorUsername = null;
+        pendingFileName = null;
+        pendingLength = 0;
+        pendingZipBytes = null;
+    }
 }

--- a/Source/Common/Networking/State/ServerBootstrapState.cs
+++ b/Source/Common/Networking/State/ServerBootstrapState.cs
@@ -1,10 +1,15 @@
+using System;
+using System.IO;
 using Multiplayer.Common.Networking.Packet;
+using Multiplayer.Common.Util;
 
 namespace Multiplayer.Common;
 
 [PacketHandlerClass]
 public class ServerBootstrapState(ConnectionBase connection) : MpConnectionState(connection)
 {
+    private static string? configuratorUsername;
+
     public override void StartState()
     {
         if (!Server.BootstrapMode)
@@ -13,6 +18,43 @@ public class ServerBootstrapState(ConnectionBase connection) : MpConnectionState
             return;
         }
 
-        connection.Send(new ServerBootstrapPacket(true));
+        if (configuratorUsername != null && configuratorUsername != connection.username)
+        {
+            connection.Send(new ServerBootstrapPacket(true, SettingsMissing()));
+            return;
+        }
+
+        configuratorUsername = connection.username;
+        connection.Send(new ServerBootstrapPacket(true, SettingsMissing()));
+        ServerLog.Log($"Bootstrap: configurator '{connection.username}' connected.");
     }
+
+    public override void OnDisconnect()
+    {
+        if (configuratorUsername == connection.username)
+            configuratorUsername = null;
+    }
+
+    [TypedPacketHandler]
+    public void HandleSettings(ClientBootstrapSettingsPacket packet)
+    {
+        if (!IsConfigurator())
+            return;
+
+        var settingsPath = Path.Combine(AppContext.BaseDirectory, "settings.toml");
+        var tempPath = settingsPath + ".tmp";
+
+        TomlSettingsCommon.Save(packet.settings, tempPath);
+
+        if (File.Exists(settingsPath))
+            File.Delete(settingsPath);
+
+        File.Move(tempPath, settingsPath);
+        ServerLog.Log("Bootstrap: wrote settings.toml. Waiting for save upload.");
+        connection.Send(new ServerBootstrapPacket(true, false));
+    }
+
+    private static bool SettingsMissing() => !File.Exists(Path.Combine(AppContext.BaseDirectory, "settings.toml"));
+
+    private bool IsConfigurator() => configuratorUsername == connection.username;
 }

--- a/Source/Common/Networking/State/ServerBootstrapState.cs
+++ b/Source/Common/Networking/State/ServerBootstrapState.cs
@@ -1,0 +1,18 @@
+using Multiplayer.Common.Networking.Packet;
+
+namespace Multiplayer.Common;
+
+[PacketHandlerClass]
+public class ServerBootstrapState(ConnectionBase connection) : MpConnectionState(connection)
+{
+    public override void StartState()
+    {
+        if (!Server.BootstrapMode)
+        {
+            connection.ChangeState(ConnectionStateEnum.ServerJoining);
+            return;
+        }
+
+        connection.Send(new ServerBootstrapPacket(true));
+    }
+}

--- a/Source/Common/Networking/State/ServerJoiningState.cs
+++ b/Source/Common/Networking/State/ServerJoiningState.cs
@@ -50,7 +50,8 @@ public class ServerJoiningState : AsyncConnectionState
             if (Server.BootstrapMode)
             {
                 var settingsMissing = !File.Exists(Path.Combine(AppContext.BaseDirectory, "settings.toml"));
-                connection.Send(new ServerBootstrapPacket(true, settingsMissing));
+                var saveMissing = !File.Exists(Path.Combine(AppContext.BaseDirectory, "save.zip"));
+                connection.Send(new ServerBootstrapPacket(true, settingsMissing, saveMissing));
             }
         }
     }

--- a/Source/Common/Networking/State/ServerJoiningState.cs
+++ b/Source/Common/Networking/State/ServerJoiningState.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Multiplayer.Common.Networking.Packet;
 
@@ -43,7 +44,15 @@ public class ServerJoiningState : AsyncConnectionState
         if (packet.protocolVersion != MpVersion.Protocol)
             Player.Disconnect(MpDisconnectReason.Protocol, ByteWriter.GetBytes(MpVersion.Version, MpVersion.Protocol));
         else
+        {
             Player.SendPacket(new ServerProtocolOkPacket(Server.settings.hasPassword));
+
+            if (Server.BootstrapMode)
+            {
+                var settingsMissing = !File.Exists(Path.Combine(AppContext.BaseDirectory, "settings.toml"));
+                connection.Send(new ServerBootstrapPacket(true, settingsMissing));
+            }
+        }
     }
 
     private void HandleUsername(ClientUsernamePacket packet)
@@ -143,6 +152,13 @@ public class ServerJoiningState : AsyncConnectionState
             defStatus = defStatus,
             rawServerInitData = serverInitData.RawData
         }.Serialize());
+
+        if (Server.BootstrapMode)
+        {
+            connection.ChangeState(ConnectionStateEnum.ServerBootstrap);
+            return defsMatch;
+        }
+
         return defsMatch;
     }
 }

--- a/Source/Common/PlayerManager.cs
+++ b/Source/Common/PlayerManager.cs
@@ -30,7 +30,7 @@ namespace Multiplayer.Common
         // id can be an IPAddress or CSteamID
         public MpDisconnectReason? OnPreConnect(object id)
         {
-            if (server.FullyStarted is false)
+            if (server.FullyStarted is false && !server.BootstrapMode)
                 return MpDisconnectReason.ServerStarting;
 
             if (id is IPAddress addr && IPAddress.IsLoopback(addr))

--- a/Source/Common/ServerSettings.cs
+++ b/Source/Common/ServerSettings.cs
@@ -6,8 +6,8 @@ namespace Multiplayer.Common
 {
     public class ServerSettings
     {
-        public string gameName;
-        public string lanAddress;
+        public string gameName = "Multiplayer Server";
+        public string lanAddress = "127.0.0.1";
 
         public string directAddress = $"0.0.0.0:{MultiplayerServer.DefaultPort}";
         public int maxPlayers = 8;
@@ -50,6 +50,8 @@ namespace Multiplayer.Common
         {
             // Remember to mirror the default values
 
+            ScribeLike.Look(ref gameName!, "gameName", "Multiplayer Server");
+            ScribeLike.Look(ref lanAddress!, "lanAddress", "127.0.0.1");
             ScribeLike.Look(ref directAddress!, "directAddress", $"0.0.0.0:{MultiplayerServer.DefaultPort}");
             ScribeLike.Look(ref maxPlayers, "maxPlayers", 8);
             ScribeLike.Look(ref autosaveInterval, "autosaveInterval", 1f);

--- a/Source/Common/Util/TomlSettingsCommon.cs
+++ b/Source/Common/Util/TomlSettingsCommon.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace Multiplayer.Common.Util
+{
+    public static class TomlSettingsCommon
+    {
+        public static string Serialize(ServerSettings settings)
+        {
+            var scribe = new SimpleTomlScribe { mode = SimpleTomlMode.Saving };
+            ScribeLike.provider = scribe;
+
+            settings.ExposeData();
+
+            return scribe.ToToml();
+        }
+
+        public static void Save(ServerSettings settings, string filename)
+        {
+            File.WriteAllText(filename, Serialize(settings));
+        }
+    }
+
+    internal enum SimpleTomlMode
+    {
+        Loading,
+        Saving
+    }
+
+    internal class SimpleTomlScribe : ScribeLike.Provider
+    {
+        private readonly Dictionary<string, string> data = new();
+        private readonly List<KeyValuePair<string, string>> entries = new();
+        public SimpleTomlMode mode;
+
+        public override void Look<T>(ref T value, string label, T defaultValue, bool forceSave)
+        {
+            if (mode == SimpleTomlMode.Loading)
+            {
+                if (data.TryGetValue(label, out var raw))
+                    value = ParseValue<T>(raw);
+                else
+                    value = defaultValue;
+            }
+            else
+            {
+                entries.Add(new KeyValuePair<string, string>(label, FormatValue(value)));
+            }
+        }
+
+        private static T ParseValue<T>(string raw)
+        {
+            var type = typeof(T);
+
+            if (type == typeof(string))
+                return (T)(object)Unquote(raw);
+
+            if (type == typeof(bool))
+                return (T)(object)raw.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+            if (type == typeof(int))
+                return (T)(object)int.Parse(raw, CultureInfo.InvariantCulture);
+
+            if (type == typeof(float))
+                return (T)(object)float.Parse(raw, CultureInfo.InvariantCulture);
+
+            if (type.IsEnum)
+                return (T)Enum.Parse(type, Unquote(raw));
+
+            return (T)Convert.ChangeType(raw, type, CultureInfo.InvariantCulture);
+        }
+
+        private static string Unquote(string value)
+        {
+            if (value.Length >= 2 && value.StartsWith("\"") && value.EndsWith("\""))
+            {
+                value = value.Substring(1, value.Length - 2);
+                value = value.Replace("\\\"", "\"").Replace("\\\\", "\\");
+            }
+
+            return value;
+        }
+
+        private static string FormatValue<T>(T value)
+        {
+            if (value == null) return "\"\"";
+            if (value is bool boolean) return boolean ? "true" : "false";
+            if (value is int integer) return integer.ToString(CultureInfo.InvariantCulture);
+            if (value is float single) return single.ToString(CultureInfo.InvariantCulture);
+            if (typeof(T).IsEnum) return Quote(value.ToString()!);
+            if (value is string str) return Quote(str);
+            return Quote(value.ToString()!);
+        }
+
+        private static string Quote(string value) =>
+            "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+
+        public string ToToml()
+        {
+            var sb = new StringBuilder();
+            for (var i = 0; i < entries.Count; i++)
+                sb.AppendLine(entries[i].Key + " = " + entries[i].Value);
+            return sb.ToString();
+        }
+    }
+}

--- a/Source/Server/BootstrapMode.cs
+++ b/Source/Server/BootstrapMode.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using Multiplayer.Common;
+
+namespace Server;
+
+public static class BootstrapMode
+{
+    public static void WaitForClient(MultiplayerServer server, CancellationToken token)
+    {
+        ServerLog.Log("Bootstrap: waiting for first client connection...");
+
+        while (server.running && !token.IsCancellationRequested)
+            Thread.Sleep(250);
+    }
+}

--- a/Source/Server/Server.cs
+++ b/Source/Server/Server.cs
@@ -5,6 +5,7 @@ using Multiplayer.Common.Util;
 using Server;
 
 ServerLog.detailEnabled = true;
+Directory.SetCurrentDirectory(AppContext.BaseDirectory);
 
 const string settingsFile = "settings.toml";
 const string stopCmd = "stop";
@@ -16,10 +17,12 @@ var settings = new ServerSettings
     lan = false
 };
 
-if (File.Exists(settingsFile))
+var bootstrap = !File.Exists(settingsFile);
+
+if (!bootstrap)
     settings = TomlSettings.Load(settingsFile);
 else
-    TomlSettings.Save(settings, settingsFile); // Save default settings
+    ServerLog.Log($"Bootstrap mode: '{settingsFile}' not found. Waiting for a client to upload it.");
 
 if (settings.steam) ServerLog.Error("Steam is not supported in standalone server.");
 if (settings.arbiter) ServerLog.Error("Arbiter is not supported in standalone server.");
@@ -31,7 +34,18 @@ var server = MultiplayerServer.instance = new MultiplayerServer(settings)
 
 var consoleSource = new ConsoleSource();
 
-LoadSave(server, saveFile);
+if (!bootstrap && File.Exists(saveFile))
+{
+    LoadSave(server, saveFile);
+}
+else
+{
+    bootstrap = true;
+    ServerLog.Log($"Bootstrap mode: '{saveFile}' not found. Server will start without a loaded save.");
+    ServerLog.Log("Waiting for a client to upload world data.");
+}
+
+server.BootstrapMode = bootstrap;
 
 if (settings.direct) {
     var badEndpoint = settings.TryParseEndpoints(out var endpoints);
@@ -67,6 +81,12 @@ if (settings.lan)
 }
 
 new Thread(server.Run) { Name = "Server thread" }.Start();
+
+if (bootstrap)
+    BootstrapMode.WaitForClient(server, CancellationToken.None);
+
+if (bootstrap && !server.running)
+    return;
 
 while (true)
 {

--- a/Source/Tests/BootstrapSettingsTest.cs
+++ b/Source/Tests/BootstrapSettingsTest.cs
@@ -1,0 +1,24 @@
+using Multiplayer.Common;
+using Multiplayer.Common.Util;
+
+namespace Tests;
+
+public class BootstrapSettingsTest
+{
+    [Test]
+    public void SharedTomlSerializerIncludesJoinCriticalFields()
+    {
+        var settings = new ServerSettings
+        {
+            gameName = "Bootstrap Test",
+            lanAddress = "192.168.1.15",
+            direct = true,
+            lan = true,
+        };
+
+        var toml = TomlSettingsCommon.Serialize(settings);
+
+        Assert.That(toml, Does.Contain("gameName = \"Bootstrap Test\""));
+        Assert.That(toml, Does.Contain("lanAddress = \"192.168.1.15\""));
+    }
+}


### PR DESCRIPTION
## Summary
This adds a standalone server bootstrap flow for fresh dedicated server setups.

- Start the standalone server in bootstrap mode when settings.toml and/or save.zip are missing.
- - Let the first client configure and upload server settings.
- - Let the same client generate a temporary game, create the initial save, reconnect, and upload save.zip.
- - Keep the existing join flow intact outside bootstrap mode.
- - Clean up bootstrap reconnect/UI state handling and fix the final shutdown path after save upload.
## Notes
- The bootstrap flow was adapted from the existing working bootstrap implementation, then adjusted to the current dev branch architecture.
- - Server-driven bootstrap state is used for the real server/bootstrap file state, while transient generation UI flow stays client-side.
- - The implementation stays isolated as much as possible to bootstrap-specific files and state transitions.
## Testing
- dotnet build Source/Server/Server.csproj
- - dotnet build Source/Client/Multiplayer.csproj
- - dotnet build Source/Multiplayer.sln
- - dotnet test Source/Tests/Tests.csproj
- - Manual end-to-end validation:
-   - start Server.exe without settings.toml and save.zip
-   - connect from the client and configure/upload settings.toml
-   - generate the initial game and upload save.zip
-   - verify reconnect/bootstrap UI behavior
-   - verify the server writes the files and shuts down cleanly after bootstrap completion.

After that the server have to be started and will work.