### PR TITLE
Remove MultiplayerSession.initialOpinions

### DIFF
--- a/Source/Client/MultiplayerGame.cs
+++ b/Source/Client/MultiplayerGame.cs
@@ -1,6 +1,3 @@
-using Multiplayer.Client.Desyncs;
-using RimWorld;
-using RimWorld.BaseGen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -8,7 +5,10 @@ using LudeonTK;
 using Multiplayer.API;
 using Multiplayer.Client.AsyncTime;
 using Multiplayer.Client.Comp;
+using Multiplayer.Client.Desyncs;
 using Multiplayer.Client.Factions;
+using RimWorld;
+using RimWorld.BaseGen;
 using UnityEngine;
 using Verse;
 
@@ -75,10 +75,6 @@ namespace Multiplayer.Client
                     edgeThing.randomRotations = new List<int>() { 0, 1, 2, 3 };
 
             typeof(SymbolResolver_SingleThing).TypeInitializer.Invoke(null, null);
-
-            foreach (var initialOpinion in Multiplayer.session.initialOpinions)
-                sync.AddClientOpinionAndCheckDesync(initialOpinion);
-            Multiplayer.session.initialOpinions.Clear();
 
             FactionCreator.ClearData();
         }

--- a/Source/Client/Networking/State/ClientLoadingState.cs
+++ b/Source/Client/Networking/State/ClientLoadingState.cs
@@ -119,11 +119,12 @@ public class ClientLoadingState(ConnectionBase connection) : ClientBaseState(con
         TickPatch.serverFrozen = serverFrozen;
 
         int syncInfos = data.ReadInt32();
+        var initialOpinions = new List<ClientSyncOpinion>(syncInfos);
         for (int i = 0; i < syncInfos; i++)
-            Session.initialOpinions.Add(ClientSyncOpinion.Deserialize(new ByteReader(data.ReadPrefixedBytes())));
+            initialOpinions.Add(ClientSyncOpinion.Deserialize(new ByteReader(data.ReadPrefixedBytes())));
 
         Log.Message(syncInfos > 0
-            ? $"Initial sync opinions: {Session.initialOpinions.First().startTick}...{Session.initialOpinions.Last().startTick}"
+            ? $"Initial sync opinions: {initialOpinions.First().startTick}...{initialOpinions.Last().startTick}"
             : "No initial sync opinions");
 
         TickPatch.SetSimulation(
@@ -134,7 +135,13 @@ public class ClientLoadingState(ConnectionBase connection) : ClientBaseState(con
         );
 
         Stopwatch watch = Stopwatch.StartNew();
-        Loader.ReloadGame(mapsToLoad, true, false);
+        Loader.ReloadGame(mapsToLoad, true, () =>
+        {
+            foreach (var opinion in initialOpinions)
+            {
+                Multiplayer.game.sync.AddClientOpinionAndCheckDesync(opinion);
+            }
+        });
         var loadingMs = watch.ElapsedMilliseconds;
         Log.Message($"Loaded game in {loadingMs}ms");
         connection.ChangeState(ConnectionStateEnum.ClientPlaying);

--- a/Source/Client/Saving/Loader.cs
+++ b/Source/Client/Saving/Loader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using HarmonyLib;
@@ -10,11 +11,17 @@ namespace Multiplayer.Client.Saving;
 
 public static class Loader
 {
-    public static void ReloadGame(List<int> mapsToLoad, bool changeScene, bool forceAsyncTime)
+    public static void ReloadGame(List<int> mapsToLoad, bool changeScene, bool forceAsyncTime) => ReloadGame(mapsToLoad,
+        changeScene, () =>
+        {
+            if (forceAsyncTime) Multiplayer.game.gameComp.asyncTime = true;
+        });
+
+    public static void ReloadGame(List<int> mapsToLoad, bool changeScene, Action customPostLoadAction)
     {
         var gameDoc = DataSnapshotToXml(Multiplayer.session.dataSnapshot, mapsToLoad);
 
-        LoadPatch.gameToLoad = new(gameDoc, Multiplayer.session.dataSnapshot.SessionData);
+        LoadPatch.gameToLoad = new TempGameData(gameDoc, Multiplayer.session.dataSnapshot.SessionData);
         TickPatch.replayTimeSpeed = TimeSpeed.Paused;
 
         if (changeScene)
@@ -32,7 +39,11 @@ public static class Loader
 
                 LongEventHandler.ExecuteWhenFinished(() =>
                 {
-                    LongEventHandler.QueueLongEvent(() => PostLoad(forceAsyncTime), "MpSimulating", false, null);
+                    LongEventHandler.QueueLongEvent(() =>
+                    {
+                        PostLoad();
+                        customPostLoadAction();
+                    }, "MpSimulating", false, null);
                 });
             }, "Play", "MpLoading", true, null);
         }
@@ -41,12 +52,13 @@ public static class Loader
             LongEventHandler.QueueLongEvent(() =>
             {
                 SaveLoad.LoadInMainThread(LoadPatch.gameToLoad);
-                PostLoad(forceAsyncTime);
+                PostLoad();
+                customPostLoadAction();
             }, "MpLoading", false, null);
         }
     }
 
-    private static void PostLoad(bool forceAsyncTime)
+    private static void PostLoad()
     {
         // If the client gets disconnected during loading
         if (Multiplayer.Client == null) return;
@@ -63,12 +75,8 @@ public static class Loader
         );
         Multiplayer.game.myFactionLoading = null;
 
-        if (forceAsyncTime)
-            Multiplayer.game.gameComp.asyncTime = true;
-
         Multiplayer.AsyncWorldTime.cmds = new Queue<ScheduledCommand>(
-            Multiplayer.session.dataSnapshot.MapCmds.GetValueSafe(ScheduledCommand.Global) ??
-            new List<ScheduledCommand>());
+            Multiplayer.session.dataSnapshot.MapCmds.GetValueSafe(ScheduledCommand.Global) ?? []);
         // Map cmds are added in MapAsyncTimeComp.FinalizeInit
     }
 

--- a/Source/Client/Session/MultiplayerSession.cs
+++ b/Source/Client/Session/MultiplayerSession.cs
@@ -32,7 +32,6 @@ namespace Multiplayer.Client
         public PlayerCursors playerCursors = new();
         public int autosaveCounter;
         public float? lastSaveAt;
-        public List<ClientSyncOpinion> initialOpinions = new();
 
         public bool replay;
         public int replayTimerStart = -1;


### PR DESCRIPTION
Only used for supplying data to SyncCoordinator. Instead pass that data through a Loader post-load action to get rid of that global state.