### PR TITLE
fix gravship-multifaction-faction-context

### DIFF
--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -776,14 +776,11 @@ static class CompShuttle_ContainedColonistCount_Patch
 
 }
 
-
-[HarmonyPatch(typeof(WorldComponent_GravshipController),
-    "RemoveGravshipFromMap")]
+[HarmonyPatch(typeof(WorldComponent_GravshipController), nameof(WorldComponent_GravshipController.RemoveGravshipFromMap))]
 static class RemoveGravshipFromMap_Patch
 {
     static void Prefix(Building_GravEngine engine, out bool __state)
     {
-
         __state = false;
         if (Multiplayer.Client == null) return;
         if (!Multiplayer.GameComp.multifaction) return;
@@ -806,7 +803,6 @@ static class PlaceGravship_FactionContext_Patch
 {
     static void Prefix(Gravship gravship, Map map, out bool __state)
     {
-
         __state = false;
         if (Multiplayer.Client == null) return;
         if (!Multiplayer.GameComp.multifaction) return;

--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -775,3 +775,50 @@ static class CompShuttle_ContainedColonistCount_Patch
     }
 
 }
+
+
+[HarmonyPatch(typeof(WorldComponent_GravshipController),
+    "RemoveGravshipFromMap")]
+static class RemoveGravshipFromMap_Patch
+{
+    static void Prefix(Building_GravEngine engine, out bool __state)
+    {
+
+        __state = false;
+        if (Multiplayer.Client == null) return;
+        if (!Multiplayer.GameComp.multifaction) return;
+        if (engine == null) return;
+
+        engine.Map.PushFaction(engine.Faction);
+
+        __state = true;
+    }
+
+    static void Finalizer(Building_GravEngine engine, bool __state)
+    {
+        if (!__state) return;
+        engine.Map.PopFaction();
+    }
+}
+
+[HarmonyPatch(typeof(WorldComponent_GravshipController), nameof(WorldComponent_GravshipController.PlaceGravship))]
+static class PlaceGravship_FactionContext_Patch
+{
+    static void Prefix(Gravship gravship, Map map, out bool __state)
+    {
+
+        __state = false;
+        if (Multiplayer.Client == null) return;
+        if (!Multiplayer.GameComp.multifaction) return;
+
+        map.PushFaction(gravship.Faction);
+
+        __state = true;
+    }
+
+    static void Finalizer(Gravship gravship, Map map,bool __state)
+    {
+        if (!__state) return;
+        map.PopFaction();
+    }
+}


### PR DESCRIPTION
The GravShip logics working outside the tick system. It got raw faction context base on every player was playing. this makes differences on clients so everything got messed up. One example: each player got their own faction's area/zones onboard copied, but ignore others.
This PR patches the main logic with Faction Push/Pop so it can works correctly.