### PR TITLE
Raise fragmented init data limit for large mod lists

### DIFF
--- a/Source/Common/Networking/Packet/InitDataPacket.cs
+++ b/Source/Common/Networking/Packet/InitDataPacket.cs
@@ -14,6 +14,8 @@ public record struct ServerInitDataRequestPacket(bool includeConfigs) : IPacket
 [PacketDefinition(Packets.Client_InitData, allowFragmented: true)]
 public record struct ClientInitDataPacket : IPacket
 {
+    private const int MaxRawDataLength = ConnectionBase.MaxFragmentPacketTotalSize;
+
     public string rwVersion;
     public int[] debugOnlySyncCmds;
     public int[] hostOnlySyncCmds;
@@ -30,6 +32,6 @@ public record struct ClientInitDataPacket : IPacket
         buf.BindEnum(ref modCtorRoundMode);
         buf.BindEnum(ref staticCtorRoundMode);
         buf.Bind(ref defInfos, BinderOf.Identity<KeyedDefInfo>());
-        buf.BindRemaining(ref rawData);
+        buf.BindRemaining(ref rawData, maxLength: MaxRawDataLength);
     }
 }

--- a/Source/Common/Networking/Packet/InitDataPacket.cs
+++ b/Source/Common/Networking/Packet/InitDataPacket.cs
@@ -14,7 +14,10 @@ public record struct ServerInitDataRequestPacket(bool includeConfigs) : IPacket
 [PacketDefinition(Packets.Client_InitData, allowFragmented: true)]
 public record struct ClientInitDataPacket : IPacket
 {
-    private const int MaxRawDataLength = ConnectionBase.MaxFragmentPacketTotalSize;
+    // 1 MB limit — large mod lists can exceed the default 32 KB BindRemaining limit,
+    // but 32 MiB (MaxFragmentPacketTotalSize) is excessive.
+    // Subtract 6 bytes for SendFragmented's first-fragment overhead.
+    private const int MaxRawDataLength = (1 << 20) - 6;
 
     public string rwVersion;
     public int[] debugOnlySyncCmds;

--- a/Source/Common/Networking/Packet/InitDataPacket.cs
+++ b/Source/Common/Networking/Packet/InitDataPacket.cs
@@ -14,10 +14,8 @@ public record struct ServerInitDataRequestPacket(bool includeConfigs) : IPacket
 [PacketDefinition(Packets.Client_InitData, allowFragmented: true)]
 public record struct ClientInitDataPacket : IPacket
 {
-    // 1 MB limit — large mod lists can exceed the default 32 KB BindRemaining limit,
-    // but 32 MiB (MaxFragmentPacketTotalSize) is excessive.
-    // Subtract 6 bytes for SendFragmented's first-fragment overhead.
-    private const int MaxRawDataLength = (1 << 20) - 6;
+    // 1 MiB limit — large mod lists can exceed the default 32 KiB BindRemaining limit
+    private const int MaxRawDataLength = 1 << 20;
 
     public string rwVersion;
     public int[] debugOnlySyncCmds;


### PR DESCRIPTION
This PR raises the fragmented init data limit for large mod lists.

Why:
- the init data limit should still account for packet-size security guardrails
- but it also needs to allow legitimate large payloads such as big mod lists or larger files exchanged during initialization

What this change does:
- adjusts the limit calculation so the effective fragmented payload budget still respects the safety margin for packet size
- keeps the security guardrails in place instead of removing them
- allows initialization data that would otherwise be rejected even though it is valid and expected for large mod setups

Scope:
- standalone, isolated change in InitDataPacket
- independent from the standalone server PR stack