### PR TITLE
Remove desyncTracesFromHost from MultiplayerSession

### DIFF
--- a/Source/Client/Desyncs/SaveableDesyncInfo.cs
+++ b/Source/Client/Desyncs/SaveableDesyncInfo.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using HarmonyLib;
+using JetBrains.Annotations;
 using Multiplayer.Common;
 using Multiplayer.Common.Util;
 using RimWorld;
@@ -31,7 +32,7 @@ public class SaveableDesyncInfo(
 
     public bool ReadyToSave => metadata.IsCompleted && replay.IsCompleted;
 
-    public void Save()
+    public void Save([CanBeNull] HostInfo hostInfo)
     {
         var watch = Stopwatch.StartNew();
 
@@ -43,10 +44,10 @@ public class SaveableDesyncInfo(
             zip.AddEntry("desync_info", GetDesyncDetails());
 
             zip.AddEntry("local_traces.txt", GetLocalTraces());
-            zip.AddEntry("host_traces.txt", Multiplayer.session.desyncTracesFromHost ?? "No host traces");
+            zip.AddEntry("host_traces.txt", hostInfo?.Traces ?? "No host traces");
 
             zip.AddEntry("local_jitted_methods.txt", JittedMethods.GetJittedMethodsString());
-            zip.AddEntry("host_jitted_methods.txt", Multiplayer.session.jittedMethodsFromHost ?? "No host jitted methods");
+            zip.AddEntry("host_jitted_methods.txt", hostInfo?.JittedMethods ?? "No host jitted methods");
 
             var extraLogs = LogGenerator.PrepareLogData();
             if (extraLogs != null) zip.AddEntry("local_logs.txt", extraLogs);
@@ -193,4 +194,6 @@ public class SaveableDesyncInfo(
         {
         }
     }
+
+    public record HostInfo([CanBeNull] string Traces, [CanBeNull] string JittedMethods);
 }

--- a/Source/Client/Desyncs/SyncCoordinator.cs
+++ b/Source/Client/Desyncs/SyncCoordinator.cs
@@ -127,7 +127,6 @@ namespace Multiplayer.Client
 
             var diffAt = FindTraceHashesDiffTick(local, remote, out var found);
             Multiplayer.Client.Send(new ClientDesyncedPacket(local.startTick, diffAt));
-            Multiplayer.session.desyncTracesFromHost = null;
 
             MpUI.ClearWindowStack();
             Find.WindowStack.Add(new DesyncedWindow(

--- a/Source/Client/Networking/State/ClientPlayingState.cs
+++ b/Source/Client/Networking/State/ClientPlayingState.cs
@@ -194,8 +194,10 @@ namespace Multiplayer.Client
             }
             else if (packet.mode == ServerTracesPacket.Mode.Transfer)
             {
-                Multiplayer.session.desyncTracesFromHost = GZipStream.UncompressString(packet.rawTraces);
-                Multiplayer.session.jittedMethodsFromHost = GZipStream.UncompressString(packet.rawJittedMethods);
+                var traces = GZipStream.UncompressString(packet.rawTraces);
+                var jittedMethods = GZipStream.UncompressString(packet.rawJittedMethods);
+                var hostInfo = new SaveableDesyncInfo.HostInfo(traces, jittedMethods);
+                Find.WindowStack.WindowOfType<DesyncedWindow>()?.HandleHostDesyncInfo(hostInfo);
             }
         }
 

--- a/Source/Client/Session/MultiplayerSession.cs
+++ b/Source/Client/Session/MultiplayerSession.cs
@@ -32,8 +32,6 @@ namespace Multiplayer.Client
         public PlayerCursors playerCursors = new();
         public int autosaveCounter;
         public float? lastSaveAt;
-        public string desyncTracesFromHost;
-        public string jittedMethodsFromHost;
         public List<ClientSyncOpinion> initialOpinions = new();
 
         public bool replay;

--- a/Source/Client/Windows/DesyncedWindow.cs
+++ b/Source/Client/Windows/DesyncedWindow.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using Multiplayer.Client.Desyncs;
 using Multiplayer.Client.Util;
 using Multiplayer.Common;
@@ -18,6 +19,7 @@ namespace Multiplayer.Client
         private float openedAt;
         private bool infoWritten;
         private bool rejoining;
+        [CanBeNull] private SaveableDesyncInfo.HostInfo hostInfo;
 
         public DesyncedWindow(string text, SaveableDesyncInfo desyncInfo)
         {
@@ -55,6 +57,7 @@ namespace Multiplayer.Client
             float x = 0;
             if (Widgets.ButtonText(new Rect(x, 0, 120, 35), "MpTryResync".Translate()) && !rejoining)
             {
+                rejoining = true;
                 Log.Message("Multiplayer: requesting rejoin");
                 Rejoiner.DoRejoin();
             }
@@ -66,7 +69,7 @@ namespace Multiplayer.Client
             x += 120 + 10;
 
             if (Widgets.ButtonText(new Rect(x, 0, 120, 35), "MpChatButton".Translate()))
-                Find.WindowStack.Add(new ChatWindow()
+                Find.WindowStack.Add(new ChatWindow
                 {
                     closeOnClickedOutside = true,
                     absorbInputAroundWindow = true,
@@ -90,14 +93,19 @@ namespace Multiplayer.Client
             GUI.EndGroup();
         }
 
+        public void HandleHostDesyncInfo(SaveableDesyncInfo.HostInfo hostInfo)
+        {
+            this.hostInfo = hostInfo;
+        }
+
         public override void WindowUpdate()
         {
             const float maxWait = 5f;
 
-            var shouldWrite = Multiplayer.session?.desyncTracesFromHost != null || Time.realtimeSinceStartup - openedAt > maxWait;
+            var shouldWrite = hostInfo != null || Time.realtimeSinceStartup - openedAt > maxWait;
             if (!infoWritten && shouldWrite && desyncInfo.ReadyToSave)
             {
-                desyncInfo.Save();
+                desyncInfo.Save(hostInfo);
                 infoWritten = true;
             }
         }


### PR DESCRIPTION
It's only used for the DesyncedWindow, so just directly pass it there instead of using global state