### PR TITLE
Update for Rimworld 1.6.4850

### DIFF
--- a/Source/Client/Factions/Blueprints.cs
+++ b/Source/Client/Factions/Blueprints.cs
@@ -15,7 +15,7 @@ namespace Multiplayer.Client
     // Don't draw other factions' blueprints
     // Don't link graphics of different factions' blueprints
 
-    [HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.CanPlaceBlueprintAt))]
+    [HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.CanPlaceBlueprintAt_NewTemp))]
     static class CanPlaceBlueprintAtPatch
     {
         static MethodInfo CanPlaceBlueprintOver = AccessTools.Method(typeof(GenConstruct), nameof(GenConstruct.CanPlaceBlueprintOver));
@@ -48,7 +48,7 @@ namespace Multiplayer.Client
         static bool ShouldIgnore1(Thing oldThing) => oldThing.def.IsBlueprint && oldThing.Faction != Faction.OfPlayer;
     }
 
-    [HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.CanPlaceBlueprintAt))]
+    [HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.CanPlaceBlueprintAt_NewTemp))]
     static class CanPlaceBlueprintAtPatch2
     {
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> e, MethodBase original)

--- a/Source/Client/Multiplayer.csproj
+++ b/Source/Client/Multiplayer.csproj
@@ -24,8 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Krafs.Publicizer" Version="2.3.0" />
-    <PackageReference Include="Lib.Harmony" Version="2.4.1" ExcludeAssets="runtime" />
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4566" />
+    <PackageReference Include="Lib.Harmony" Version="2.4.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4759-beta" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.6.0" />
   </ItemGroup>

--- a/Source/Client/Multiplayer.csproj
+++ b/Source/Client/Multiplayer.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Krafs.Publicizer" Version="2.3.0" />
     <PackageReference Include="Lib.Harmony" Version="2.4.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4759-beta" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4850" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.6.0" />
   </ItemGroup>

--- a/Source/Common/Common.csproj
+++ b/Source/Common/Common.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4566" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4759-beta" />
     <PackageReference Include="LiteNetLib" Version="1.3.1" />
-    <PackageReference Include="Lib.Harmony" Version="2.4.1" ExcludeAssets="runtime" />
+    <PackageReference Include="Lib.Harmony" Version="2.4.2" ExcludeAssets="runtime" />
     <PackageReference Include="MSBuildGitHash" Version="2.0.2" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.6.0" />

--- a/Source/Common/Common.csproj
+++ b/Source/Common/Common.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4759-beta" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4850" />
     <PackageReference Include="LiteNetLib" Version="1.3.1" />
     <PackageReference Include="Lib.Harmony" Version="2.4.2" ExcludeAssets="runtime" />
     <PackageReference Include="MSBuildGitHash" Version="2.0.2" />

--- a/Source/MultiplayerLoader/MultiplayerLoader.csproj
+++ b/Source/MultiplayerLoader/MultiplayerLoader.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4566" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4759-beta" />
     <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Zetrith.Prepatcher" Version="1.2.0" />
-    <PackageReference Include="Lib.Harmony" Version="2.4.1" ExcludeAssets="runtime" />
+    <PackageReference Include="Lib.Harmony" Version="2.4.2" ExcludeAssets="runtime" />
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 

--- a/Source/MultiplayerLoader/MultiplayerLoader.csproj
+++ b/Source/MultiplayerLoader/MultiplayerLoader.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4759-beta" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4850" />
     <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Server/Server.csproj
+++ b/Source/Server/Server.csproj
@@ -17,7 +17,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Common\Common.csproj" />
-      <PackageReference Include="Lib.Harmony" Version="2.4.1" />
+      <PackageReference Include="Lib.Harmony" Version="2.4.2" />
     </ItemGroup>
 
 </Project>

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="NUnit.Analyzers" Version="4.10.0" />
         <PackageReference Include="coverlet.collector" Version="3.1.2" />
 
-        <PackageReference Include="Lib.Harmony" Version="2.4.1" />
+        <PackageReference Include="Lib.Harmony" Version="2.4.2" />
 
         <PackageReference Include="Verify.NUnit" Version="21.3.0" />
     </ItemGroup>

--- a/Source/TestsOnMono/TestsOnMono.csproj
+++ b/Source/TestsOnMono/TestsOnMono.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Common\Common.csproj" />
-      <PackageReference Include="Lib.Harmony" Version="2.4.1" />
+      <PackageReference Include="Lib.Harmony" Version="2.4.2" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In case you want to move dev version to the latest [unstable] rimworld version (marked as a release candidate) with a lot of useful bugfixes.

"GenConstruct.CanPlaceBlueprintAt" from stable version now just calls the new "GenConstruct.CanPlaceBlueprintAt_NewTemp", which bugs existing MP transplier on load. "GenConstruct.CanPlaceBlueprintAt_NewTemp" Mostly repeats already existing method, so I just changed targets of a patch.
Also updated packages for the latest Harmony and (obviously) latest unstable patch.