### PR TITLE
fix PathGridDoorsBlockedJob race: snapshot pawn positions before job …

### DIFF
--- a/Source/Client/Patches/Determinism.cs
+++ b/Source/Client/Patches/Determinism.cs
@@ -665,6 +665,82 @@ namespace Multiplayer.Client.Patches
         }
     }
 
+    // PathGridDoorsBlockedJob is a cross-tick Unity Job: scheduled at end of MapPreTick(N),
+    // completes at start of MapPreTick(N+1). During MapTick(N) it runs concurrently on a
+    // worker thread and reads live pawn.Position while the main thread writes
+    // pawn.Position = nextCell in Pawn_PathFollower.PatherTick(). Host and client see
+    // different enemy positions depending on thread scheduling → different blocked cells →
+    // different A* path → different nextCell for the pathing pawn → WillCollideNextCell
+    // differs → one client enters the attack branch → ChooseMeleeVerb → Rand.Chance → desync.
+    //
+    // Fix: snapshot all cached pawn positions on the main thread right after
+    // ScheduleBatchedPathJobs (still inside MapPreTick, before any pawn ticking).
+    // Worker threads reading pawn.Position during Execute() get the stable snapshot.
+    static class PawnPositionSnapshot
+    {
+        // Written once per tick on the main thread before jobs are dispatched;
+        // read concurrently by worker threads. Dictionary is safe for concurrent reads.
+        static readonly Dictionary<Pawn, IntVec3> snapshot = new();
+
+        public static void Rebuild(IReadOnlyList<Pawn> pawns)
+        {
+            snapshot.Clear();
+            foreach (var pawn in pawns)
+                snapshot[pawn] = pawn.Position;
+        }
+
+        public static bool TryGet(Pawn pawn, out IntVec3 pos) =>
+            snapshot.TryGetValue(pawn, out pos);
+    }
+
+    [HarmonyPatch(typeof(PathFinder), "ScheduleBatchedPathJobs")]
+    static class ScheduleBatchedPathJobsSnapshotPositions
+    {
+        static readonly FieldInfo CachedPawns =
+            AccessTools.Field(typeof(PathFinder), "cachedPawns");
+
+        static void Prefix(PathFinder __instance)
+        {
+            if (Multiplayer.Client == null) return;
+            // Snapshot pawn positions immediately before PathGridDoorsBlockedJob is
+            // dispatched so worker threads read stable positions instead of live ones.
+            PawnPositionSnapshot.Rebuild((IReadOnlyList<Pawn>)CachedPawns.GetValue(__instance));
+        }
+    }
+
+    [HarmonyPatch]
+    static class PathGridDoorsBlockedJobPositionPatch
+    {
+        static readonly MethodInfo PositionGetter =
+            AccessTools.PropertyGetter(typeof(Thing), nameof(Thing.Position));
+
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(PathGridDoorsBlockedJob), "Execute");
+            yield return AccessTools.Method(typeof(PathGridDoorsBlockedJob), "CanBlockEver");
+        }
+
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
+        {
+            foreach (var inst in insts)
+            {
+                if (inst.Calls(PositionGetter))
+                    inst.operand = AccessTools.Method(
+                        typeof(PathGridDoorsBlockedJobPositionPatch), nameof(GetPosition));
+                yield return inst;
+            }
+        }
+
+        internal static IntVec3 GetPosition(Thing thing)
+        {
+            if (Multiplayer.Client != null
+                && thing is Pawn pawn
+                && PawnPositionSnapshot.TryGet(pawn, out IntVec3 pos))
+                return pos;
+            return thing.Position;
+        }
+    }
+
     [HarmonyPatch(typeof(MainTabWindow), nameof(MainTabWindow.SetInitialSizeAndPosition))]
     static class MainTabWindow_NoResizingInSimulation
     {


### PR DESCRIPTION
fix for https://discord.com/channels/524286515644203028/568070216626470922/1493717766006374552
played for 1 day and haven't met a desync during compats yet. the deep-copy seems not affecting performance very much, I didn't really noticed the tps drop so maybe need to use performance analyser to judge this.

I also have a version that logging whether the postion changed in tick or threads read it first. And I'd put my test results here too.
Host side:
Threads read first. for my save when I got manhunting incident with 100 wolfs can see the ticks run first for many of them. 
Client side:
mostly threads read first, but still sometimes got ticks run first without a battle, I believe this is why sometimes we observe a wild animal trigger a desync randomly.
multithread issues got random chance happening due to player's computer set, so I can only say that it triggers a bit often on my enviroment.