### PR TITLE
Reset bootstrap client mode after save upload

### DIFF
--- a/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
@@ -24,6 +24,7 @@ public partial class BootstrapConfiguratorWindow
     private bool saveReady;
     private bool isUploadingSave;
     private bool saveUploadAutoStarted;
+    private bool closeBootstrapModeOnDisconnect;
     private string savedReplayPath;
     private string saveUploadStatus;
     private float saveUploadProgress;
@@ -380,6 +381,7 @@ public partial class BootstrapConfiguratorWindow
         {
             try
             {
+                closeBootstrapModeOnDisconnect = true;
                 connection.SendFragmented(new ClientBootstrapSaveDataPacket(saveData, hash).Serialize());
 
                 OnMainThread.Enqueue(() =>
@@ -392,6 +394,7 @@ public partial class BootstrapConfiguratorWindow
             {
                 OnMainThread.Enqueue(() =>
                 {
+                    closeBootstrapModeOnDisconnect = false;
                     isUploadingSave = false;
                     saveUploadStatus = $"Failed to upload save.zip: {exception.GetType().Name}: {exception.Message}";
                 });

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.cs
@@ -107,6 +107,35 @@ public partial class BootstrapConfiguratorWindow : Window, IConnectionStatusList
             Instance = null;
     }
 
+    private void ExitBootstrapMode(bool clearPendingUploadState)
+    {
+        closeBootstrapModeOnDisconnect = false;
+        retainInstanceOnClose = false;
+
+        ResetTransientUiState(resetServerDrivenState: true);
+
+        isUploadingToml = false;
+        uploadProgress = 0f;
+        statusText = null;
+        settingsUploaded = false;
+        saveReady = false;
+        savedReplayPath = null;
+        saveUploadStatus = null;
+        saveUploadProgress = 0f;
+        bootstrapState = BootstrapServerState.None;
+
+        if (clearPendingUploadState)
+            pendingUploadState = null;
+
+        if (Current.Game?.components != null)
+            Current.Game.components.RemoveAll(component => component is Comp.BootstrapCoordinator);
+
+        if (Find.WindowStack?.Windows.Contains(this) == true)
+            Find.WindowStack.TryRemove(this);
+        else if (ReferenceEquals(Instance, this))
+            Instance = null;
+    }
+
     internal void ResetTransientUiState(bool resetServerDrivenState = false)
     {
         AwaitingBootstrapMapInit = false;
@@ -234,7 +263,6 @@ public partial class BootstrapConfiguratorWindow : Window, IConnectionStatusList
 
     public void Disconnected(SessionDisconnectInfo info)
     {
-        ResetTransientUiState(resetServerDrivenState: true);
-        Find.WindowStack.TryRemove(this);
+        ExitBootstrapMode(clearPendingUploadState: closeBootstrapModeOnDisconnect);
     }
 }


### PR DESCRIPTION
## Summary
- add a client-side bootstrap teardown path that runs on disconnect only after save upload has started
- preserve the intentional reconnect flow before upload, but clear bootstrap state once the upload-complete disconnect happens
- reset lingering bootstrap window/coordinator state so later singleplayer starts do not re-enter bootstrap mode

## Testing
- dotnet build .\Client\Multiplayer.csproj