### PR TITLE
package dedicated server beta artifacts for Windows and Linux

### DIFF
--- a/.github/workflows/alpha-notes.md
+++ b/.github/workflows/alpha-notes.md
@@ -14,16 +14,19 @@
    * You should have a `Multiplayer` folder in the `Mods` folder (`Mods/Multiplayer`)
    * Make sure you do not have this directory structure: `Mods/Multiplayer-beta/Multiplayer`. If you do, move the `Multiplayer` folder to the parent directory.
 
----
-
 #### Standalone server
 
 Download `Server-beta.zip` if you want to host a dedicated standalone server for testing.
 
 **Setup**
 1. Download and extract `Server-beta.zip`.
-2. Run `Server.exe` (Windows) or `dotnet Server.dll` (Linux/Mac) from the extracted folder.
-3. The server will start and wait for the first connection.
+2. Open the folder for your platform:
+   - `Server/Windows`
+   - `Server/Linux`
+3. Start the server using:
+   - Windows: `Server.exe`
+   - Linux: `./Server.sh`
+4. The server will start and wait for the first connection.
 
 **First-time configuration (bootstrap)**
 No manual configuration files are required.

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -34,8 +34,22 @@ jobs:
     - name: Build Mod
       run: dotnet build ${{ env.SLN_PATH }} --configuration Release --no-restore
 
-    - name: Publish Server
-      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --no-restore --no-build -o output/Server
+    - name: Publish Server (Windows)
+      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --runtime win-x64 --self-contained false -p:UseAppHost=true -o output/Server/Windows
+
+    - name: Publish Server (Linux)
+      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --runtime linux-x64 --self-contained false -p:UseAppHost=true -o output/Server/Linux
+
+    - name: Add Server Launchers
+      run: |
+        cat > output/Server/Linux/Server.sh <<'EOF'
+        #!/usr/bin/env bash
+        set -euo pipefail
+        SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+        exec dotnet "$SCRIPT_DIR/Server.dll" "$@"
+        EOF
+
+        chmod +x output/Server/Linux/Server.sh
 
     - name: Package files
       run: |

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build Mod
       run: dotnet build ${{ env.SLN_PATH }} --configuration Release --no-restore
 
-    - name: Publish Server
+        - name: Publish Server
       run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --no-restore --no-build -o output/Server
 
     - name: Package files

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build Mod
       run: dotnet build ${{ env.SLN_PATH }} --configuration Release --no-restore
 
-        - name: Publish Server
+    - name: Publish Server
       run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --no-restore --no-build -o output/Server
 
     - name: Package files


### PR DESCRIPTION
This PR updates the beta dedicated server packaging by creating separate folders for Linux and Windows inside `Server-beta.zip`.

The main goal is to allow Windows users to run the standalone server directly via `Server.exe`, instead of receiving only the Linux-style host binary with no `.exe` extension.

Changes included:
- creation of separate folders for Linux and Windows in the server beta archive
- publish a `win-x64` server build so Windows users get `Server.exe`
- publish a `linux-x64` server build and add `Server.sh` for quick startup on Linux
- update the beta release notes to explain the new layout

Validation:
- validated local `dotnet publish` for both `win-x64` and `linux-x64`
- confirmed the Windows output contains `Server.exe`
- confirmed the Linux output contains the expected runtime files plus `Server.sh`