### PR TITLE
Abort join point creation when host disconnects

### DIFF
--- a/Source/Common/PlayerManager.cs
+++ b/Source/Common/PlayerManager.cs
@@ -71,6 +71,12 @@ namespace Multiplayer.Common
             ServerPlayer player = conn.serverPlayer;
             Players.Remove(player);
 
+            if (player.IsHost && server.worldData.CreatingJoinPoint)
+            {
+                server.worldData.AbortJoinPointCreation();
+                ServerLog.Log("Aborted join point creation because the host disconnected.");
+            }
+
             if (player.hasJoined)
             {
                 // Send PlayerCount command to remove the player from their last known map

--- a/Source/Common/WorldData.cs
+++ b/Source/Common/WorldData.cs
@@ -52,6 +52,17 @@ public class WorldData
         tmpMapCmds = null;
         lastJoinPointAtWorkTicks = Server.workTicks;
         dataSource!.SetResult(this);
+        dataSource = null;
+    }
+
+    public void AbortJoinPointCreation()
+    {
+        if (!CreatingJoinPoint)
+            return;
+
+        tmpMapCmds = null;
+        dataSource?.SetResult(this);
+        dataSource = null;
     }
 
     public Task<WorldData> WaitJoinPoint()

--- a/Source/Tests/ServerTest.cs
+++ b/Source/Tests/ServerTest.cs
@@ -45,6 +45,31 @@ public class ServerTest
         }
     }
 
+    [Test]
+    public async Task JoinPointAbortUnblocksWaiters()
+    {
+        var server = new MultiplayerServer(new ServerSettings
+        {
+            gameName = "Test",
+            direct = false,
+            lan = false
+        });
+
+        Assert.That(server.worldData.TryStartJoinPointCreation(true), Is.True);
+        Assert.That(server.worldData.CreatingJoinPoint, Is.True);
+
+        var waitTask = server.worldData.WaitJoinPoint();
+        Assert.That(waitTask.IsCompleted, Is.False);
+
+        server.worldData.AbortJoinPointCreation();
+
+        var completed = await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.That(completed, Is.SameAs(server.worldData));
+        Assert.That(server.worldData.CreatingJoinPoint, Is.False);
+        Assert.That(server.worldData.WaitJoinPoint().IsCompleted, Is.True);
+    }
+
     private void ConnectClient(int port)
     {
         var clientListener = new TestNetListener();


### PR DESCRIPTION
## Summary

Abort an in-progress join point when the host disconnects so reconnect does not remain blocked in `ServerLoading`.

Fixes #860.

## What changed

- add `WorldData.AbortJoinPointCreation()` to cleanly end a pending join point wait without replacing the current world snapshot
- abort join point creation from `PlayerManager.SetDisconnected()` when the disconnected player is the host
- log the abort so server-side behavior is visible in diagnostics
- add a regression test to verify aborting a join point unblocks waiters

## Why this fixes the issue

Previously, if the host disconnected during join point creation, `WorldData.CreatingJoinPoint` stayed active and `ServerLoading` kept waiting on `WaitJoinPoint()`. That prevented reconnect from progressing.

After this change, disconnecting the host resets the pending join point creation and releases waiting loading states so reconnect can proceed against the last stable world snapshot.

## Validation

- `dotnet build Source/Server/Server.csproj -c Release`
- `ServerTest` regression passes
- selected server/common tests pass
