### PR TITLE
Server: Allow game to continue without host in FreezeManager

### DIFF
--- a/Source/Common/FreezeManager.cs
+++ b/Source/Common/FreezeManager.cs
@@ -29,14 +29,23 @@ namespace Multiplayer.Common
 
         public void Tick()
         {
-            if (!Server.PlayingPlayers.Any(p => p.IsHost))
-                return;
+            var hostPlayer = Server.PlayingPlayers.FirstOrDefault(p => p.IsHost);
 
-            if (!Frozen && Server.HostPlayer.frozen)
-                Frozen = true;
+            if (hostPlayer != null)
+            {
+                // Host is present: freeze/unfreeze follows the host's state
+                if (!Frozen && hostPlayer.frozen)
+                    Frozen = true;
 
-            if (Frozen && !Server.HostPlayer.frozen && (!Server.PlayingPlayers.Any(p => p.frozen) || Server.NetTimer - Server.HostPlayer.unfrozenAt > MaxFreezeWaitTime))
-                Frozen = false;
+                if (Frozen && !hostPlayer.frozen && (!Server.PlayingPlayers.Any(p => p.frozen) || Server.NetTimer - hostPlayer.unfrozenAt > MaxFreezeWaitTime))
+                    Frozen = false;
+            }
+            else
+            {
+                // Host is absent: unfreeze if any player is active
+                if (Frozen && Server.PlayingPlayers.Any())
+                    Frozen = false;
+            }
         }
     }
 }

--- a/Source/Tests/FreezeManagerTest.cs
+++ b/Source/Tests/FreezeManagerTest.cs
@@ -1,0 +1,144 @@
+using Multiplayer.Common;
+
+namespace Tests;
+
+[TestFixture]
+public class FreezeManagerTest
+{
+    private MultiplayerServer server = null!;
+    private int nextPlayerId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        server = MultiplayerServer.instance = new MultiplayerServer(new ServerSettings
+        {
+            gameName = "Test",
+            direct = false,
+            lan = false
+        });
+        nextPlayerId = 1;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        MultiplayerServer.instance = null;
+    }
+
+    private ServerPlayer AddPlayer(string username, bool isHost = false)
+    {
+        var conn = new DummyConnection(username);
+        var player = new ServerPlayer(nextPlayerId++, conn);
+        conn.serverPlayer = player;
+        conn.ChangeState(ConnectionStateEnum.ServerPlaying);
+
+        if (isHost)
+            server.hostUsername = username;
+
+        server.playerManager.Players.Add(player);
+        return player;
+    }
+
+    private void RemovePlayer(ServerPlayer player)
+    {
+        server.playerManager.Players.Remove(player);
+    }
+
+    [Test]
+    public void HostPresent_HostFrozen_ServerFreezes()
+    {
+        var host = AddPlayer("host", isHost: true);
+        host.frozen = true;
+
+        server.freezeManager.Tick();
+
+        Assert.That(server.freezeManager.Frozen, Is.True);
+    }
+
+    [Test]
+    public void HostPresent_HostNotFrozen_ServerNotFrozen()
+    {
+        var host = AddPlayer("host", isHost: true);
+        host.frozen = false;
+
+        server.freezeManager.Tick();
+
+        Assert.That(server.freezeManager.Frozen, Is.False);
+    }
+
+    [Test]
+    public void HostAbsent_PlayersPresent_NotFrozen()
+    {
+        // Host was never added — only a non-host player is present
+        AddPlayer("player1");
+
+        // Force frozen state to true to verify it gets unfrozen
+        // Use Tick with a temporary host to set Frozen = true
+        var tempHost = AddPlayer("host", isHost: true);
+        tempHost.frozen = true;
+        server.freezeManager.Tick();
+        Assert.That(server.freezeManager.Frozen, Is.True);
+
+        // Now remove host — simulating disconnect
+        RemovePlayer(tempHost);
+        server.hostUsername = "host"; // host username stays but player is gone
+
+        server.freezeManager.Tick();
+
+        Assert.That(server.freezeManager.Frozen, Is.False);
+    }
+
+    [Test]
+    public void HostAbsent_NoPlayers_StaysFrozen()
+    {
+        // Set Frozen = true by having a host freeze, then removing everyone
+        var host = AddPlayer("host", isHost: true);
+        host.frozen = true;
+        server.freezeManager.Tick();
+        Assert.That(server.freezeManager.Frozen, Is.True);
+
+        RemovePlayer(host);
+
+        server.freezeManager.Tick();
+
+        Assert.That(server.freezeManager.Frozen, Is.True);
+    }
+
+    [Test]
+    public void HostAbsent_NoPlayers_NotFrozenStaysNotFrozen()
+    {
+        // No players at all, not frozen — should remain not frozen
+        // (no one to send the freeze packet to anyway)
+        server.freezeManager.Tick();
+
+        Assert.That(server.freezeManager.Frozen, Is.False);
+    }
+
+    [Test]
+    public void HostReconnects_ResumesNormalBehavior()
+    {
+        // Start with host, freeze
+        var host = AddPlayer("host", isHost: true);
+        host.frozen = true;
+        server.freezeManager.Tick();
+        Assert.That(server.freezeManager.Frozen, Is.True);
+
+        // Host disconnects, player present → unfreezes
+        RemovePlayer(host);
+        var player = AddPlayer("player1");
+        server.freezeManager.Tick();
+        Assert.That(server.freezeManager.Frozen, Is.False);
+
+        // Host reconnects and is not frozen → stays unfrozen
+        var hostAgain = AddPlayer("host", isHost: true);
+        hostAgain.frozen = false;
+        server.freezeManager.Tick();
+        Assert.That(server.freezeManager.Frozen, Is.False);
+
+        // Host freezes again → server freezes
+        hostAgain.frozen = true;
+        server.freezeManager.Tick();
+        Assert.That(server.freezeManager.Frozen, Is.True);
+    }
+}

--- a/Source/Tests/Helper/DummyConnection.cs
+++ b/Source/Tests/Helper/DummyConnection.cs
@@ -1,0 +1,16 @@
+using Multiplayer.Common;
+
+namespace Tests;
+
+public class DummyConnection : ConnectionBase
+{
+    public DummyConnection(string username)
+    {
+        this.username = username;
+    }
+
+    public override int Latency { get => 0; set { } }
+
+    protected override void SendRaw(byte[] raw, bool reliable) { }
+    protected override void OnClose(Multiplayer.Common.Networking.Packet.ServerDisconnectPacket? goodbye) { }
+}


### PR DESCRIPTION
## Problem (standalone server)

When the host disconnects from a standalone/dedicated server, `FreezeManager.Tick()` returns early (`if (!Server.PlayingPlayers.Any(p => p.IsHost)) return;`), leaving the server frozen indefinitely. Other connected players cannot continue the game even though they are active.

This is particularly impactful for standalone server deployments where the host may disconnect and reconnect freely while other players remain connected.

## Solution

Modified `FreezeManager.Tick()` to handle the host-absent case:
- **Host present**: unchanged behavior - freeze/unfreeze follows the host's `frozen` state
- **Host absent, players connected**: the server unfreezes so the game can continue
- **Host absent, no players**: freeze state is left unchanged (the server loop already won't advance the game timer without active players)
- **Host reconnects**: normal host-driven freeze/unfreeze behavior resumes seamlessly

## Changes

- `Source/Common/FreezeManager.cs`: Replaced the early-return guard with a two-branch approach
- `Source/Tests/FreezeManagerTest.cs`: 6 new unit tests covering all scenarios
- `Source/Tests/Helper/DummyConnection.cs`: Lightweight test double for `ConnectionBase`

## Testing

All 71 tests pass (65 existing + 6 new).