### PR TITLE
Fix/shuttle quest colonist register

### DIFF
--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -761,7 +761,7 @@ static class CompShuttle_ContainedColonistCount_Patch
             yield return ci;
         }
     }
-    static bool IsFreeColonistAnyPlayerFaction(Pawn pawn)
+    public static bool IsFreeColonistAnyPlayerFaction(Pawn pawn)
     {
         if (Multiplayer.Client == null || !Multiplayer.GameComp.multifaction)
             return pawn.IsFreeColonist;
@@ -816,5 +816,25 @@ static class PlaceGravship_FactionContext_Patch
     {
         if (!__state) return;
         map.PopFaction();
+    }
+}
+
+[HarmonyPatch(typeof(QuestPart_LendColonistsToFaction), "Enable")]
+static class QuestPart_LendColonistsToFaction_Enable_Patch
+{
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
+    {
+        var isFreeColonist = AccessTools.PropertyGetter(typeof(Pawn), nameof(Pawn.IsFreeColonist));
+        var replacement = AccessTools.Method(typeof(CompShuttle_ContainedColonistCount_Patch),
+            nameof(CompShuttle_ContainedColonistCount_Patch.IsFreeColonistAnyPlayerFaction));
+        foreach (var ci in insts)
+        {
+            if (ci.Calls(isFreeColonist))
+            {
+                ci.opcode = OpCodes.Call;
+                ci.operand = replacement;
+            }
+            yield return ci;
+        }
     }
 }


### PR DESCRIPTION
Extending fix about shuttle launch in MultiFaction.

This raise me 2 more opinions about fixing it:
1. Since the quests are ticking with Spectator faction context (or maybe not push so Spectator as default?), we let IsFreeColonist check for Spectator accept all playerfaction's pawn, this can fix any further quests that checking pawns faction. but It's abit deep in codes so I'm not sure if there's something broken in other place.
2. Or we push/pop faction when ticking quests, this should also fix but need more works on some strange situaion, like preventing faction'B's pawn to get in shuttle that belongs to quest for playerA and get disappeared when the shuttle is back because it's not belongs to playerA and not registered to be back with shuttle.