### PR TITLE
Seed RoomTempTracker.RegenerateEqualizeCells with per-room deterministic state

### DIFF
--- a/Source/Client/Patches/Seeds.cs
+++ b/Source/Client/Patches/Seeds.cs
@@ -209,6 +209,25 @@ namespace Multiplayer.Client
         }
     }
 
+    [HarmonyPatch(typeof(RoomTempTracker), nameof(RoomTempTracker.RegenerateEqualizeCells))]
+    static class SeedRegenerateEqualizeCells
+    {
+        static void Prefix(RoomTempTracker __instance, ref bool __state)
+        {
+            if (Multiplayer.Client == null) return;
+
+            int seed = Gen.HashCombineInt(__instance.room.ID, Find.World.ConstantRandSeed);
+            Rand.PushState(seed);
+            __state = true;
+        }
+
+        static void Postfix(bool __state)
+        {
+            if (__state)
+                Rand.PopState();
+        }
+    }
+
     [HarmonyPatch(typeof(PreceptComp_UnwillingToDo_Chance), nameof(PreceptComp_UnwillingToDo_Chance.MemberWillingToDo))]
     static class SeedPreceptComp_UnwillingToDo_Chance
     {


### PR DESCRIPTION
## Summary
- Wrap `RoomTempTracker.RegenerateEqualizeCells` in `Rand.PushState(Gen.HashCombineInt(room.ID, World.ConstantRandSeed))` / `PopState`, MP-only.
- Fixes a reproducible "Wrong random state" desync caused by `equalizeCells.Shuffle()` consuming unsynced `Verse.Rand` state at room-regeneration time.

## The bug
`RoomTempTracker.RegenerateEqualizeCells` ends with `equalizeCells.Shuffle()`, which consumes from `Verse.Rand`.

The list is not serialised — `RoomTempTracker` has no `ExposeData`, and `Room` itself does not implement `IExposable`. Rooms are reconstructed after load (and on world-upload / client rejoin) by `RegionAndRoomUpdater`; every new/reused Room then fires `Notify_RoomShapeChanged` → `tempTracker.RoomChanged()` → `RegenerateEqualizationData()` → `RegenerateEqualizeCells()`. The same chain also fires mid-game on `Notify_RoomShapeChanged`/`Notify_RoofChanged` (walls built, doors placed, roofs changed).

If any of those regenerations run while host and client Rand streams are not byte-aligned, the same cell set ends up in different orders on each side. `WallEqualizationTempChangePerInterval` then samples different neighbours via `cycleIndex % cells.Count`, computes different temperature deltas, and the room temperature drifts apart by ~1e-2 °C per equalisation tick. The drift stays invisible for a while (when `cycleIndex` completes full cycles the average converges) and only manifests once a partial-cycle window hits a `Rand.Chance` site — typically `FreezeManager.DoIceMelting` — where one side calls `Rand.Value` and the other short-circuits. Main RNG stream desyncs from there.

## Why this fix
The shuffle's purpose is benign — `cycleIndex` iterates all cells over time, so long-term order doesn't affect behaviour. Seeding it deterministically per-room costs one PushState/PopState pair per regeneration and produces identical orderings across all clients regardless of upstream Rand state at the regen moment.

The seed combines `room.ID` (stable, save-persistent) with `Find.World.ConstantRandSeed` (per-game) — same convention used by other seed patches in this file (`SeedMapLoad`, `SeedPawnGraphics`, etc.). The `if (Multiplayer.Client == null) return;` guard keeps single-player behaviour untouched.

## Test plan
- [x] Build clean Release DLL pair from fix branch
- [x] Deploy and replay a save that previously desynced — no desync past the prior divergence point
- [x] Smoke test — colonists work normally, temperatures behave normally, no NREs in `Player.log`
- [x] SP unchanged — the MP-only guard ensures single-player code path is untouched