### PR TITLE
Fix bootstrap config window race after map entry

### DIFF
--- a/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.BootstrapFlow.cs
@@ -16,6 +16,7 @@ public partial class BootstrapConfiguratorWindow
 {
     private const string BootstrapSaveName = "MpBootstrapSave";
     private const float PostMapEnterSaveDelaySeconds = 1.5f;
+    private const float PostMapEnterWindowDelaySeconds = 0.1f;
 
     private bool hideWindowDuringMapGen;
     private bool autoAdvanceArmed;
@@ -29,6 +30,7 @@ public partial class BootstrapConfiguratorWindow
     private string saveUploadStatus;
     private float saveUploadProgress;
     private float postMapEnterSaveDelayRemaining;
+    private float postMapEnterWindowDelayRemaining;
 
     private float GetGenerateMapStepHeight()
     {
@@ -132,6 +134,7 @@ public partial class BootstrapConfiguratorWindow
         savedReplayPath = null;
         autoAdvanceArmed = true;
         AwaitingBootstrapMapInit = true;
+        postMapEnterWindowDelayRemaining = 0f;
         saveUploadStatus = "Generating map...";
         Find.WindowStack.TryRemove(this);
 
@@ -144,7 +147,7 @@ public partial class BootstrapConfiguratorWindow
         if (AwaitingBootstrapMapInit)
             return;
 
-        if (Multiplayer.Client != null || bootstrapSaveQueued || saveReady || isUploadingSave || saveUploadAutoStarted)
+        if (Multiplayer.Client != null || bootstrapSaveQueued || saveReady || isUploadingSave || saveUploadAutoStarted || awaitingControllablePawns || postMapEnterSaveDelayRemaining > 0f)
             return;
 
         if (Current.ProgramState != ProgramState.Playing || Find.Maps == null || Find.Maps.Count == 0)
@@ -174,11 +177,10 @@ public partial class BootstrapConfiguratorWindow
         retainInstanceOnClose = false;
         AwaitingBootstrapMapInit = false;
         postMapEnterSaveDelayRemaining = PostMapEnterSaveDelaySeconds;
+        postMapEnterWindowDelayRemaining = PostMapEnterWindowDelaySeconds;
         awaitingControllablePawns = true;
         bootstrapSaveQueued = false;
         saveUploadStatus = "Map initialized. Waiting for controllable colonists to spawn...";
-
-        TryShowBootstrapWindow();
     }
 
     private void TryShowBootstrapWindow()
@@ -189,7 +191,7 @@ public partial class BootstrapConfiguratorWindow
         if (Find.WindowStack.WindowOfType<BootstrapConfiguratorWindow>() != null)
             return;
 
-        if (Find.WindowStack.Windows.OfType<Dialog_MessageBox>().Any())
+        if (Find.WindowStack.Windows.Any(window => window is Dialog_MessageBox or Dialog_NodeTree))
             return;
 
         Find.WindowStack.Add(this);
@@ -199,6 +201,13 @@ public partial class BootstrapConfiguratorWindow
     {
         if (hideWindowDuringMapGen || bootstrapSaveQueued || saveReady || isUploadingSave)
             return;
+
+        if (postMapEnterWindowDelayRemaining > 0f || postMapEnterSaveDelayRemaining > 0f || awaitingControllablePawns)
+        {
+            postMapEnterWindowDelayRemaining -= Time.deltaTime;
+            if (postMapEnterWindowDelayRemaining <= 0f)
+                TryShowBootstrapWindow();
+        }
 
         if (postMapEnterSaveDelayRemaining <= 0f && !awaitingControllablePawns)
             return;

--- a/Source/Client/Windows/BootstrapConfiguratorWindow.cs
+++ b/Source/Client/Windows/BootstrapConfiguratorWindow.cs
@@ -145,6 +145,7 @@ public partial class BootstrapConfiguratorWindow : Window, IConnectionStatusList
         isUploadingSave = false;
         saveUploadAutoStarted = false;
         postMapEnterSaveDelayRemaining = 0f;
+        postMapEnterWindowDelayRemaining = 0f;
 
         if (resetServerDrivenState)
         {


### PR DESCRIPTION
## Problem

During server bootstrap, after entering the generated map the Server Bootstrap Configuration window could reappear too early. In practice it could show before, or on top of, the scenario/game-start dialog instead of waiting until that dialog had been acknowledged.

## Cause

The bootstrap flow could re-show the config window immediately after map initialization, while the scenario dialog was still being opened or was still active. At the same time, the bootstrap-map-init arm path could still run during the post-init waiting phase.

## Fix

- add a short dedicated post-map delay before re-showing the bootstrap waiting window
- stop showing the bootstrap window immediately from OnBootstrapMapInitialized
- only show it when there are no blocking dialogs on the stack, including Dialog_MessageBox and Dialog_NodeTree
- avoid re-arming the bootstrap-map-init wait while already in the post-init waiting phase
- reset the new transient window-delay state together with the rest of the bootstrap transient state

## Testing

- reproduced the issue during bootstrap map creation
- built the client with `dotnet build .\Source\Client\Multiplayer.csproj -c Release`
- verified in game that the scenario dialog appears first and the bootstrap waiting window only appears after dismissing it
- completed the bootstrap flow through save upload and server shutdown