### PR TITLE
Use shared entry transition for bootstrap reconnect

### DIFF
--- a/Source/Client/Session/Rejoiner.cs
+++ b/Source/Client/Session/Rejoiner.cs
@@ -1,4 +1,5 @@
-﻿using Multiplayer.Client.Util;
+﻿using System;
+using Multiplayer.Client.Util;
 using Multiplayer.Common;
 using Verse;
 using Verse.Profile;

--- a/Source/Client/Session/Rejoiner.cs
+++ b/Source/Client/Session/Rejoiner.cs
@@ -7,6 +7,22 @@ namespace Multiplayer.Client;
 
 public static class Rejoiner
 {
+    public static void ReturnToEntry(Action onFinished)
+    {
+        LongEventHandler.ClearQueuedEvents();
+        LongEventHandler.QueueLongEvent(() =>
+        {
+            MemoryUtility.ClearAllMapsAndWorld();
+            Current.Game = null;
+
+            LongEventHandler.ExecuteWhenFinished(() =>
+            {
+                MpUI.ClearWindowStack();
+                onFinished?.Invoke();
+            });
+        }, "Entry", "LoadingLongEvent", true, null, false);
+    }
+
     public static void DoRejoin()
     {
         Multiplayer.Client.Send(Packets.Client_RequestRejoin);
@@ -18,18 +34,6 @@ public static class Rejoiner
 
         Log.Message("Multiplayer: rejoining");
 
-        // From GenScene.GoToMainMenu
-        LongEventHandler.ClearQueuedEvents();
-        LongEventHandler.QueueLongEvent(() =>
-        {
-            MemoryUtility.ClearAllMapsAndWorld();
-            Current.Game = null;
-
-            LongEventHandler.ExecuteWhenFinished(() =>
-            {
-                MpUI.ClearWindowStack();
-                Find.WindowStack.Add(new RejoiningWindow());
-            });
-        }, "Entry", "LoadingLongEvent", true, null, false);
+        ReturnToEntry(() => Find.WindowStack.Add(new RejoiningWindow()));
     }
 }

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
@@ -328,24 +328,35 @@ public partial class BootstrapConfiguratorWindow
             StatusText = statusText ?? string.Empty
         };
 
-        saveUploadStatus = "Save created. Returning to menu...";
-        LongEventHandler.QueueLongEvent(ReturnToMenuAndReconnect, "Returning to menu", false, null);
+        saveUploadStatus = "Save created. Returning to entry...";
+        LongEventHandler.ExecuteWhenFinished(ReturnToEntryAndReconnect);
     }
 
-    private void ReturnToMenuAndReconnect()
+    private void ReturnToEntryAndReconnect()
     {
-        GenScene.GoToMainMenu();
-        LongEventHandler.ExecuteWhenFinished(ReconnectAfterReturningToMenu);
+        try
+        {
+            Log.Message("Bootstrap: returning to entry for save upload reconnect");
+            Rejoiner.ReturnToEntry(ReconnectAfterReturningToEntry);
+        }
+        catch (Exception exception)
+        {
+            saveUploadStatus = $"Return to entry failed: {exception.GetType().Name}: {exception.Message}";
+            bootstrapSaveQueued = false;
+            Log.Error($"Bootstrap return to entry failed: {exception}");
+        }
     }
 
-    private void ReconnectAfterReturningToMenu()
+    private void ReconnectAfterReturningToEntry()
     {
         if (Current.ProgramState != ProgramState.Entry || Current.Game != null)
         {
-            saveUploadStatus = "Waiting to finish returning to menu...";
-            LongEventHandler.ExecuteWhenFinished(ReconnectAfterReturningToMenu);
+            saveUploadStatus = "Waiting to finish returning to entry...";
+            LongEventHandler.ExecuteWhenFinished(ReconnectAfterReturningToEntry);
             return;
         }
+
+        Multiplayer.StopMultiplayer();
 
         saveUploadStatus = "Reconnecting to upload save...";
 


### PR DESCRIPTION
## Summary
- route bootstrap save-upload reconnect through the same Entry transition flow already used by Rejoiner
- extract a shared helper in Rejoiner so the Harmony-controlled return-to-entry path is implemented once
- keep the bootstrap reconnect waiting for Entry completion before reconnecting

## Testing
- dotnet build .\Client\Multiplayer.csproj --configuration Release -v:q
- manual bootstrap test confirming save creation and reconnect flow complete without the return-to-menu crash
