### PR TITLE
Let bootstrap shutdown exit standalone server

### DIFF
--- a/Source/Server/Server.cs
+++ b/Source/Server/Server.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using Multiplayer.Common;
 using Multiplayer.Common.Util;
 
@@ -118,12 +119,19 @@ new Thread(server.Run) { Name = "Server thread" }.Start();
 
 while (server.running)
 {
-    var cmd = Console.ReadLine();
-    if (cmd != null)
-        server.Enqueue(() => server.HandleChatCmd(consoleSource, cmd));
+    if (Console.KeyAvailable)
+    {
+        var cmd = Console.ReadLine();
+        if (cmd != null)
+            server.Enqueue(() => server.HandleChatCmd(consoleSource, cmd));
 
-    if (cmd == stopCmd)
-        break;
+        if (cmd == stopCmd)
+            break;
+    }
+    else
+    {
+        Thread.Sleep(50);
+    }
 }
 
 class ConsoleSource : IChatSource


### PR DESCRIPTION
## Summary
- make the standalone server process exit cleanly after bootstrap writes save.zip
- avoid blocking the main loop on Console.ReadLine while the server has already requested shutdown
- keep the fix limited to shutdown behavior without changing bootstrap/server restart semantics

## Testing
- dotnet publish .\Server\Server.csproj --configuration Release --runtime win-x64 --self-contained false -p:UseAppHost=true -o ..\artifacts\live-test-server\Windows
- manual bootstrap test confirming the process exits after "Bootstrap: wrote save.zip. Configuration complete; stopping server."
