### PR TITLE
Send selected info only to other players

### DIFF
--- a/Source/Common/Networking/State/ServerPlayingState.cs
+++ b/Source/Common/Networking/State/ServerPlayingState.cs
@@ -116,7 +116,7 @@ namespace Multiplayer.Common
 
         [TypedPacketHandler]
         public void HandleSelected(ClientSelectedPacket packet) =>
-            Server.SendToPlaying(new ServerSelectedPacket(Player.id, packet));
+            Server.SendToPlaying(new ServerSelectedPacket(Player.id, packet), excluding: Player);
 
         [TypedPacketHandler]
         public void HandlePing(ClientPingLocPacket packet) =>


### PR DESCRIPTION
To avoid a player having their own selection highlighted as if it was another player's selection