### PR TITLE
Standalone server: stream map commands only to relevant players

### DIFF
--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Ionic.Zlib;
 using Multiplayer.Client.Desyncs;
+using Multiplayer.Client.Saving;
 using Multiplayer.Common;
 using Multiplayer.Common.Networking.Packet;
 using RimWorld;
@@ -148,8 +150,11 @@ namespace Multiplayer.Client
             byte[] mapData = GZipStream.UncompressBuffer(data.ReadPrefixedBytes());
             Session.dataSnapshot.MapData[mapId] = mapData;
 
-            //ClientJoiningState.ReloadGame(TickPatch.tickUntil, Find.Maps.Select(m => m.uniqueID).Concat(mapId).ToList());
-            // todo Multiplayer.client.Send(Packets.CLIENT_MAP_LOADED);
+            OnMainThread.Enqueue(() =>
+            {
+                var mapsToLoad = Find.Maps.Select(m => m.uniqueID).Append(mapId).Distinct().ToList();
+                Loader.ReloadGame(mapsToLoad, false, Multiplayer.game?.gameComp.asyncTime ?? false);
+            });
         }
 
         [TypedPacketHandler]

--- a/Source/Common/CommandHandler.cs
+++ b/Source/Common/CommandHandler.cs
@@ -52,7 +52,7 @@ namespace Multiplayer.Common
                 var serialized = ServerCommandPacket.From(cmd).Serialize();
                 foreach (var player in server.PlayingPlayers)
                 {
-                    if (!player.hasReportedCurrentMap || player.currentMapId == mapId)
+                    if (!player.hasReportedCurrentMap || player.currentMapId < 0 || player.currentMapId == mapId)
                         player.conn.Send(serialized, true);
                 }
             }

--- a/Source/Common/CommandHandler.cs
+++ b/Source/Common/CommandHandler.cs
@@ -46,7 +46,20 @@ namespace Multiplayer.Common
             // todo cull target players if not global
             server.worldData.mapCmds.GetOrAddNew(mapId).Add(toSave);
             server.worldData.tmpMapCmds?.GetOrAddNew(mapId).Add(toSave);
-            server.SendToPlaying(ServerCommandPacket.From(cmd));
+
+            if (server.CanUseStandaloneMapStreaming(mapId))
+            {
+                var serialized = ServerCommandPacket.From(cmd).Serialize();
+                foreach (var player in server.PlayingPlayers)
+                {
+                    if (!player.hasReportedCurrentMap || player.currentMapId == mapId)
+                        player.conn.Send(serialized, true);
+                }
+            }
+            else
+            {
+                server.SendToPlaying(ServerCommandPacket.From(cmd));
+            }
 
             SentCmds++;
         }

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -73,6 +73,8 @@ namespace Multiplayer.Common
 
         public int NetTimer { get; private set; }
 
+        public bool IsStandaloneServer { get; set; }
+
         public MultiplayerServer(ServerSettings settings)
         {
             this.settings = settings;
@@ -227,6 +229,26 @@ namespace Multiplayer.Common
             foreach (ServerPlayer player in PlayingIngamePlayers)
                 if (player != excluding)
                     player.conn.Send(serialized, reliable);
+        }
+
+        public bool CanUseStandaloneMapStreaming(int mapId) =>
+            IsStandaloneServer && mapId != ScheduledCommand.Global && worldData.mapData.ContainsKey(mapId);
+
+        public void SendMapResponse(ServerPlayer player, int mapId)
+        {
+            if (!CanUseStandaloneMapStreaming(mapId))
+                return;
+
+            ByteWriter writer = new ByteWriter();
+            writer.WriteInt32(mapId);
+
+            var mapCmds = worldData.mapCmds.GetValueSafe(mapId) ?? [];
+            writer.WriteInt32(mapCmds.Count);
+            foreach (var cmd in mapCmds)
+                writer.WritePrefixedBytes(cmd);
+
+            writer.WritePrefixedBytes(worldData.mapData[mapId]);
+            player.conn.SendFragmented(Packets.Server_MapResponse, writer.ToArray());
         }
 
         public ServerPlayer? GetPlayer(string username)

--- a/Source/Common/Networking/State/ServerPlayingState.cs
+++ b/Source/Common/Networking/State/ServerPlayingState.cs
@@ -33,6 +33,8 @@ namespace Multiplayer.Common
         [TypedPacketHandler]
         public void HandleClientCommand(ClientCommandPacket packet)
         {
+            int? mapToResync = null;
+
             if (packet.type == CommandType.PlayerCount)
             {
                 ByteReader reader = new ByteReader(packet.data);
@@ -42,11 +44,18 @@ namespace Multiplayer.Common
                     ServerLog.Error($"Inconsistent player {Player.Username} map. Last known map: {Player.currentMapId}, " +
                                     $"however received command with transition: {prevMapId} -> {newMapId}");
                 Player.currentMapId = newMapId;
+                Player.hasReportedCurrentMap = true;
+
+                if (Server.CanUseStandaloneMapStreaming(newMapId))
+                    mapToResync = newMapId;
             }
 
             // todo check if map id is valid for the player
 
             Server.commands.Send(packet.type, Player.FactionId, packet.mapId, packet.data, Player);
+
+            if (mapToResync is int currentMapId)
+                Server.SendMapResponse(Player, currentMapId);
         }
 
         public const int MaxChatMsgLength = 128;

--- a/Source/Common/ServerPlayer.cs
+++ b/Source/Common/ServerPlayer.cs
@@ -32,6 +32,7 @@ namespace Multiplayer.Common
 
         // Track which map the player is currently on
         public int currentMapId = -1;
+        public bool hasReportedCurrentMap;
 
         public string Username => conn.username;
         public int Latency => conn.Latency;

--- a/Source/Server/Server.cs
+++ b/Source/Server/Server.cs
@@ -30,6 +30,7 @@ if (settings.arbiter) ServerLog.Error("Arbiter is not supported in standalone se
 var server = MultiplayerServer.instance = new MultiplayerServer(settings)
 {
     running = true,
+    IsStandaloneServer = true,
 };
 
 var consoleSource = new ConsoleSource();

--- a/Source/Tests/Helper/RecordingConnection.cs
+++ b/Source/Tests/Helper/RecordingConnection.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Multiplayer.Common;
+using Multiplayer.Common.Networking.Packet;
+
+namespace Tests;
+
+public class RecordingConnection : ConnectionBase
+{
+    public List<Packets> SentPackets { get; } = new();
+
+    public RecordingConnection(string username)
+    {
+        this.username = username;
+    }
+
+    public override int Latency { get => 0; set { } }
+
+    protected override void SendRaw(byte[] raw, bool reliable)
+    {
+        if (raw.Length == 0)
+            return;
+
+        SentPackets.Add((Packets)(raw[0] & 0x3F));
+    }
+
+    protected override void OnClose(ServerDisconnectPacket? goodbye) { }
+}

--- a/Source/Tests/StandaloneMapStreamingTest.cs
+++ b/Source/Tests/StandaloneMapStreamingTest.cs
@@ -1,0 +1,91 @@
+using Multiplayer.Common;
+
+namespace Tests;
+
+[TestFixture]
+public class StandaloneMapStreamingTest
+{
+    private MultiplayerServer server = null!;
+    private int nextPlayerId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        server = MultiplayerServer.instance = new MultiplayerServer(new ServerSettings
+        {
+            gameName = "Test",
+            direct = false,
+            lan = false
+        })
+        {
+            IsStandaloneServer = true,
+        };
+        nextPlayerId = 1;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        MultiplayerServer.instance = null;
+    }
+
+    private (ServerPlayer player, RecordingConnection conn) AddPlayer(string username, int currentMapId, bool hasReportedCurrentMap = true)
+    {
+        var conn = new RecordingConnection(username);
+        var player = new ServerPlayer(nextPlayerId++, conn)
+        {
+            currentMapId = currentMapId,
+            hasReportedCurrentMap = hasReportedCurrentMap,
+        };
+        conn.serverPlayer = player;
+        conn.ChangeState(ConnectionStateEnum.ServerPlaying);
+        server.playerManager.Players.Add(player);
+        return (player, conn);
+    }
+
+    [Test]
+    public void StandaloneFiltering_SendsMapCommandsOnlyToPlayersOnThatMap()
+    {
+        server.worldData.mapData[1] = [1, 2, 3];
+        var (playerOnMap, connOnMap) = AddPlayer("map1", 1);
+        var (_, connOtherMap) = AddPlayer("map2", 2);
+
+        server.commands.Send(CommandType.Designator, 0, 1, [], sourcePlayer: playerOnMap);
+
+        Assert.That(connOnMap.SentPackets, Does.Contain(Packets.Server_Command));
+        Assert.That(connOtherMap.SentPackets, Does.Not.Contain(Packets.Server_Command));
+    }
+
+    [Test]
+    public void NonStandaloneServer_KeepsBroadcastBehavior()
+    {
+        server.IsStandaloneServer = false;
+        server.worldData.mapData[1] = [1, 2, 3];
+        var (playerOnMap, connOnMap) = AddPlayer("map1", 1);
+        var (_, connOtherMap) = AddPlayer("map2", 2);
+
+        server.commands.Send(CommandType.Designator, 0, 1, [], sourcePlayer: playerOnMap);
+
+        Assert.That(connOnMap.SentPackets, Does.Contain(Packets.Server_Command));
+        Assert.That(connOtherMap.SentPackets, Does.Contain(Packets.Server_Command));
+    }
+
+    [Test]
+    public void PlayerCountMapSwitch_SendsMapResponseForStandaloneSnapshotMaps()
+    {
+        server.worldData.mapData[5] = [9, 9, 9];
+        server.worldData.mapCmds[5] = [ScheduledCommand.Serialize(new ScheduledCommand(CommandType.Designator, 10, 0, 5, 1, []))];
+        var (player, conn) = AddPlayer("player", -1, hasReportedCurrentMap: false);
+
+        var state = player.conn.GetState<ServerPlayingState>()!;
+        state.HandleClientCommand(new Multiplayer.Common.Networking.Packet.ClientCommandPacket(
+            CommandType.PlayerCount,
+            ScheduledCommand.Global,
+            ByteWriter.GetBytes(-1, 5)
+        ));
+
+        Assert.That(player.currentMapId, Is.EqualTo(5));
+        Assert.That(player.hasReportedCurrentMap, Is.True);
+        Assert.That(conn.SentPackets, Does.Contain(Packets.Server_MapResponse));
+    }
+}

--- a/Source/Tests/StandaloneMapStreamingTest.cs
+++ b/Source/Tests/StandaloneMapStreamingTest.cs
@@ -71,6 +71,21 @@ public class StandaloneMapStreamingTest
     }
 
     [Test]
+    public void StandaloneFiltering_FallsBackToBroadcastForPlayersOutsideAnyMap()
+    {
+        server.worldData.mapData[1] = [1, 2, 3];
+        var (playerOnMap, connOnMap) = AddPlayer("map1", 1);
+        var (_, connWorldMap) = AddPlayer("world", -2);
+        var (_, connOtherMap) = AddPlayer("map2", 2);
+
+        server.commands.Send(CommandType.Designator, 0, 1, [], sourcePlayer: playerOnMap);
+
+        Assert.That(connOnMap.SentPackets, Does.Contain(Packets.Server_Command));
+        Assert.That(connWorldMap.SentPackets, Does.Contain(Packets.Server_Command));
+        Assert.That(connOtherMap.SentPackets, Does.Not.Contain(Packets.Server_Command));
+    }
+
+    [Test]
     public void PlayerCountMapSwitch_SendsMapResponseForStandaloneSnapshotMaps()
     {
         server.worldData.mapData[5] = [9, 9, 9];


### PR DESCRIPTION
## Scope

This change is intentionally limited to the standalone dedicated server path. Local hosting and non-standalone modes keep the previous broadcast behavior.

## What changed

- Added a standalone-only gate (MultiplayerServer.IsStandaloneServer), set only by Source/Server/Server.cs`n- Filtered map-scoped Server_Command packets to players currently on the relevant map
- When a player reports a map switch via PlayerCount, the standalone server sends a Server_MapResponse resync for the destination map
- Client reloads the destination map from the updated snapshot when Server_MapResponse arrives
- Conservative fallback: if a map does not exist in the server snapshot data, the old broadcast path is preserved

## Validation

- dotnet test Source/Tests/Tests.csproj -c Release --no-restore
- dotnet build Source/Client/Multiplayer.csproj -c Release
- dotnet build Source/Server/Server.csproj -c Release