### PR TITLE
Add mod compatibility database caching

### DIFF
--- a/Source/Client/ModCompatibilityManager.cs
+++ b/Source/Client/ModCompatibilityManager.cs
@@ -32,7 +32,7 @@ namespace Multiplayer.Client
         {
             public string? CachedDate { get; set; }
             public string? CachedETag { get; set; }
-            public List<ModCompatibility> Mods { get; set; }
+            public List<ModCompatibility>? Mods { get; set; }
         }
 
         private static async Task<CacheRoot?> TryLoadCachedDb()
@@ -63,9 +63,20 @@ namespace Multiplayer.Client
         }
 
         [DebugAction(category = "Multiplayer", allowedGameStates = AllowedGameStates.Entry)]
-        private static void ClearModCompatCache() => File.Delete(CacheFilePath);
+        private static void ClearCompatCacheFile() => File.Delete(CacheFilePath);
+        [DebugAction(category = "Multiplayer", allowedGameStates = AllowedGameStates.Entry)]
+        private static void ClearLoadedCompatData() {
+            workshopLookup.Clear();
+            nameLookup.Clear();
+            fetchSuccess = null;
+        }
+
         [DebugAction(category = "Multiplayer", allowedGameStates = AllowedGameStates.Entry)]
         private static void UpdateModCompatCache() => Task.Run(UpdateModCompatibilityDb);
+
+        // Requires clearing loaded compat data to work (because of the static constructor which runs before it's
+        // possible to switch this value).
+        [TweakValue(category: "Multiplayer")] private static bool simulateOffline = false;
 
         private static async Task UpdateModCompatibilityDb()
         {
@@ -74,6 +85,14 @@ namespace Multiplayer.Client
             try
             {
                 var cached = await TryLoadCachedDb();
+                if (cached?.Mods != null)
+                {
+                    ServerLog.Log("MP: displaying cached mod compat while updating...");
+                    SetupFrom(cached.Mods);
+                }
+
+                if (simulateOffline) throw new Exception("Simulating offline state");
+
                 var req = new RestRequest("mod-compatibility?version=1.1&format=metadata")
                 {
                     RequestFormat = DataFormat.Json
@@ -82,7 +101,6 @@ namespace Multiplayer.Client
                 {
                     req.AddHeader("If-Modified-Since", date);
                 }
-
                 if (cached?.CachedETag is { } etag)
                 {
                     req.AddHeader("If-None-Match", etag);
@@ -91,10 +109,10 @@ namespace Multiplayer.Client
                 var stopwatch = Stopwatch.StartNew();
                 var resp = client.Get(req);
                 if (resp.ErrorException != null) throw resp.ErrorException;
-                List<ModCompatibility> modCompatibilities;
+                List<ModCompatibility>? modCompatibilities;
                 if (resp.StatusCode == HttpStatusCode.NotModified)
                 {
-                    modCompatibilities = cached!.Mods;
+                    modCompatibilities = cached!.Mods!;
                 }
                 else
                 {
@@ -118,26 +136,29 @@ namespace Multiplayer.Client
                     _ = Task.Run(async () => await TrySaveCachedDb(cacheRoot));
                 }
 
-                var elapsed = stopwatch.Elapsed;
-                Log.Message(
-                    $"MP: successfully fetched {modCompatibilities.Count} mods compatibility info in {elapsed}");
+                Log.Message($"MP: successfully fetched {modCompatibilities.Count} mods compatibility info " +
+                            $"in {stopwatch.Elapsed}");
 
-                workshopLookup = modCompatibilities
-                    .Where(mod => mod.workshopId != 0)
-                    .GroupBy(mod => mod.workshopId)
-                    .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
-
-                nameLookup = modCompatibilities
-                    .GroupBy(mod => mod.name.ToLower())
-                    .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
-
+                SetupFrom(modCompatibilities);
                 fetchSuccess = true;
             }
             catch (Exception e)
             {
-                Log.Warning($"MP: updating mod compatibility list failed {e.Message} {e.StackTrace}");
+                Log.Warning($"MP: updating mod compatibility list failed:\n{e}");
                 fetchSuccess = false;
             }
+        }
+
+        private static void SetupFrom(List<ModCompatibility> mods)
+        {
+            workshopLookup = mods
+                .Where(mod => mod.workshopId != 0)
+                .GroupBy(mod => mod.workshopId)
+                .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
+
+            nameLookup = mods
+                .GroupBy(mod => mod.name.ToLower())
+                .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
         }
 
         public static ModCompatibility LookupByWorkshopId(PublishedFileId_t workshopId) {

--- a/Source/Client/ModCompatibilityManager.cs
+++ b/Source/Client/ModCompatibilityManager.cs
@@ -16,7 +16,11 @@ namespace Multiplayer.Client
 {
     public static class ModCompatibilityManager
     {
-        private static bool startedLazyFetch;
+        static ModCompatibilityManager()
+        {
+            Task.Run(UpdateModCompatibilityDb);
+        }
+
         public static bool? fetchSuccess;
 
         private static Dictionary<long, ModCompatibility> workshopLookup = new();
@@ -60,76 +64,80 @@ namespace Multiplayer.Client
 
         [DebugAction(category = "Multiplayer", allowedGameStates = AllowedGameStates.Entry)]
         private static void ClearModCompatCache() => File.Delete(CacheFilePath);
-
         [DebugAction(category = "Multiplayer", allowedGameStates = AllowedGameStates.Entry)]
-        private static void UpdateModCompatibilityDb() {
-            startedLazyFetch = true;
+        private static void UpdateModCompatCache() => Task.Run(UpdateModCompatibilityDb);
 
-            Task.Run(async () =>
+        private static async Task UpdateModCompatibilityDb()
+        {
+            var client = new RestClient("https://bot.rimworldmultiplayer.com/");
+            client.AddDefaultHeader("X-Multiplayer-Version", MpVersion.Version);
+            try
             {
-                var client = new RestClient("https://bot.rimworldmultiplayer.com/");
-                client.AddDefaultHeader("X-Multiplayer-Version", MpVersion.Version);
-                try {
-                    var cached = await TryLoadCachedDb();
-                    var req = new RestRequest("mod-compatibility?version=1.1&format=metadata")
+                var cached = await TryLoadCachedDb();
+                var req = new RestRequest("mod-compatibility?version=1.1&format=metadata")
+                {
+                    RequestFormat = DataFormat.Json
+                };
+                if (cached?.CachedDate is { } date)
+                {
+                    req.AddHeader("If-Modified-Since", date);
+                }
+
+                if (cached?.CachedETag is { } etag)
+                {
+                    req.AddHeader("If-None-Match", etag);
+                }
+
+                var stopwatch = Stopwatch.StartNew();
+                var resp = client.Get(req);
+                if (resp.ErrorException != null) throw resp.ErrorException;
+                List<ModCompatibility> modCompatibilities;
+                if (resp.StatusCode == HttpStatusCode.NotModified)
+                {
+                    modCompatibilities = cached!.Mods;
+                }
+                else
+                {
+                    if (resp.StatusCode != HttpStatusCode.OK)
                     {
-                        RequestFormat = DataFormat.Json
+                        Log.Warning(
+                            $"MP: received unexpected status code {resp.StatusCode} when fetching mod compatibility. Headers: {resp.Headers}");
+                    }
+
+                    modCompatibilities = SimpleJson.DeserializeObject<List<ModCompatibility>>(resp.Content);
+                    var cacheRoot = new CacheRoot
+                    {
+                        CachedDate = resp.Headers
+                            .FirstOrDefault(header => header.Name.EqualsIgnoreCase("Last-Modified"))
+                            ?.Value?.ToString(),
+                        CachedETag = resp.Headers
+                            .FirstOrDefault(header => header.Name.EqualsIgnoreCase("ETag"))
+                            ?.Value?.ToString(),
+                        Mods = modCompatibilities
                     };
-                    if (cached?.CachedDate is { } date)
-                    {
-                        req.AddHeader("If-Modified-Since", date);
-                    }
-                    if (cached?.CachedETag is { } etag)
-                    {
-                        req.AddHeader("If-None-Match", etag);
-                    }
-
-                    var stopwatch = Stopwatch.StartNew();
-                    var resp = client.Get(req);
-                    if (resp.ErrorException != null) throw resp.ErrorException;
-                    List<ModCompatibility> modCompatibilities;
-                    if (resp.StatusCode == HttpStatusCode.NotModified)
-                    {
-                        modCompatibilities = cached!.Mods;
-                    }
-                    else
-                    {
-                        if (resp.StatusCode != HttpStatusCode.OK)
-                        {
-                            Log.Warning($"MP: received unexpected status code {resp.StatusCode} when fetching mod compatibility. Headers: {resp.Headers}");
-                        }
-                        modCompatibilities = SimpleJson.DeserializeObject<List<ModCompatibility>>(resp.Content);
-                        var cacheRoot = new CacheRoot
-                        {
-                            CachedDate = resp.Headers
-                                .FirstOrDefault(header => header.Name.EqualsIgnoreCase("Last-Modified"))
-                                ?.Value?.ToString(),
-                            CachedETag = resp.Headers
-                                .FirstOrDefault(header => header.Name.EqualsIgnoreCase("ETag"))
-                                ?.Value?.ToString(),
-                            Mods = modCompatibilities
-                        };
-                        _ = Task.Run(async () => await TrySaveCachedDb(cacheRoot));
-                    }
-                    var elapsed = stopwatch.Elapsed;
-                    Log.Message($"MP: successfully fetched {modCompatibilities.Count} mods compatibility info in {elapsed}");
-
-                    workshopLookup = modCompatibilities
-                        .Where(mod => mod.workshopId != 0)
-                        .GroupBy(mod => mod.workshopId)
-                        .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
-
-                    nameLookup = modCompatibilities
-                        .GroupBy(mod => mod.name.ToLower())
-                        .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
-
-                    fetchSuccess = true;
+                    _ = Task.Run(async () => await TrySaveCachedDb(cacheRoot));
                 }
-                catch (Exception e) {
-                    Log.Warning($"MP: updating mod compatibility list failed {e.Message} {e.StackTrace}");
-                    fetchSuccess = false;
-                }
-            });
+
+                var elapsed = stopwatch.Elapsed;
+                Log.Message(
+                    $"MP: successfully fetched {modCompatibilities.Count} mods compatibility info in {elapsed}");
+
+                workshopLookup = modCompatibilities
+                    .Where(mod => mod.workshopId != 0)
+                    .GroupBy(mod => mod.workshopId)
+                    .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
+
+                nameLookup = modCompatibilities
+                    .GroupBy(mod => mod.name.ToLower())
+                    .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
+
+                fetchSuccess = true;
+            }
+            catch (Exception e)
+            {
+                Log.Warning($"MP: updating mod compatibility list failed {e.Message} {e.StackTrace}");
+                fetchSuccess = false;
+            }
         }
 
         public static ModCompatibility LookupByWorkshopId(PublishedFileId_t workshopId) {
@@ -137,18 +145,10 @@ namespace Multiplayer.Client
         }
 
         public static ModCompatibility LookupByWorkshopId(ulong workshopId) {
-            if (!startedLazyFetch) {
-                UpdateModCompatibilityDb();
-            }
-
             return workshopLookup.TryGetValue((long) workshopId);
         }
 
         public static ModCompatibility LookupByName(string name) {
-            if (!startedLazyFetch) {
-                UpdateModCompatibilityDb();
-            }
-
             return nameLookup.TryGetValue(name.ToLower());
         }
     }

--- a/Source/Client/ModCompatibilityManager.cs
+++ b/Source/Client/ModCompatibilityManager.cs
@@ -24,7 +24,7 @@ namespace Multiplayer.Client
         public static bool? fetchSuccess;
 
         private static Dictionary<long, ModCompatibility> workshopLookup = new();
-        public static Dictionary<string, ModCompatibility> nameLookup = new();
+        private static Dictionary<string, ModCompatibility> nameLookup = new();
 
         private const string CacheFileName = "compat.json";
         private static readonly string CacheFilePath = Path.Combine(Multiplayer.CacheDir, CacheFileName);
@@ -113,13 +113,15 @@ namespace Multiplayer.Client
                 if (resp.StatusCode == HttpStatusCode.NotModified)
                 {
                     modCompatibilities = cached!.Mods!;
+                    Log.Message($"MP: successfully validated {modCompatibilities.Count} mods compatibility info " +
+                                $"in {stopwatch.Elapsed}");
                 }
                 else
                 {
                     if (resp.StatusCode != HttpStatusCode.OK)
                     {
                         Log.Warning(
-                            $"MP: received unexpected status code {resp.StatusCode} when fetching mod compatibility. Headers: {resp.Headers}");
+                            $"MP: received unexpected status code {resp.StatusCode} when fetching mod compatibility. Headers: {resp.Headers.Join(", ")}");
                     }
 
                     modCompatibilities = SimpleJson.DeserializeObject<List<ModCompatibility>>(resp.Content);
@@ -134,10 +136,9 @@ namespace Multiplayer.Client
                         Mods = modCompatibilities
                     };
                     _ = Task.Run(async () => await TrySaveCachedDb(cacheRoot));
+                    Log.Message($"MP: successfully fetched {modCompatibilities.Count} mods compatibility info " +
+                                $"in {stopwatch.Elapsed}");
                 }
-
-                Log.Message($"MP: successfully fetched {modCompatibilities.Count} mods compatibility info " +
-                            $"in {stopwatch.Elapsed}");
 
                 SetupFrom(modCompatibilities);
                 fetchSuccess = true;
@@ -161,16 +162,19 @@ namespace Multiplayer.Client
                 .ToDictionary(grouping => grouping.Key, grouping => grouping.First());
         }
 
-        public static ModCompatibility LookupByWorkshopId(PublishedFileId_t workshopId) {
-            return LookupByWorkshopId(workshopId.m_PublishedFileId);
+        public static ModCompatibility? LookupByWorkshopId(PublishedFileId_t workshopId) =>
+            LookupByWorkshopId(workshopId.m_PublishedFileId);
+
+        public static ModCompatibility? LookupByWorkshopId(ulong workshopId)
+        {
+            workshopLookup.TryGetValue((long)workshopId, out var compat);
+            return compat;
         }
 
-        public static ModCompatibility LookupByWorkshopId(ulong workshopId) {
-            return workshopLookup.TryGetValue((long) workshopId);
-        }
-
-        public static ModCompatibility LookupByName(string name) {
-            return nameLookup.TryGetValue(name.ToLower());
+        public static ModCompatibility? LookupByName(string name)
+        {
+            nameLookup.TryGetValue(name.ToLower(), out var compat);
+            return compat;
         }
     }
 

--- a/Source/Client/ModCompatibilityManager.cs
+++ b/Source/Client/ModCompatibilityManager.cs
@@ -1,7 +1,13 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
+using LudeonTK;
+using Multiplayer.Common;
 using RestSharp;
 using Steamworks;
 using Verse;
@@ -16,19 +22,97 @@ namespace Multiplayer.Client
         private static Dictionary<long, ModCompatibility> workshopLookup = new();
         public static Dictionary<string, ModCompatibility> nameLookup = new();
 
+        private const string CacheFileName = "compat.json";
+        private static readonly string CacheFilePath = Path.Combine(Multiplayer.CacheDir, CacheFileName);
+        private class CacheRoot
+        {
+            public string? CachedDate { get; set; }
+            public string? CachedETag { get; set; }
+            public List<ModCompatibility> Mods { get; set; }
+        }
+
+        private static async Task<CacheRoot?> TryLoadCachedDb()
+        {
+            if (!File.Exists(CacheFilePath)) return null;
+            var data = await File.ReadAllTextAsync(CacheFilePath);
+            try
+            {
+                return SimpleJson.DeserializeObject<CacheRoot>(data);
+            }
+            catch (Exception e)
+            {
+                Log.Warning($"MP: Failed to deserialize {CacheFileName}:\n{e}");
+                return null;
+            }
+        }
+        private static async Task TrySaveCachedDb(CacheRoot cache)
+        {
+            try
+            {
+                var data = SimpleJson.SerializeObject(cache);
+                await File.WriteAllTextAsync(CacheFilePath, data);
+            }
+            catch (Exception e)
+            {
+                Log.Warning($"MP: Failed to save cache {CacheFileName}:\n{e}");
+            }
+        }
+
+        [DebugAction(category = "Multiplayer", allowedGameStates = AllowedGameStates.Entry)]
+        private static void ClearModCompatCache() => File.Delete(CacheFilePath);
+
+        [DebugAction(category = "Multiplayer", allowedGameStates = AllowedGameStates.Entry)]
         private static void UpdateModCompatibilityDb() {
             startedLazyFetch = true;
 
-            Task.Run(() => {
+            Task.Run(async () =>
+            {
                 var client = new RestClient("https://bot.rimworldmultiplayer.com/");
+                client.AddDefaultHeader("X-Multiplayer-Version", MpVersion.Version);
                 try {
+                    var cached = await TryLoadCachedDb();
                     var req = new RestRequest("mod-compatibility?version=1.1&format=metadata")
                     {
                         RequestFormat = DataFormat.Json
                     };
-                    var response = client.Get<List<ModCompatibility>>(req);
-                    var modCompatibilities = response.Data;
-                    Log.Message($"MP: successfully fetched {modCompatibilities.Count} mods compatibility info");
+                    if (cached?.CachedDate is { } date)
+                    {
+                        req.AddHeader("If-Modified-Since", date);
+                    }
+                    if (cached?.CachedETag is { } etag)
+                    {
+                        req.AddHeader("If-None-Match", etag);
+                    }
+
+                    var stopwatch = Stopwatch.StartNew();
+                    var resp = client.Get(req);
+                    if (resp.ErrorException != null) throw resp.ErrorException;
+                    List<ModCompatibility> modCompatibilities;
+                    if (resp.StatusCode == HttpStatusCode.NotModified)
+                    {
+                        modCompatibilities = cached!.Mods;
+                    }
+                    else
+                    {
+                        if (resp.StatusCode != HttpStatusCode.OK)
+                        {
+                            Log.Warning($"MP: received unexpected status code {resp.StatusCode} when fetching mod compatibility. Headers: {resp.Headers}");
+                        }
+                        modCompatibilities = SimpleJson.DeserializeObject<List<ModCompatibility>>(resp.Content);
+                        var cacheRoot = new CacheRoot
+                        {
+                            CachedDate = resp.Headers
+                                .FirstOrDefault(header => header.Name.EqualsIgnoreCase("Last-Modified"))
+                                ?.Value?.ToString(),
+                            CachedETag = resp.Headers
+                                .FirstOrDefault(header => header.Name.EqualsIgnoreCase("ETag"))
+                                ?.Value?.ToString(),
+                            Mods = modCompatibilities
+                        };
+                        _ = Task.Run(async () => await TrySaveCachedDb(cacheRoot));
+                    }
+                    var elapsed = stopwatch.Elapsed;
+                    Log.Message($"MP: successfully fetched {modCompatibilities.Count} mods compatibility info in {elapsed}");
 
                     workshopLookup = modCompatibilities
                         .Where(mod => mod.workshopId != 0)

--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -75,6 +75,7 @@ namespace Multiplayer.Client
         public static string ReplaysDir => GenFilePaths.FolderUnderSaveData("MpReplays");
         public static string DesyncsDir => GenFilePaths.FolderUnderSaveData("MpDesyncs");
         public static string LogsDir => GenFilePaths.FolderUnderSaveData("MpLogs");
+        public static string CacheDir => GenFilePaths.FolderUnderSaveData("MpCache");
 
         public static Stopwatch clock = Stopwatch.StartNew();
 


### PR DESCRIPTION
Introduces caching for the mod compat data. The current HTTP API server doesn't send `Last-Modified` or `ETag` headers, however this PR has support for it, if the server were to send those headers at some point. 

In case the API is unavailable (and when waiting for the server's response) the cached data is shown (if any is present).

The cache file is ~0.5MB which is small enough not to be an issue. If it ever became too big, we can implement on-disk compression to reduce the size.

The UI could probably be slightly improved to show a different message depending on the state: `Loading...`, or `Updating...` (cache present), but not sure if it's worth the effort for such a minor improvement.

Mostly supersedes https://github.com/rwmt/Multiplayer/pull/831 (except in the rare case when someone turns MP on for the first time, and the API is dead at the same time)