### PR TITLE
Add custom disconnection dialog when version mismatch is a likely cause

### DIFF
--- a/Source/Client/OnMainThread.cs
+++ b/Source/Client/OnMainThread.cs
@@ -1,10 +1,10 @@
-using Multiplayer.Client.DebugUi;
-using Multiplayer.Client.Networking;
-using Multiplayer.Common;
 using System;
 using System.Collections.Generic;
+using Multiplayer.Client.DebugUi;
 using Multiplayer.Client.Desyncs;
+using Multiplayer.Client.Networking;
 using Multiplayer.Client.Util;
+using Multiplayer.Common;
 using UnityEngine;
 using Verse;
 using Verse.Steam;
@@ -53,8 +53,8 @@ namespace Multiplayer.Client
                 {
                     Log.Error($"Exception handling packet by {conn}: {e}");
 
-                    ConnectionStatusListeners.TryNotifyAll_Disconnected(new SessionDisconnectInfo
-                        { titleTranslated = "MpPacketErrorLocal".Translate() });
+                    ConnectionStatusListeners.TryNotifyAll_Disconnected(
+                        SessionDisconnectInfo.FromLocalPacketReadException(e));
                     Multiplayer.StopMultiplayer();
                 }
             }

--- a/Source/Client/Session/SessionDisconnectInfo.cs
+++ b/Source/Client/Session/SessionDisconnectInfo.cs
@@ -115,4 +115,19 @@ public struct SessionDisconnectInfo
 
         return disconnectInfo;
     }
+
+    public static SessionDisconnectInfo FromLocalPacketReadException(Exception e)
+    {
+        var disconnectInfo = new SessionDisconnectInfo
+            { titleTranslated = "MpPacketErrorLocal".Translate() };
+
+        if (e is PacketBadIdException)
+        {
+            disconnectInfo.descTranslated = "MpPacketErrorLocalBadId".Translate();
+            disconnectInfo.descTranslated += '\n' + "MpWrongVersionUpdateInfo".Translate();
+            disconnectInfo.wideWindow = true;
+        }
+
+        return disconnectInfo;
+    }
 }

--- a/Source/Common/Networking/ConnectionBase.cs
+++ b/Source/Common/Networking/ConnectionBase.cs
@@ -166,7 +166,7 @@ namespace Multiplayer.Common
         protected virtual void HandleReceiveMsg(int msgId, int fragState, ByteReader reader, bool reliable)
         {
             if (msgId is < 0 or >= (int)Packets.Count)
-                throw new PacketReadException($"Bad packet id {msgId}");
+                throw new PacketBadIdException(msgId);
 
             Packets packetType = (Packets)msgId;
             if (reader.Left > MaxSinglePacketSize)

--- a/Source/Common/Networking/PacketReadException.cs
+++ b/Source/Common/Networking/PacketReadException.cs
@@ -12,4 +12,6 @@ namespace Multiplayer.Common
         {
         }
     }
+
+    public class PacketBadIdException(int id) : PacketReadException($"Bad packet id: {id}");
 }


### PR DESCRIPTION
A rather niche issue, but probably won't hurt to have it. Not sure if the DebugActions are worth it, probably overkill?

Without Steam:
<img width="675" height="285" alt="image" src="https://github.com/user-attachments/assets/08d442a8-e05b-4a3f-ac02-3278dafd19c2" />

With Steam:
<img width="613" height="342" alt="image" src="https://github.com/user-attachments/assets/586eb1ae-9229-4dec-bb4a-8c43e77247c7" />
