### PR TITLE
Add a analyzer for Harmony to help detect issues with patches

### DIFF
--- a/Source/Client/Multiplayer.csproj
+++ b/Source/Client/Multiplayer.csproj
@@ -26,6 +26,8 @@
     <PackageReference Include="Krafs.Publicizer" Version="2.3.0" />
     <PackageReference Include="Lib.Harmony" Version="2.4.1" ExcludeAssets="runtime" />
     <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4566" />
+    <PackageReference Include="MicroUtils.HarmonyAnalyzers" Version="1.6.1" PrivateAssets="all"
+                      IncludeAssets="analyzers" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.6.0" />
   </ItemGroup>


### PR DESCRIPTION
Inspection MH013 reports false-positive warnings for some patches in this repo. I'll keep this PR a draft, until [that issue is fixed](https://github.com/microsoftenator2022/MicroUtils.HarmonyAnalyzers/pull/4). 

This analyzer would've detected the issues in #907, #909