### PR TITLE
fix map rotation during server bootstrap bootstrap

### DIFF
--- a/Source/Client/Networking/State/ClientJoiningState.cs
+++ b/Source/Client/Networking/State/ClientJoiningState.cs
@@ -127,6 +127,16 @@ namespace Multiplayer.Client
                 {
                     if (bootstrapState is { Enabled: true } state)
                     {
+                        var connectingWindows = Find.WindowStack.Windows
+                            .OfType<BaseConnectingWindow>()
+                            .ToList();
+
+                        foreach (var connectingWindow in connectingWindows)
+                        {
+                            connectingWindow.suppressPostCloseActions = true;
+                            Find.WindowStack.TryRemove(connectingWindow);
+                        }
+
                         connection.ChangeState(ConnectionStateEnum.ClientBootstrap);
                         Find.WindowStack.Add(new BootstrapConfiguratorWindow(connection, state));
                         return;

--- a/Source/Client/Windows/ConnectingWindow.cs
+++ b/Source/Client/Windows/ConnectingWindow.cs
@@ -14,6 +14,7 @@ namespace Multiplayer.Client
         protected abstract string ConnectingString { get; }
 
         public bool returnToServerBrowser;
+        public bool suppressPostCloseActions;
         protected string result;
 
         // Only show this window if there aren't any others during connecting
@@ -117,6 +118,9 @@ namespace Multiplayer.Client
 
         public override void PostClose()
         {
+            if (suppressPostCloseActions)
+                return;
+
             Multiplayer.StopMultiplayer();
 
             if (returnToServerBrowser)


### PR DESCRIPTION
## Summary
Close any active connecting windows when the join flow switches into standalone bootstrap mode, and suppress their normal PostClose side effects so the bootstrap transition does not stop multiplayer or reopen the server browser.

This fixes the blocked world map rotation during standalone server bootstrap. The root cause was a stale connecting window remaining in the window stack and continuing to prevent camera motion, which left the globe stuck during starting-site selection.

## Testing
- dotnet build .\Source\Client\Multiplayer.csproj -c Release
- dotnet build .\Source\Server\Server.csproj -c Release
- Tested bootstrap flow in game from a clean dev worktree
- Verified normal join flow still works