### PR TITLE
Add modVersion to About.xml

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -7,6 +7,7 @@
   </supportedVersions>
   <author>RimWorld Multiplayer Team</author>
   <url>https://github.com/rwmt/Multiplayer</url>
+  <modVersion></modVersion> <!-- filled out by workshop_bundler.sh -->
   <description>&lt;b&gt;Important: This mod should be placed right below Core and expansions in the mod list to work properly!
 Requires RimWorld >= 1.6.4491&lt;/b&gt;\n
 Multiplayer mod for RimWorld.

--- a/workshop_bundler.sh
+++ b/workshop_bundler.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-
-
 VERSION=$(grep -Po '(?<=SimpleVersion = ")[0-9\.]+' Source/Common/Version.cs)
 
 git submodule update --init --recursive || { echo 'git submodule update FAILED' ; exit 1; }
@@ -30,10 +28,16 @@ cat <<EOF > LoadFolders.xml
 </loadFolders>
 EOF
 
-
+GIT_COMMIT=$(git rev-parse --short HEAD 2>&1)
+GIT_COMMIT_STATUS=$?
+if [ $GIT_COMMIT_STATUS -eq 0 ]; then
+  FULL_VERSION="${VERSION} (${GIT_COMMIT})"
+else
+  FULL_VERSION="${VERSION}"
+  echo "WARN: Failed to check git commit: ${GIT_COMMIT}"
+fi
 sed -i "/<supportedVersions>/ a \ \ \ \ <li>1.5</li>" About/About.xml
-sed -i "/Multiplayer mod for RimWorld./aThis is version ${VERSION}." About/About.xml
-sed -i "s/<version>.*<\/version>\$/<version>${VERSION}<\/version>/" About/Manifest.xml
+sed -i "s/<modVersion>.*<\/modVersion>.*\$/<modVersion>${FULL_VERSION}<\/modVersion>/" About/About.xml
 
 # The current version
 mkdir -p 1.6


### PR DESCRIPTION
Includes the simple version (x.y.z) and a short commit hash if available.

Removes `<version>` from About/Manifest.xml as About.xml has support for it since 1.5 and is the standard way to add version info.

<img width="291" height="185" alt="image" src="https://github.com/user-attachments/assets/4f1585d8-8404-49c3-9f24-f58fada410b6" />
