### PR TITLE
Server: Fallback time control to allow all players when host is absent

### DIFF
--- a/Source/Common/CommandHandler.cs
+++ b/Source/Common/CommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Multiplayer.Common.Networking.Packet;
 
 namespace Multiplayer.Common
@@ -30,7 +31,9 @@ namespace Multiplayer.Common
                     return;
 
                 if (cmdType is CommandType.MapTimeSpeed or CommandType.GlobalTimeSpeed &&
-                    server.settings.timeControl == TimeControl.HostOnly && !sourcePlayer.IsHost)
+                    server.settings.timeControl == TimeControl.HostOnly &&
+                    !sourcePlayer.IsHost &&
+                    server.PlayingPlayers.Any(p => p.IsHost))
                     return;
             }
 

--- a/Source/Tests/Helper/DummyConnection.cs
+++ b/Source/Tests/Helper/DummyConnection.cs
@@ -1,0 +1,16 @@
+using Multiplayer.Common;
+
+namespace Tests;
+
+public class DummyConnection : ConnectionBase
+{
+    public DummyConnection(string username)
+    {
+        this.username = username;
+    }
+
+    public override int Latency { get => 0; set { } }
+
+    protected override void SendRaw(byte[] raw, bool reliable) { }
+    protected override void OnClose(Multiplayer.Common.Networking.Packet.ServerDisconnectPacket? goodbye) { }
+}

--- a/Source/Tests/TimeControlFallbackTest.cs
+++ b/Source/Tests/TimeControlFallbackTest.cs
@@ -1,0 +1,135 @@
+using Multiplayer.Common;
+
+namespace Tests;
+
+[TestFixture]
+public class TimeControlFallbackTest
+{
+    private MultiplayerServer server = null!;
+    private int nextPlayerId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        server = MultiplayerServer.instance = new MultiplayerServer(new ServerSettings
+        {
+            gameName = "Test",
+            direct = false,
+            lan = false,
+            timeControl = TimeControl.HostOnly
+        });
+        nextPlayerId = 1;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        MultiplayerServer.instance = null;
+    }
+
+    private ServerPlayer AddPlayer(string username, bool isHost = false)
+    {
+        var conn = new DummyConnection(username);
+        var player = new ServerPlayer(nextPlayerId++, conn);
+        conn.serverPlayer = player;
+        conn.ChangeState(ConnectionStateEnum.ServerPlaying);
+
+        if (isHost)
+            server.hostUsername = username;
+
+        server.playerManager.Players.Add(player);
+        return player;
+    }
+
+    private void RemovePlayer(ServerPlayer player)
+    {
+        server.playerManager.Players.Remove(player);
+    }
+
+    [Test]
+    public void HostOnly_HostPresent_NonHostTimeCommandRejected()
+    {
+        AddPlayer("host", isHost: true);
+        var player = AddPlayer("player1");
+
+        int cmdsBefore = server.commands.SentCmds;
+        server.commands.Send(CommandType.MapTimeSpeed, 0, 0, Array.Empty<byte>(), sourcePlayer: player);
+
+        Assert.That(server.commands.SentCmds, Is.EqualTo(cmdsBefore),
+            "Non-host time command should be rejected when host is present");
+    }
+
+    [Test]
+    public void HostOnly_HostPresent_HostTimeCommandAccepted()
+    {
+        var host = AddPlayer("host", isHost: true);
+
+        int cmdsBefore = server.commands.SentCmds;
+        server.commands.Send(CommandType.MapTimeSpeed, 0, 0, Array.Empty<byte>(), sourcePlayer: host);
+
+        Assert.That(server.commands.SentCmds, Is.EqualTo(cmdsBefore + 1),
+            "Host time command should be accepted");
+    }
+
+    [Test]
+    public void HostOnly_HostAbsent_NonHostTimeCommandAccepted()
+    {
+        // Host was present but disconnected
+        server.hostUsername = "host";
+        var player = AddPlayer("player1");
+
+        int cmdsBefore = server.commands.SentCmds;
+        server.commands.Send(CommandType.MapTimeSpeed, 0, 0, Array.Empty<byte>(), sourcePlayer: player);
+
+        Assert.That(server.commands.SentCmds, Is.EqualTo(cmdsBefore + 1),
+            "Non-host time command should be accepted when host is absent (fallback)");
+    }
+
+    [Test]
+    public void HostOnly_HostAbsent_GlobalTimeSpeedAlsoAccepted()
+    {
+        server.hostUsername = "host";
+        var player = AddPlayer("player1");
+
+        int cmdsBefore = server.commands.SentCmds;
+        server.commands.Send(CommandType.GlobalTimeSpeed, 0, 0, Array.Empty<byte>(), sourcePlayer: player);
+
+        Assert.That(server.commands.SentCmds, Is.EqualTo(cmdsBefore + 1),
+            "Non-host GlobalTimeSpeed should be accepted when host is absent");
+    }
+
+    [Test]
+    public void EveryoneControls_TimeCommandAlwaysAccepted()
+    {
+        server.settings.timeControl = TimeControl.EveryoneControls;
+        AddPlayer("host", isHost: true);
+        var player = AddPlayer("player1");
+
+        int cmdsBefore = server.commands.SentCmds;
+        server.commands.Send(CommandType.MapTimeSpeed, 0, 0, Array.Empty<byte>(), sourcePlayer: player);
+
+        Assert.That(server.commands.SentCmds, Is.EqualTo(cmdsBefore + 1),
+            "EveryoneControls should always accept time commands");
+    }
+
+    [Test]
+    public void HostOnly_HostReconnects_EnforcementResumes()
+    {
+        // Start with host absent → fallback active
+        server.hostUsername = "host";
+        var player = AddPlayer("player1");
+
+        int cmdsBefore = server.commands.SentCmds;
+        server.commands.Send(CommandType.MapTimeSpeed, 0, 0, Array.Empty<byte>(), sourcePlayer: player);
+        Assert.That(server.commands.SentCmds, Is.EqualTo(cmdsBefore + 1),
+            "Fallback should be active when host is absent");
+
+        // Host reconnects → enforcement resumes
+        AddPlayer("host", isHost: true);
+
+        int cmdsAfterReconnect = server.commands.SentCmds;
+        server.commands.Send(CommandType.MapTimeSpeed, 0, 0, Array.Empty<byte>(), sourcePlayer: player);
+        Assert.That(server.commands.SentCmds, Is.EqualTo(cmdsAfterReconnect),
+            "HostOnly enforcement should resume when host reconnects");
+    }
+}


### PR DESCRIPTION
## Problem (standalone server)

When `timeControl` is set to `HostOnly`, time speed commands (`MapTimeSpeed`, `GlobalTimeSpeed`) from non-host players are rejected by `CommandHandler.Send()`. If the host disconnects from the standalone server, all remaining players are unable to change the game speed — effectively locked at whatever speed it was before the host left.

This is particularly impactful for standalone server deployments where the host may disconnect and reconnect freely while other players remain connected.

## Solution

Added a check: the `HostOnly` restriction is only enforced when the host is actually among the playing players. When the host is absent, any player can issue time speed commands. When the host reconnects, `HostOnly` enforcement resumes automatically.

## Changes

- `Source/Common/CommandHandler.cs`: Added `server.PlayingPlayers.Any(p => p.IsHost)` guard to the time control policy check
- `Source/Tests/TimeControlFallbackTest.cs`: 6 new unit tests covering host-present rejection, host-absent fallback, reconnection, and EveryoneControls mode
- `Source/Tests/Helper/DummyConnection.cs`: Lightweight test double for `ConnectionBase`

## Testing

All 71 tests pass (65 existing + 6 new).