### PR TITLE
Fix RegisterSyncField(Type, string) to preserve caller targetType (#880)

### DIFF
--- a/Source/Client/Syncing/Sync.cs
+++ b/Source/Client/Syncing/Sync.cs
@@ -57,22 +57,27 @@ namespace Multiplayer.Client
 
         public static ISyncField RegisterSyncField(Type targetType, string fieldName)
         {
-            return RegisterSyncField(AccessTools.Field(targetType, fieldName));
-        }
+            FieldInfo field = AccessTools.Field(targetType, fieldName)
+                ?? throw new Exception($"Couldn't find field {targetType}::{fieldName}");
 
-        public static ISyncField RegisterSyncField(FieldInfo field)
-        {
-            string memberPath = field.ReflectedType + "/" + field.Name;
             SyncField sf;
+            string memberPath;
             if (field.IsStatic) {
+                memberPath = field.ReflectedType + "/" + field.Name;
                 sf = Field(null, null, memberPath);
             } else {
-                sf = Field(field.ReflectedType, null, field.Name);
+                memberPath = targetType + "/" + field.Name;
+                sf = Field(targetType, null, field.Name);
             }
 
             registeredSyncFields.Add(memberPath, sf);
 
             return sf;
+        }
+
+        public static ISyncField RegisterSyncField(FieldInfo field)
+        {
+            return RegisterSyncField(field.ReflectedType, field.Name);
         }
 
         public static SyncDelegate RegisterSyncDelegate(Type inType, string nestedType, string methodName, string[] fields = null, Type[] args = null)


### PR DESCRIPTION
## Summary

Fixes #880.

`MP.RegisterSyncField(Type, string)` currently routes through `RegisterSyncField(FieldInfo)`, which keys everything off `FieldInfo.ReflectedType`. Because `AccessTools.Field` walks the inheritance chain via `Type.GetField`, the returned `FieldInfo` for a private field declared on a base class comes back with `ReflectedType` collapsed to the base type — silently discarding the concrete `Type` the caller passed in.

Downstream, `SyncField` stores that base `targetType` (`SyncField.cs` L24-30), and `DoSync` serializes `target` as the base type (L47-52). Any `SyncWorker` registered against the concrete subclass then fails to match, because the wire format now references the base.

Concrete case that surfaced this: `Gizmo_Slider.targetValuePct` is declared on the base `Gizmo_Slider`. A compat patch calling `MP.RegisterSyncField(concreteSubclass, \"targetValuePct\")` ended up registered against `Gizmo_Slider` instead, breaking the subclass `SyncWorker` lookup. The Vanilla Gravship Expanded compat patch currently works around this with a reflection `SetValue` on the private `targetType` field (rwmt/Multiplayer-Compatibility#577); that workaround can be removed once this ships.

## Fix

- `RegisterSyncField(Type, string)` now looks up the `FieldInfo` only to validate existence and branch on static, but passes the caller's `targetType` straight through to `Sync.Field` and the `memberPath` key. The internal `Sync.Field(Type, string, string)` path already accepted an arbitrary `Type` — it just wasn't reachable from the public compat API.
- `RegisterSyncField(FieldInfo)` is collapsed into a one-line delegate to `(field.ReflectedType, field.Name)`, preserving its prior behavior exactly and eliminating the duplicated switch.
- Style matches the surrounding file: explicit `FieldInfo` declaration, `?? throw new Exception(...)` as in `Sync.Method`, K&R braces.

No behavior change for callers whose `targetType` equals the declaring type (the common case), or for any caller of the `FieldInfo` overload.

## Test plan

- [x] `dotnet build Source/Client/Multiplayer.csproj -c Release` — 0 errors
- [x] In-game: VGE oxygen regulator slider syncs across clients without the compat-side `SetValue` workaround
- [x] Regression spot-check of existing `RegisterSyncField(Type, string)` callers in Multiplayer-Compatibility (Pharmacist, AnimalTab, SRTS Expanded, VEF autocast) — where `targetType` already equals the declaring type, behavior is unchanged
- [x] Regression spot-check of `RegisterSyncField(FieldInfo)` callers (CommonSense, VanillaHairExpanded) — routes through the same path as before via `ReflectedType`