### PR TITLE
Fix render burn

### DIFF
--- a/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
@@ -276,7 +276,7 @@ public class AsyncWorldTimeComp : IExposable, ITickable
 
     private static void CreateJoinPointAndSendIfHost()
     {
-        Multiplayer.session.dataSnapshot = SaveLoad.CreateGameDataSnapshot(SaveLoad.SaveAndReload(), Multiplayer.GameComp.multifaction);
+        Multiplayer.session.dataSnapshot = SaveLoad.CreateGameDataSnapshot(SaveLoad.SaveAndReload(SaveReloadCacheMode.Cache), Multiplayer.GameComp.multifaction);
 
         if (!TickPatch.Simulating && !Multiplayer.IsReplay)
         {

--- a/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
@@ -276,7 +276,7 @@ public class AsyncWorldTimeComp : IExposable, ITickable
 
     private static void CreateJoinPointAndSendIfHost()
     {
-        Multiplayer.session.dataSnapshot = SaveLoad.CreateGameDataSnapshot(SaveLoad.SaveAndReload(SaveReloadCacheMode.Cache), Multiplayer.GameComp.multifaction);
+        Multiplayer.session.dataSnapshot = SaveLoad.CreateGameDataSnapshot(SaveLoad.SaveAndReload(true), Multiplayer.GameComp.multifaction);
 
         if (!TickPatch.Simulating && !Multiplayer.IsReplay)
         {

--- a/Source/Client/Saving/SaveLoad.cs
+++ b/Source/Client/Saving/SaveLoad.cs
@@ -18,15 +18,9 @@ namespace Multiplayer.Client
 {
     public record TempGameData(XmlDocument SaveData, byte[] SessionData);
 
-    public enum SaveReloadCacheMode
-    {
-        None,
-        Cache,
-    }
-
     public static class SaveLoad
     {
-        public static TempGameData SaveAndReload(SaveReloadCacheMode cacheMode = SaveReloadCacheMode.None)
+        public static TempGameData SaveAndReload(bool cache = false)
         {
             Multiplayer.reloading = true;
 
@@ -64,22 +58,19 @@ namespace Multiplayer.Client
                 gameData = SaveGameData();
             }
 
-            switch (cacheMode)
+            if (cache)
             {
-                case SaveReloadCacheMode.Cache:
-                    MapDrawerRegenPatch.copyFrom = drawers;
-                    WorldGridCachePatch.copyFrom = worldGridSaved;
-                    WorldGridExposeDataPatch.copyFrom = worldGridSaved;
-                    WorldRendererCachePatch.copyFrom = worldGridSaved;
-                    break;
-
-                case SaveReloadCacheMode.None:
-                default:
-                    MapDrawerRegenPatch.copyFrom.Clear();
-                    WorldGridCachePatch.copyFrom = null;
-                    WorldGridExposeDataPatch.copyFrom = null;
-                    WorldRendererCachePatch.copyFrom = null;
-                    break;
+                MapDrawerRegenPatch.copyFrom = drawers;
+                WorldGridCachePatch.copyFrom = worldGridSaved;
+                WorldGridExposeDataPatch.copyFrom = worldGridSaved;
+                WorldRendererCachePatch.copyFrom = worldGridSaved;
+            }
+            else
+            {
+                MapDrawerRegenPatch.copyFrom.Clear();
+                WorldGridCachePatch.copyFrom = null;
+                WorldGridExposeDataPatch.copyFrom = null;
+                WorldRendererCachePatch.copyFrom = null;
             }
 
             MusicManagerPlay musicManager = null;

--- a/Source/Client/Saving/SaveLoad.cs
+++ b/Source/Client/Saving/SaveLoad.cs
@@ -18,9 +18,15 @@ namespace Multiplayer.Client
 {
     public record TempGameData(XmlDocument SaveData, byte[] SessionData);
 
+    public enum SaveReloadCacheMode
+    {
+        None,
+        Cache,
+    }
+
     public static class SaveLoad
     {
-        public static TempGameData SaveAndReload()
+        public static TempGameData SaveAndReload(SaveReloadCacheMode cacheMode = SaveReloadCacheMode.None)
         {
             Multiplayer.reloading = true;
 
@@ -58,10 +64,23 @@ namespace Multiplayer.Client
                 gameData = SaveGameData();
             }
 
-            MapDrawerRegenPatch.copyFrom = drawers;
-            WorldGridCachePatch.copyFrom = worldGridSaved;
-            WorldGridExposeDataPatch.copyFrom = worldGridSaved;
-            WorldRendererCachePatch.copyFrom = worldGridSaved;
+            switch (cacheMode)
+            {
+                case SaveReloadCacheMode.Cache:
+                    MapDrawerRegenPatch.copyFrom = drawers;
+                    WorldGridCachePatch.copyFrom = worldGridSaved;
+                    WorldGridExposeDataPatch.copyFrom = worldGridSaved;
+                    WorldRendererCachePatch.copyFrom = worldGridSaved;
+                    break;
+
+                case SaveReloadCacheMode.None:
+                default:
+                    MapDrawerRegenPatch.copyFrom.Clear();
+                    WorldGridCachePatch.copyFrom = null;
+                    WorldGridExposeDataPatch.copyFrom = null;
+                    WorldRendererCachePatch.copyFrom = null;
+                    break;
+            }
 
             MusicManagerPlay musicManager = null;
             if (Find.MusicManagerPlay.gameObjectCreated)


### PR DESCRIPTION
## Summary
Fix render burn during hosting by making reload cache usage explicit.

## What changed
- nest the SaveLoad cache handling in a switch case
- default to no cache loading when SaveAndReload is called without a mode
- keep cache loading only for the explicit in-game reload path
- avoid loading render caches in hosting/bootstrap flows where they were being applied incorrectly

## Why
The render burn was caused by loading the render/world cache in cases where the game was creating or hosting a session, not performing the in-game reload path that actually benefits from those caches.
