### PR TITLE
Allow Properties in RegisterSyncField

### DIFF
--- a/Source/Client/Syncing/Sync.cs
+++ b/Source/Client/Syncing/Sync.cs
@@ -57,12 +57,13 @@ namespace Multiplayer.Client
 
         public static ISyncField RegisterSyncField(Type targetType, string fieldName)
         {
-            FieldInfo field = AccessTools.Field(targetType, fieldName)
+            MemberInfo field = AccessTools.Field(targetType, fieldName) as MemberInfo
+                ?? AccessTools.Property(targetType, fieldName)
                 ?? throw new Exception($"Couldn't find field {targetType}::{fieldName}");
 
             SyncField sf;
             string memberPath;
-            if (field.IsStatic) {
+            if (field.IsStatic()) {
                 memberPath = field.ReflectedType + "/" + field.Name;
                 sf = Field(null, null, memberPath);
             } else {


### PR DESCRIPTION
Minimal changes here allow Properties to sync with RegisterSyncField. For full compatibility, MPApi requires additional minor changes to support the attribute on Properties.