### PR TITLE
Add ConnectionBase.ChangeState(MpConnectionState) and introduce state-passing through that

### DIFF
--- a/Source/Client/Networking/ClientUtil.cs
+++ b/Source/Client/Networking/ClientUtil.cs
@@ -12,8 +12,7 @@ namespace Multiplayer.Client
     {
         public static void TryConnectWithWindow(IConnector connector, bool returnToServerBrowser = true)
         {
-            var (conn, window) = connector.Connect();
-            conn.username = Multiplayer.username;
+            var (conn, window) = connector.Connect(Multiplayer.username);
 
             Multiplayer.session = new MultiplayerSession
             {

--- a/Source/Client/Networking/NetworkingLiteNet.cs
+++ b/Source/Client/Networking/NetworkingLiteNet.cs
@@ -25,9 +25,9 @@ namespace Multiplayer.Client.Networking
             }
         }
 
-        public static ClientLiteNetConnection Connect(string address, int port)
+        public static ClientLiteNetConnection Connect(string address, int port, string username)
         {
-            var netClient = new NetManager(new NetListener())
+            var netClient = new NetManager(new NetListener(username))
             {
                 EnableStatistics = true,
                 IPv6Enabled = MpUtil.SupportsIPv6(),
@@ -56,14 +56,15 @@ namespace Multiplayer.Client.Networking
             netManager.Stop();
         }
 
-        private class NetListener : INetEventListener
+        private class NetListener(string username) : INetEventListener
         {
             private ClientLiteNetConnection GetConnection(NetPeer peer) =>
                 peer.GetConnection() as ClientLiteNetConnection ?? throw new Exception("Can't get connection");
 
             public void OnPeerConnected(NetPeer peer)
             {
-                GetConnection(peer).ChangeState(ConnectionStateEnum.ClientJoining);
+                var conn = GetConnection(peer);
+                conn.ChangeState(new ClientJoiningState(conn, username));
                 MpLog.Log("Net client connected");
             }
 

--- a/Source/Client/Networking/NetworkingSteam.cs
+++ b/Source/Client/Networking/NetworkingSteam.cs
@@ -55,9 +55,9 @@ namespace Multiplayer.Client.Networking
 
     public class SteamClientConn : SteamBaseConn, ITickableConnection
     {
-        public SteamClientConn(CSteamID remoteId) : base(remoteId, RandomChannelId(), 0)
+        public SteamClientConn(CSteamID remoteId, string username) : base(remoteId, RandomChannelId(), 0)
         {
-            ChangeState(ConnectionStateEnum.ClientSteam);
+            ChangeState(new ClientSteamState(this, username));
         }
 
         static ushort RandomChannelId() => (ushort)new Random().Next();

--- a/Source/Client/Networking/State/ClientJoiningState.cs
+++ b/Source/Client/Networking/State/ClientJoiningState.cs
@@ -9,14 +9,9 @@ using Verse;
 
 namespace Multiplayer.Client
 {
-
     [PacketHandlerClass(inheritHandlers: false)]
-    public class ClientJoiningState : ClientBaseState
+    public class ClientJoiningState(ConnectionBase connection, string username) : ClientBaseState(connection)
     {
-        public ClientJoiningState(ConnectionBase connection) : base(connection)
-        {
-        }
-
         [TypedPacketHandler]
         public new void HandleDisconnected(ServerDisconnectPacket packet) => base.HandleDisconnected(packet);
 
@@ -38,14 +33,14 @@ namespace Multiplayer.Client
             if (packet.hasPassword)
             {
                 // Delay showing the window for better UX
-                OnMainThread.Schedule(() => Find.WindowStack.Add(new GamePasswordWindow
+                OnMainThread.Schedule(() => Find.WindowStack.Add(new GamePasswordWindow(username)
                 {
                     returnToServerBrowser = Find.WindowStack.WindowOfType<BaseConnectingWindow>().returnToServerBrowser
                 }), 0.3f);
             }
             else
             {
-                connection.Send(new ClientUsernamePacket(Multiplayer.username));
+                connection.Send(new ClientUsernamePacket(username));
             }
         }
 
@@ -68,8 +63,9 @@ namespace Multiplayer.Client
             {
                 modCtorRoundMode = MultiplayerData.modCtorRoundMode,
                 staticCtorRoundMode = MultiplayerData.staticCtorRoundMode,
-                defInfos = MultiplayerData.localDefInfos.Select(kv => new KeyedDefInfo
-                    { name = kv.Key, count = kv.Value.count, hash = kv.Value.hash }).ToArray()
+                defInfos = MultiplayerData.localDefInfos
+                    .Select(kv => new KeyedDefInfo { name = kv.Key, count = kv.Value.count, hash = kv.Value.hash })
+                    .ToArray()
             }.Serialize());
 
         [TypedPacketHandler]

--- a/Source/Client/Networking/State/ClientSteamState.cs
+++ b/Source/Client/Networking/State/ClientSteamState.cs
@@ -5,18 +5,19 @@ namespace Multiplayer.Client
 {
     public class ClientSteamState : MpConnectionState
     {
-        public ClientSteamState(ConnectionBase connection) : base(connection)
-        {
-            var steamConn = connection as SteamBaseConn;
+        private readonly string username;
 
+        public ClientSteamState(SteamBaseConn conn, string username) : base(conn)
+        {
+            this.username = username;
             // The flag byte is: joinPacket | reliable | hasChannel
-            steamConn.SendRawSteam(ByteWriter.GetBytes((byte)0b111, steamConn.recvChannel), true);
+            conn.SendRawSteam(ByteWriter.GetBytes((byte)0b111, conn.recvChannel), true);
         }
 
         [PacketHandler(Packets.Server_SteamAccept)]
         public void HandleSteamAccept(ByteReader data)
         {
-            connection.ChangeState(ConnectionStateEnum.ClientJoining);
+            connection.ChangeState(new ClientJoiningState(connection, username));
         }
     }
 

--- a/Source/Client/Session/Rejoiner.cs
+++ b/Source/Client/Session/Rejoiner.cs
@@ -12,7 +12,6 @@ public static class Rejoiner
         Multiplayer.Client.Send(Packets.Client_RequestRejoin);
 
         Multiplayer.Client.ChangeState(ConnectionStateEnum.ClientLoading);
-        Multiplayer.Client.GetState<ClientLoadingState>()!.subState = LoadingState.Waiting;
         Multiplayer.Client.Lenient = true;
 
         Multiplayer.session.desynced = false;

--- a/Source/Client/Util/ConnectorRegistry.cs
+++ b/Source/Client/Util/ConnectorRegistry.cs
@@ -12,7 +12,7 @@ public interface IConnector
 {
     /// Does include the connector's prefix.
     public string GetConnectionString();
-    public (ConnectionBase, BaseConnectingWindow) Connect();
+    public (ConnectionBase, BaseConnectingWindow) Connect(string username);
 }
 
 /// Utility class for creating connectors and parsing them from a string based on their unique prefix.
@@ -61,8 +61,8 @@ public class SteamConnector(CSteamID remoteId) : IConnector
 
     public string GetConnectionString() => $"{Prefix}:{remoteId}";
 
-    public (ConnectionBase, BaseConnectingWindow) Connect() =>
-        (new SteamClientConn(remoteId), new SteamConnectingWindow(remoteId));
+    public (ConnectionBase, BaseConnectingWindow) Connect(string username) =>
+        (new SteamClientConn(remoteId, username), new SteamConnectingWindow(remoteId));
 }
 
 public class LiteNetConnector(string address, int port) : IConnector
@@ -97,6 +97,6 @@ public class LiteNetConnector(string address, int port) : IConnector
 
     public string GetConnectionString() => $"{Prefix}:{address}:{port}";
 
-    public (ConnectionBase, BaseConnectingWindow) Connect() =>
-        (ClientLiteNetConnection.Connect(address, port), new ConnectingWindow(address, port));
+    public (ConnectionBase, BaseConnectingWindow) Connect(string username) =>
+        (ClientLiteNetConnection.Connect(address, port, username), new ConnectingWindow(address, port));
 }

--- a/Source/Client/Windows/GamePasswordWindow.cs
+++ b/Source/Client/Windows/GamePasswordWindow.cs
@@ -6,9 +6,11 @@ namespace Multiplayer.Client;
 public class GamePasswordWindow : AbstractTextInputWindow
 {
     public bool returnToServerBrowser;
+    private readonly string username;
 
-    public GamePasswordWindow()
+    public GamePasswordWindow(string username)
     {
+        this.username = username;
         title = "MpGamePassword".Translate();
         doCloseX = false;
         closeOnCancel = false;
@@ -20,7 +22,7 @@ public class GamePasswordWindow : AbstractTextInputWindow
 
     public override bool Accept()
     {
-        Multiplayer.Client.Send(new ClientUsernamePacket(Multiplayer.username, curText));
+        Multiplayer.Client.Send(new ClientUsernamePacket(username, curText));
         Close(false);
         return true;
     }

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -25,12 +25,7 @@ namespace Multiplayer.Common
                 StateObj.alive = false;
 
             State = state;
-
-            if (State == ConnectionStateEnum.Disconnected)
-                StateObj = null;
-            else
-                StateObj = (MpConnectionState)Activator.CreateInstance(MpConnectionState.stateImpls[(int)state], this);
-
+            StateObj = MpConnectionState.CreateState(state, this);
             StateObj?.StartState();
         }
 

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -6,6 +6,7 @@ namespace Multiplayer.Common
 {
     public abstract class ConnectionBase
     {
+        /// Available ONLY server-side. Always null client-side.
         public string? username;
         public ServerPlayer? serverPlayer;
 

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -19,6 +19,16 @@ namespace Multiplayer.Common
 
         public T? GetState<T>() where T : MpConnectionState => (T?)StateObj;
 
+        public void ChangeState(MpConnectionState state)
+        {
+            if (StateObj != null)
+                StateObj.alive = false;
+
+            State = MpConnectionState.GetStateEnumOf(state);
+            StateObj = state;
+            StateObj?.StartState();
+        }
+
         public void ChangeState(ConnectionStateEnum state)
         {
             if (StateObj != null)

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -17,8 +17,6 @@ namespace Multiplayer.Common
         // This is set during rejoining and is usually caused by connection state mismatch.
         public bool Lenient { get; set; }
 
-        public T? GetState<T>() where T : MpConnectionState => (T?)StateObj;
-
         public void ChangeState(MpConnectionState state)
         {
             if (StateObj != null)

--- a/Source/Common/Networking/MpConnectionState.cs
+++ b/Source/Common/Networking/MpConnectionState.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Multiplayer.Common.Networking.Packet;
-using Verse;
 
 namespace Multiplayer.Common
 {

--- a/Source/Common/Networking/MpConnectionState.cs
+++ b/Source/Common/Networking/MpConnectionState.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Multiplayer.Common.Networking.Packet;
+using Verse;
 
 namespace Multiplayer.Common
 {
@@ -29,6 +30,14 @@ namespace Multiplayer.Common
 
         private static PacketHandlerInfo?[,] packetHandlers =
             new PacketHandlerInfo?[(int)ConnectionStateEnum.Count, (int)Packets.Count];
+
+        public static ConnectionStateEnum GetStateEnumOf(MpConnectionState state)
+        {
+            var stateType = state.GetType();
+            var index = Array.IndexOf(StateImpls, stateType);
+            if (index == -1) throw new Exception($"Tried to get state enum of unrecognized connection state: {state} ({stateType})");
+            return (ConnectionStateEnum)index;
+        }
 
         public static MpConnectionState? CreateState(ConnectionStateEnum state, ConnectionBase conn) =>
             state == ConnectionStateEnum.Disconnected

--- a/Source/Common/Networking/MpConnectionState.cs
+++ b/Source/Common/Networking/MpConnectionState.cs
@@ -25,16 +25,21 @@ namespace Multiplayer.Common
         public virtual PacketHandlerInfo? GetPacketHandler(Packets id) =>
             packetHandlers[(int)connection.State, (int)id];
 
-        public static Type[] stateImpls = new Type[(int)ConnectionStateEnum.Count];
+        private static readonly Type[] StateImpls = new Type[(int)ConnectionStateEnum.Count];
 
         private static PacketHandlerInfo?[,] packetHandlers =
             new PacketHandlerInfo?[(int)ConnectionStateEnum.Count, (int)Packets.Count];
+
+        public static MpConnectionState? CreateState(ConnectionStateEnum state, ConnectionBase conn) =>
+            state == ConnectionStateEnum.Disconnected
+                ? null
+                : (MpConnectionState)Activator.CreateInstance(StateImpls[(int)state], conn);
 
         public static void SetImplementation(ConnectionStateEnum state, Type type)
         {
             if (!type.IsSubclassOf(typeof(MpConnectionState))) return;
 
-            stateImpls[(int)state] = type;
+            StateImpls[(int)state] = type;
 
             // The point of this attribute is to explicitly mark how to handle packet listeners from the base type.
             // If the base type is the lowest possible (MpConnectionState, which doesn't have any listeners), there is

--- a/Source/Tests/Helper/Utils.cs
+++ b/Source/Tests/Helper/Utils.cs
@@ -1,0 +1,8 @@
+using Multiplayer.Common;
+
+namespace Tests;
+
+public static class Utils
+{
+    public static T? GetState<T>(this ConnectionBase connection) where T : MpConnectionState => (T?)connection.StateObj;
+}

--- a/Source/Tests/StandaloneMapStreamingTest.cs
+++ b/Source/Tests/StandaloneMapStreamingTest.cs
@@ -1,4 +1,5 @@
 using Multiplayer.Common;
+using Multiplayer.Common.Networking.Packet;
 
 namespace Tests;
 
@@ -93,7 +94,7 @@ public class StandaloneMapStreamingTest
         var (player, conn) = AddPlayer("player", -1, hasReportedCurrentMap: false);
 
         var state = player.conn.GetState<ServerPlayingState>()!;
-        state.HandleClientCommand(new Multiplayer.Common.Networking.Packet.ClientCommandPacket(
+        state.HandleClientCommand(new ClientCommandPacket(
             CommandType.PlayerCount,
             ScheduledCommand.Global,
             ByteWriter.GetBytes(-1, 5)
@@ -112,7 +113,7 @@ public class StandaloneMapStreamingTest
         var (player, conn) = AddPlayer("player", -2);
 
         var state = player.conn.GetState<ServerPlayingState>()!;
-        state.HandleClientCommand(new Multiplayer.Common.Networking.Packet.ClientCommandPacket(
+        state.HandleClientCommand(new ClientCommandPacket(
             CommandType.PlayerCount,
             ScheduledCommand.Global,
             ByteWriter.GetBytes(-2, 5)
@@ -130,7 +131,7 @@ public class StandaloneMapStreamingTest
         var (player, conn) = AddPlayer("player", 3);
 
         var state = player.conn.GetState<ServerPlayingState>()!;
-        state.HandleClientCommand(new Multiplayer.Common.Networking.Packet.ClientCommandPacket(
+        state.HandleClientCommand(new ClientCommandPacket(
             CommandType.PlayerCount,
             ScheduledCommand.Global,
             ByteWriter.GetBytes(3, 5)


### PR DESCRIPTION
Only use the new ChangeState to pass around username for now. Should generally help to properly scope data to a given state and slightly reduce reliance on reflection.