### PR TITLE
Remove standalone bootstrap enforcement

### DIFF
--- a/Source/Client/Windows/BootstrapConfiguratorWindow.SettingsUi.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.SettingsUi.cs
@@ -44,8 +44,6 @@ public partial class BootstrapConfiguratorWindow
         else if (tab == Tab.Gameplay)
             ServerSettingsUI.DrawGameplaySettingsOnly(contentRect, settings, buffers);
 
-        settings.EnforceStandaloneRequirements();
-
         settingsUiBuffers.MaxPlayersBuffer = buffers.MaxPlayersBuffer;
         settingsUiBuffers.AutosaveBuffer = buffers.AutosaveBuffer;
 
@@ -123,7 +121,6 @@ public partial class BootstrapConfiguratorWindow
 
         try
         {
-            settings.EnforceStandaloneRequirements();
             connection.Send(new ClientBootstrapSettingsPacket(settings));
         }
         catch (System.Exception e)

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.cs
@@ -71,7 +71,6 @@ public partial class BootstrapConfiguratorWindow : Window, IConnectionStatusList
 
         settings.steam = false;
         settings.arbiter = false;
-            settings.EnforceStandaloneRequirements();
 
         settingsUiBuffers.MaxPlayersBuffer = settings.maxPlayers.ToString();
         settingsUiBuffers.AutosaveBuffer = settings.autosaveInterval.ToString();

--- a/Source/Common/ServerSettings.cs
+++ b/Source/Common/ServerSettings.cs
@@ -32,12 +32,6 @@ namespace Multiplayer.Common
         public bool pauseOnDesync = true;
         public TimeControl timeControl;
 
-        public void EnforceStandaloneRequirements()
-        {
-            if (multifaction)
-                asyncTime = true;
-        }
-
         public string? TryParseEndpoints(out IPEndPoint[] endpoints)
         {
             var split = directAddress.Split(MultiplayerServer.EndpointSeparator);

--- a/Source/Server/Server.cs
+++ b/Source/Server/Server.cs
@@ -19,8 +19,6 @@ if (settingsPresent)
     settings = TomlSettings.Load(settingsFile);
 else
     ServerLog.Log($"Bootstrap mode: '{settingsFile}' not found. Waiting for a client to upload it.");
-
-settings.EnforceStandaloneRequirements();
 ServerLog.detailEnabled = settings.debugMode;
 ServerLog.verboseEnabled = settings.debugMode;
 


### PR DESCRIPTION
## Summary
- remove the standalone bootstrap enforcement that implicitly coupled multifaction and async time
- remove the obsolete bootstrap helper and its server/client bootstrap call sites
- keep standalone bootstrap settings aligned with the values explicitly chosen by the configurator

## Testing
- dotnet test .\Tests\Tests.csproj --filter BootstrapSettingsTest