### PR TITLE
Fix/map gen faction context

### DIFF
--- a/Source/Client/Factions/FactionContextSetters.cs
+++ b/Source/Client/Factions/FactionContextSetters.cs
@@ -39,12 +39,20 @@ static class MapGenFactionPatch
         var worldObjectsHolder = Find.WorldObjects;
 
         var mapParent = worldObjectsHolder.MapParentAt(tile);
-        if (mapParent != null)
+        if (mapParent != null && mapParent.Faction is { IsPlayer: true })
             return mapParent.Faction;
 
         var caravan = worldObjectsHolder.PlayerControlledCaravanAt(tile);
         if (caravan != null)
             return caravan.Faction;
+
+        var transporters = worldObjectsHolder.TravellingTransporters.Find(t => t.destinationTile == tile && t.Faction is { IsPlayer: true });
+        if (transporters != null)
+            return transporters.Faction;
+
+        var gravship = worldObjectsHolder.AllWorldObjects.Find(t => t is Gravship g && g.destinationTile == tile && t.Faction is { IsPlayer: true });
+        if (gravship != null)
+            return gravship.Faction;
 
         return TileFactionContext.GetFactionForTile(tile);
     }

--- a/Source/Client/Factions/FactionContextSetters.cs
+++ b/Source/Client/Factions/FactionContextSetters.cs
@@ -141,6 +141,20 @@ static class BillProductionValidateSettingsPatch
     }
 }
 
+[HarmonyPatch(typeof(GravshipUtility), nameof(GravshipUtility.ArriveNewMap))]
+static class GravshipArriveNewMapFactionPatch
+{
+    static void Prefix(Gravship gravship)
+    {
+        FactionContext.Push(gravship.Faction);
+    }
+
+    static void Finalizer()
+    {
+        FactionContext.Pop();
+    }
+}
+
 // Clean up after map generation is complete
 [HarmonyPatch(typeof(MapGenerator), nameof(MapGenerator.GenerateMap))]
 static class CleanupTileFactionContext


### PR DESCRIPTION
This PR contains 2 fixes
1. currently only caravan on the tile is detected when generating map, no patch for gravship landing and transporters arriving, have to add them or would fall to Faction.OfPlayer and cause desync.
2. gravship arriving at new map would use Faction.OfPlayer directly and causes desync.