### PR TITLE
Fix fragmented map responses and add standalone mapstream tests

### DIFF
--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -135,7 +135,7 @@ namespace Multiplayer.Client
         [TypedPacketHandler]
         public void HandlePing(ServerPingLocPacket packet) => Session.locationPings.ReceivePing(packet);
 
-        [PacketHandler(Packets.Server_MapResponse)]
+        [PacketHandler(Packets.Server_MapResponse, allowFragmented: true)]
         public void HandleMapResponse(ByteReader data)
         {
             int mapId = data.ReadInt32();

--- a/Source/Tests/StandaloneMapStreamingTest.cs
+++ b/Source/Tests/StandaloneMapStreamingTest.cs
@@ -103,4 +103,109 @@ public class StandaloneMapStreamingTest
         Assert.That(player.hasReportedCurrentMap, Is.True);
         Assert.That(conn.SentPackets, Does.Contain(Packets.Server_MapResponse));
     }
+}using Multiplayer.Common;
+
+namespace Tests;
+
+[TestFixture]
+public class StandaloneMapStreamingTest
+{
+    private MultiplayerServer server = null!;
+    private int nextPlayerId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        server = MultiplayerServer.instance = new MultiplayerServer(new ServerSettings
+        {
+            gameName = "Test",
+            direct = false,
+            lan = false
+        })
+        {
+            IsStandaloneServer = true,
+        };
+        nextPlayerId = 1;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        MultiplayerServer.instance = null;
+    }
+
+    private (ServerPlayer player, RecordingConnection conn) AddPlayer(string username, int currentMapId, bool hasReportedCurrentMap = true)
+    {
+        var conn = new RecordingConnection(username);
+        var player = new ServerPlayer(nextPlayerId++, conn)
+        {
+            currentMapId = currentMapId,
+            hasReportedCurrentMap = hasReportedCurrentMap,
+        };
+        conn.serverPlayer = player;
+        conn.ChangeState(ConnectionStateEnum.ServerPlaying);
+        server.playerManager.Players.Add(player);
+        return (player, conn);
+    }
+
+    [Test]
+    public void StandaloneFiltering_SendsMapCommandsOnlyToPlayersOnThatMap()
+    {
+        server.worldData.mapData[1] = [1, 2, 3];
+        var (playerOnMap, connOnMap) = AddPlayer("map1", 1);
+        var (_, connOtherMap) = AddPlayer("map2", 2);
+
+        server.commands.Send(CommandType.Designator, 0, 1, [], sourcePlayer: playerOnMap);
+
+        Assert.That(connOnMap.SentPackets, Does.Contain(Packets.Server_Command));
+        Assert.That(connOtherMap.SentPackets, Does.Not.Contain(Packets.Server_Command));
+    }
+
+    [Test]
+    public void NonStandaloneServer_KeepsBroadcastBehavior()
+    {
+        server.IsStandaloneServer = false;
+        server.worldData.mapData[1] = [1, 2, 3];
+        var (playerOnMap, connOnMap) = AddPlayer("map1", 1);
+        var (_, connOtherMap) = AddPlayer("map2", 2);
+
+        server.commands.Send(CommandType.Designator, 0, 1, [], sourcePlayer: playerOnMap);
+
+        Assert.That(connOnMap.SentPackets, Does.Contain(Packets.Server_Command));
+        Assert.That(connOtherMap.SentPackets, Does.Contain(Packets.Server_Command));
+    }
+
+    [Test]
+    public void StandaloneFiltering_FallsBackToBroadcastForPlayersOutsideAnyMap()
+    {
+        server.worldData.mapData[1] = [1, 2, 3];
+        var (playerOnMap, connOnMap) = AddPlayer("map1", 1);
+        var (_, connWorldMap) = AddPlayer("world", -2);
+        var (_, connOtherMap) = AddPlayer("map2", 2);
+
+        server.commands.Send(CommandType.Designator, 0, 1, [], sourcePlayer: playerOnMap);
+
+        Assert.That(connOnMap.SentPackets, Does.Contain(Packets.Server_Command));
+        Assert.That(connWorldMap.SentPackets, Does.Contain(Packets.Server_Command));
+        Assert.That(connOtherMap.SentPackets, Does.Not.Contain(Packets.Server_Command));
+    }
+
+    [Test]
+    public void PlayerCountMapSwitch_SendsMapResponseForStandaloneSnapshotMaps()
+    {
+        server.worldData.mapData[5] = [9, 9, 9];
+        server.worldData.mapCmds[5] = [ScheduledCommand.Serialize(new ScheduledCommand(CommandType.Designator, 10, 0, 5, 1, []))];
+        var (player, conn) = AddPlayer("player", -1, hasReportedCurrentMap: false);
+
+        var state = player.conn.GetState<ServerPlayingState>()!;
+        state.HandleClientCommand(new Multiplayer.Common.Networking.Packet.ClientCommandPacket(
+            CommandType.PlayerCount,
+            ScheduledCommand.Global,
+            ByteWriter.GetBytes(-1, 5)
+        ));
+
+        Assert.That(player.currentMapId, Is.EqualTo(5));
+        Assert.That(player.hasReportedCurrentMap, Is.True);
+        Assert.That(conn.SentPackets, Does.Contain(Packets.Server_MapResponse));
+    }
 }


### PR DESCRIPTION
## Scope

This is the follow-up delta still missing from upstream/dev after the standalone mapstream work.

## Changes

- mark Server_MapResponse as allowFragmented: true on the client handler
- add focused regression tests for standalone map streaming behavior, including world-map fallback and map-switch resync

## Why

Without allowFragmented: true, clients crash with PacketReadException when a resync map payload exceeds the single-packet size.

## Validation

- dotnet test Source/Tests/Tests.csproj -c Release --filter FullyQualifiedName~StandaloneMapStreamingTest --no-restore
- dotnet build Source/Client/Multiplayer.csproj -c Release
- dotnet test Source/Tests/Tests.csproj -c Release --no-restore