### PR TITLE
Skip VTR map updates during joinpoint reload

### DIFF
--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -64,6 +64,9 @@ namespace Multiplayer.Client.Patches
 
         public static void SendViewedMapUpdate(int previous, int current)
         {
+            if (Multiplayer.reloading)
+                return;
+
             string warn = string.Empty;
             if (previous != lastMovedToMapId)
                 warn = $" mismatch between expected previous map {previous} and last moved to map {lastMovedToMapId}";
@@ -77,6 +80,7 @@ namespace Multiplayer.Client.Patches
         public static void Reset()
         {
             lastMovedToMapId = InvalidMapId;
+            lastSentAtTick = -1;
         }
     }
 


### PR DESCRIPTION
Fixes #862

## Summary
- suppress viewed map updates while SaveAndReload is in progress
- reuse the existing Multiplayer.reloading flag instead of adding new state
- clear VTR resend bookkeeping on reset so the reloaded client starts from a clean sync state

## Validation
- dotnet build Source/Client/Multiplayer.csproj -c Release