### PR TITLE
Server zip in continuous release

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Build Mod
       run: dotnet build ${{ env.SLN_PATH }} --configuration Release --no-restore
 
+    - name: Publish Server
+      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --no-restore -o output/Server
+
     - name: Package files
       run: |
         sed -i "s/<name>\(.*\)<\/name>\$/<name>\1 [Continuous]<\/name>/" About/About.xml
@@ -41,6 +44,7 @@ jobs:
         mv About/ Assemblies/ AssembliesCustom/ Defs/ Languages/ Textures/ output/Multiplayer
         cd output/
         zip -r ../Multiplayer-beta.zip Multiplayer/
+        zip -r ../Server-beta.zip Server/
         cd ../
 
     - name: Upload Mod Artifacts
@@ -57,5 +61,5 @@ jobs:
     - name: Upload new release
       run: |
         gh release create --target "${{ github.sha }}" --title "Continuous" --notes-file ".github/workflows/alpha-notes.md" --draft "continuous"
-        gh release upload "continuous" Multiplayer-beta.zip
+        gh release upload "continuous" Multiplayer-beta.zip Server-beta.zip
         gh release edit "continuous" --draft=false


### PR DESCRIPTION
Adds the standalone server as a downloadable zip (`Server-beta.zip`) to the continuous release, alongside the existing `Multiplayer-beta.zip`.

Changes to `build-beta.yml`:
- Added a `dotnet publish` step for the Server project (outputs to `output/Server/`)
- Zips the publish output as `Server-beta.zip`
- Uploads both zips to the GitHub continuous release

This makes it easier for testers to try the standalone server without having to build it themselves.