### PR TITLE
Fix bootstrap world map rotation input

### DIFF
--- a/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
@@ -133,6 +133,8 @@ public partial class BootstrapConfiguratorWindow
         autoAdvanceArmed = true;
         AwaitingBootstrapMapInit = true;
         saveUploadStatus = "Generating map...";
+        absorbInputAroundWindow = false;
+        preventCameraMotion = false;
         Find.WindowStack.TryRemove(this);
 
         var scenarioPage = new Page_SelectScenario();
@@ -170,6 +172,8 @@ public partial class BootstrapConfiguratorWindow
         if (!AwaitingBootstrapMapInit)
             return;
 
+        absorbInputAroundWindow = true;
+        preventCameraMotion = false;
         hideWindowDuringMapGen = false;
         retainInstanceOnClose = false;
         AwaitingBootstrapMapInit = false;

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
@@ -133,6 +133,13 @@ public partial class BootstrapConfiguratorWindow
         autoAdvanceArmed = true;
         AwaitingBootstrapMapInit = true;
         saveUploadStatus = "Generating map...";
+
+        foreach (var window in Find.WindowStack.Windows)
+        {
+            window.absorbInputAroundWindow = false;
+            window.preventCameraMotion = false;
+        }
+
         absorbInputAroundWindow = false;
         preventCameraMotion = false;
         Find.WindowStack.TryRemove(this);

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
@@ -134,6 +134,9 @@ public partial class BootstrapConfiguratorWindow
         AwaitingBootstrapMapInit = true;
         saveUploadStatus = "Generating map...";
 
+        // TODO: Narrow this workaround to the specific MP window or state that still leaves
+        // WindowStack.WindowsPreventCameraMotion true during Page_SelectStartingSite.
+        // Clearing all current windows is only a temporary bootstrap fix until that blocker is isolated.
         foreach (var window in Find.WindowStack.Windows)
         {
             window.absorbInputAroundWindow = false;


### PR DESCRIPTION
## Summary
Fix bootstrap world-map rotation during colony creation.

## Changes
- clear camera-blocking window flags on any already open windows when Create game and upload save starts the vanilla new-colony flow
- keep the change localized to the bootstrap handoff point instead of patching vanilla world input globally

## Validation
- reproduced the issue in bootstrap flow
- verified in-game that globe rotation now works during starting-site selection
- built and deployed the client mod successfully