### PR TITLE
Fix Unnatural Corpse desync

### DIFF
--- a/Source/Client/Patches/Anomaly.cs
+++ b/Source/Client/Patches/Anomaly.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace Multiplayer.Client.Patches
+{
+    [HarmonyPatch(typeof(AnomalyUtility), nameof(AnomalyUtility.TryGetNearbyUnseenCell))]
+    static class AnomalyUtility_TryGetNearbyUnseenCell
+    {
+        // Discards the result from CurrentViewRect and calls EmptyCellRect
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
+        {
+            var target = AccessTools.PropertyGetter(typeof(CameraDriver), nameof(CameraDriver.CurrentViewRect));
+            var replace = AccessTools.Method(typeof(AnomalyUtility_TryGetNearbyUnseenCell), nameof(EmptyCellRect));
+
+            foreach (var inst in insts)
+            {
+                yield return inst;
+
+                if (inst.operand as MethodInfo == target)
+                {
+                    yield return new CodeInstruction(OpCodes.Pop);
+                    yield return new CodeInstruction(OpCodes.Call, replace);
+                }
+            }
+        }
+
+        static CellRect EmptyCellRect()
+        {
+            return Multiplayer.Client != null ? CellRect.Empty : Find.CameraDriver.CurrentViewRect;
+        }
+
+        static void Prefix() => Rand.PushState(Find.TickManager.TicksAbs);
+        static void Postfix() => Rand.PopState();
+    }
+}


### PR DESCRIPTION
UnnaturalCorpse and UnnaturalCorpseTracker call TryGetNearbyUnseenCell to find an area to move the corpse depending if the camera has view of the cells or not. This patch sets the view to empty whenever Multiplayer is running. There's also a random call that needs to be seeded.