### PR TITLE
Handle keepalive packets in server loading state

### DIFF
--- a/Source/Common/Networking/State/ServerLoadingState.cs
+++ b/Source/Common/Networking/State/ServerLoadingState.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Multiplayer.Common.Networking.Packet;
 
 namespace Multiplayer.Common;
 
@@ -7,6 +8,23 @@ public class ServerLoadingState : AsyncConnectionState
 {
     public ServerLoadingState(ConnectionBase connection) : base(connection)
     {
+    }
+
+    [TypedPacketHandler]
+    public void HandleClientKeepAlive(ClientKeepAlivePacket packet)
+    {
+        Player.ticksBehind = packet.ticksBehind;
+        Player.ticksBehindReceivedAt = Server.gameTimer;
+        Player.simulating = packet.simulating;
+        Player.keepAliveAt = Server.NetTimer;
+
+        if (Player.IsHost)
+            Server.workTicks = packet.workTicks;
+
+        var idMatched = Player.keepAliveId == packet.id;
+        connection.OnKeepAliveArrived(idMatched);
+        if (idMatched)
+            Player.keepAliveId++;
     }
 
     protected override async Task RunState()

--- a/Source/Tests/Helper/TestLoadingKeepAliveState.cs
+++ b/Source/Tests/Helper/TestLoadingKeepAliveState.cs
@@ -1,0 +1,56 @@
+using Multiplayer.Common;
+using Multiplayer.Common.Networking.Packet;
+
+namespace Tests;
+
+public class TestLoadingKeepAliveState : AsyncConnectionState
+{
+    public TestLoadingKeepAliveState(ConnectionBase connection) : base(connection)
+    {
+    }
+
+    private const string RwVersion = "1.0.0";
+
+    protected override async Task RunState()
+    {
+        connection.Send(ClientProtocolPacket.Current());
+        await TypedPacket<ServerProtocolOkPacket>();
+
+        connection.Send(new ClientUsernamePacket(connection.username!));
+        await TypedPacket<ServerInitDataRequestPacket>();
+
+        connection.Send(new ClientInitDataPacket
+        {
+            rwVersion = RwVersion,
+            debugOnlySyncCmds = [],
+            hostOnlySyncCmds = [],
+            modCtorRoundMode = RoundModeEnum.ToNearest,
+            staticCtorRoundMode = RoundModeEnum.ToNearest,
+            defInfos = [],
+            rawData = []
+        });
+
+        var packet = await Packet(Packets.Server_UsernameOk);
+        packet.Seek(packet.Length);
+
+        connection.Send(new ClientJoinDataPacket
+        {
+            modCtorRoundMode = RoundModeEnum.ToNearest,
+            staticCtorRoundMode = RoundModeEnum.ToNearest,
+            defInfos = []
+        });
+
+        await TypedPacket<ServerJoinDataPacket>();
+
+        connection.Send(Packets.Client_WorldRequest);
+        connection.Send(new ClientKeepAlivePacket(0, 0, false, 0), false);
+
+        packet = await Packet(Packets.Server_WorldDataStart);
+        packet.Seek(packet.Length);
+        packet = await Packet(Packets.Server_WorldData).Fragmented();
+        packet.Seek(packet.Length);
+
+        connection.Close(MpDisconnectReason.Generic);
+        connection.ChangeState(ConnectionStateEnum.Disconnected);
+    }
+}

--- a/Source/Tests/Helper/TestNetListener.cs
+++ b/Source/Tests/Helper/TestNetListener.cs
@@ -5,14 +5,17 @@ using Multiplayer.Common;
 
 namespace Tests;
 
-public class TestNetListener : INetEventListener
+public class TestNetListener(Type joiningStateType) : INetEventListener
 {
     public ConnectionBase? conn;
+    private readonly Type joiningStateType = joiningStateType;
 
     public void OnPeerConnected(NetPeer peer)
     {
         conn = new LiteNetConnection(peer);
         conn.username = "test1";
+
+        MpConnectionState.SetImplementation(ConnectionStateEnum.ClientJoining, joiningStateType);
         conn.ChangeState(ConnectionStateEnum.ClientJoining);
 
         Console.WriteLine("TestNetListener: OnPeerConnected");

--- a/Source/Tests/ServerTest.cs
+++ b/Source/Tests/ServerTest.cs
@@ -4,6 +4,7 @@ using Multiplayer.Common;
 
 namespace Tests;
 
+[NonParallelizable]
 public class ServerTest
 {
     private List<Action> teardownActions = new();
@@ -27,10 +28,8 @@ public class ServerTest
     [Test]
     public void Test()
     {
-        MpConnectionState.SetImplementation(ConnectionStateEnum.ClientJoining, typeof(TestJoiningState));
-
         var server = MakeServer(out var port);
-        ConnectClient(port);
+        ConnectClient(port, typeof(TestJoiningState));
 
         var timeoutWatch = Stopwatch.StartNew();
         while (true)
@@ -45,9 +44,36 @@ public class ServerTest
         }
     }
 
-    private void ConnectClient(int port)
+    [Test]
+    public void LoadingStateHandlesKeepAliveWhileWaitingForJoinPoint()
     {
-        var clientListener = new TestNetListener();
+        var server = MakeServer(out var port);
+        Assert.That(server.worldData.TryStartJoinPointCreation(true), Is.True);
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(200);
+            server.worldData.EndJoinPointCreation();
+        });
+
+        ConnectClient(port, typeof(TestLoadingKeepAliveState));
+
+        var timeoutWatch = Stopwatch.StartNew();
+        while (true)
+        {
+            if (server.playerManager.Players.Count == 0)
+                break;
+
+            if (timeoutWatch.ElapsedMilliseconds > 2000)
+                Assert.Fail("Timeout");
+
+            Thread.Sleep(50);
+        }
+    }
+
+    private void ConnectClient(int port, Type joiningStateType)
+    {
+        var clientListener = new TestNetListener(joiningStateType);
         var client = new NetManager(clientListener);
         client.Start();
         var peer = client.Connect("127.0.0.1", port, "");
@@ -89,9 +115,14 @@ public class ServerTest
 
         port = liteNet.netManagers[0].manager.LocalPort;
 
-        new Thread(server.Run) { IsBackground = true }.Start();
+        var serverThread = new Thread(server.Run) { IsBackground = true };
+        serverThread.Start();
 
-        teardownActions.Add(() => { server.running = false; });
+        teardownActions.Add(() =>
+        {
+            server.running = false;
+            serverThread.Join(timeout: TimeSpan.FromSeconds(2));
+        });
 
         return server;
     }


### PR DESCRIPTION
## Summary

Handle `Client_KeepAlive` packets while the connection is in `ServerLoading`.

Fixes #861.

## What changed

- add keepalive handling to `ServerLoadingState`
- update latency / behind / simulation tracking in the same way as `ServerPlayingState`
- add a regression test that sends a keepalive while the server is blocked waiting for join point completion

## Why this fixes the issue

Previously, a reconnecting client could continue sending keepalive packets while the server was still in `ServerLoading`, and the server would log them as unhandled packets.

After this change, the loading state accepts those packets normally, which removes the server log spam and keeps connection bookkeeping coherent during reconnect/loading.

## Validation

- `dotnet test Source/Tests/Tests.csproj --filter "FullyQualifiedName~LoadingStateHandlesKeepAliveWhileWaitingForJoinPoint"`
- `dotnet build Source/Server/Server.csproj -c Release`
