### PR TITLE
Fix fragmented standalone map responses on client

### DIFF
--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -135,7 +135,7 @@ namespace Multiplayer.Client
         [TypedPacketHandler]
         public void HandlePing(ServerPingLocPacket packet) => Session.locationPings.ReceivePing(packet);
 
-        [PacketHandler(Packets.Server_MapResponse)]
+        [PacketHandler(Packets.Server_MapResponse, allowFragmented: true)]
         public void HandleMapResponse(ByteReader data)
         {
             int mapId = data.ReadInt32();


### PR DESCRIPTION
## Summary
- allow the client `Server_MapResponse` handler to accept fragmented packets
- fix standalone map reloads when the server sends large map snapshots
- keep the change scoped to the `client -> standalone server` path

## Why
Standalone servers send `Server_MapResponse` with `SendFragmented(...)` for larger map payloads. The client handler rejected fragmented packets, causing map reload failures during standalone map streaming and resync.

## Validation
- `dotnet test .\\Source\\Tests\\Tests.csproj --filter "FullyQualifiedName~StandaloneMapStreamingTest"`
- `dotnet build .\\Source\\Client\\Multiplayer.csproj -c Release`