### PR TITLE
Delay bootstrap window until landing dialog clears

### DIFF
--- a/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
@@ -178,8 +178,21 @@ public partial class BootstrapConfiguratorWindow
         bootstrapSaveQueued = false;
         saveUploadStatus = "Map initialized. Waiting for controllable colonists to spawn...";
 
-        if (Find.WindowStack.WindowOfType<BootstrapConfiguratorWindow>() == null)
-            Find.WindowStack.Add(this);
+        TryShowBootstrapWindow();
+    }
+
+    private void TryShowBootstrapWindow()
+    {
+        if (Find.WindowStack == null)
+            return;
+
+        if (Find.WindowStack.WindowOfType<BootstrapConfiguratorWindow>() != null)
+            return;
+
+        if (Find.WindowStack.Windows.OfType<Dialog_MessageBox>().Any())
+            return;
+
+        Find.WindowStack.Add(this);
     }
 
     private void TickPostMapEnterSaveDelayAndMaybeSave()
@@ -195,7 +208,10 @@ public partial class BootstrapConfiguratorWindow
             return;
 
         if (!WaitForControllableColonists())
+        {
+            TryShowBootstrapWindow();
             return;
+        }
 
         postMapEnterSaveDelayRemaining = 0f;
         bootstrapSaveQueued = true;


### PR DESCRIPTION
Added a guard for the bootstrap window so it does not show up too early while the landing/scenario message is still blocking input.

This keeps the bootstrap flow active, but delays the window until the landing dialog is out of the way.