### PR TITLE
Fallback standalone server to old sync behavior

### DIFF
--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -231,8 +231,7 @@ namespace Multiplayer.Common
                     player.conn.Send(serialized, reliable);
         }
 
-        public bool CanUseStandaloneMapStreaming(int mapId) =>
-            IsStandaloneServer && mapId != ScheduledCommand.Global && worldData.mapData.ContainsKey(mapId);
+        public bool CanUseStandaloneMapStreaming(int mapId) => false;
 
         public void SendMapResponse(ServerPlayer player, int mapId)
         {

--- a/Source/Tests/StandaloneMapStreamingTest.cs
+++ b/Source/Tests/StandaloneMapStreamingTest.cs
@@ -44,7 +44,7 @@ public class StandaloneMapStreamingTest
     }
 
     [Test]
-    public void StandaloneFiltering_SendsMapCommandsOnlyToPlayersOnThatMap()
+    public void StandaloneStreamingDisabled_KeepsBroadcastBehavior()
     {
         server.worldData.mapData[1] = [1, 2, 3];
         var (playerOnMap, connOnMap) = AddPlayer("map1", 1);
@@ -53,7 +53,7 @@ public class StandaloneMapStreamingTest
         server.commands.Send(CommandType.Designator, 0, 1, [], sourcePlayer: playerOnMap);
 
         Assert.That(connOnMap.SentPackets, Does.Contain(Packets.Server_Command));
-        Assert.That(connOtherMap.SentPackets, Does.Not.Contain(Packets.Server_Command));
+        Assert.That(connOtherMap.SentPackets, Does.Contain(Packets.Server_Command));
     }
 
     [Test]
@@ -71,7 +71,7 @@ public class StandaloneMapStreamingTest
     }
 
     [Test]
-    public void StandaloneFiltering_FallsBackToBroadcastForPlayersOutsideAnyMap()
+    public void StandaloneStreamingDisabled_BroadcastsEvenWithWorldViewer()
     {
         server.worldData.mapData[1] = [1, 2, 3];
         var (playerOnMap, connOnMap) = AddPlayer("map1", 1);
@@ -82,11 +82,11 @@ public class StandaloneMapStreamingTest
 
         Assert.That(connOnMap.SentPackets, Does.Contain(Packets.Server_Command));
         Assert.That(connWorldMap.SentPackets, Does.Contain(Packets.Server_Command));
-        Assert.That(connOtherMap.SentPackets, Does.Not.Contain(Packets.Server_Command));
+        Assert.That(connOtherMap.SentPackets, Does.Contain(Packets.Server_Command));
     }
 
     [Test]
-    public void PlayerCountMapSwitch_SendsMapResponseForStandaloneSnapshotMaps()
+    public void InitialPlayerCountMapReport_DoesNotSendMapResponse()
     {
         server.worldData.mapData[5] = [9, 9, 9];
         server.worldData.mapCmds[5] = [ScheduledCommand.Serialize(new ScheduledCommand(CommandType.Designator, 10, 0, 5, 1, []))];
@@ -101,6 +101,42 @@ public class StandaloneMapStreamingTest
 
         Assert.That(player.currentMapId, Is.EqualTo(5));
         Assert.That(player.hasReportedCurrentMap, Is.True);
-        Assert.That(conn.SentPackets, Does.Contain(Packets.Server_MapResponse));
+        Assert.That(conn.SentPackets, Does.Not.Contain(Packets.Server_MapResponse));
+    }
+
+    [Test]
+    public void WorldToMapTransition_DoesNotSendMapResponse()
+    {
+        server.worldData.mapData[5] = [9, 9, 9];
+        server.worldData.mapCmds[5] = [ScheduledCommand.Serialize(new ScheduledCommand(CommandType.Designator, 10, 0, 5, 1, []))];
+        var (player, conn) = AddPlayer("player", -2);
+
+        var state = player.conn.GetState<ServerPlayingState>()!;
+        state.HandleClientCommand(new Multiplayer.Common.Networking.Packet.ClientCommandPacket(
+            CommandType.PlayerCount,
+            ScheduledCommand.Global,
+            ByteWriter.GetBytes(-2, 5)
+        ));
+
+        Assert.That(player.currentMapId, Is.EqualTo(5));
+        Assert.That(conn.SentPackets, Does.Not.Contain(Packets.Server_MapResponse));
+    }
+
+    [Test]
+    public void MapToMapTransition_DoesNotSendMapResponseWhenStreamingDisabled()
+    {
+        server.worldData.mapData[5] = [9, 9, 9];
+        server.worldData.mapCmds[5] = [ScheduledCommand.Serialize(new ScheduledCommand(CommandType.Designator, 10, 0, 5, 1, []))];
+        var (player, conn) = AddPlayer("player", 3);
+
+        var state = player.conn.GetState<ServerPlayingState>()!;
+        state.HandleClientCommand(new Multiplayer.Common.Networking.Packet.ClientCommandPacket(
+            CommandType.PlayerCount,
+            ScheduledCommand.Global,
+            ByteWriter.GetBytes(3, 5)
+        ));
+
+        Assert.That(player.currentMapId, Is.EqualTo(5));
+        Assert.That(conn.SentPackets, Does.Not.Contain(Packets.Server_MapResponse));
     }
 }


### PR DESCRIPTION
## Summary
Disable the new standalone map streaming path and fall back to the old sync behavior for standalone server sessions.

This keeps standalone server connections working linearly again:
- initial join works correctly
- entering a map works correctly
- going to the world and returning works correctly
- no standalone-specific MapResponse path is used

## What changed
- force `CanUseStandaloneMapStreaming(...)` to return `false`
- keep standalone server on the old broadcast-based sync path
- align the standalone tests with the disabled streaming behavior

## Why
The new standalone map streaming flow introduced client-side reload/resync issues during normal standalone-server play.

Falling back to the previous sync model restores the expected behavior while keeping the standalone server fully functional.

## Validation
- `dotnet build Source/Client/Multiplayer.csproj -c Release`
- `dotnet publish Source/Server/Server.csproj -c Release`
- `dotnet test Source/Tests/Tests.csproj --filter "FullyQualifiedName~StandaloneMapStreamingTest"`
- manual validation against the standalone server on the real game client
