### PR TITLE
Disable unstable join-point live cache

### DIFF
--- a/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
@@ -276,7 +276,7 @@ public class AsyncWorldTimeComp : IExposable, ITickable
 
     private static void CreateJoinPointAndSendIfHost()
     {
-        Multiplayer.session.dataSnapshot = SaveLoad.CreateGameDataSnapshot(SaveLoad.SaveAndReload(true), Multiplayer.GameComp.multifaction);
+        Multiplayer.session.dataSnapshot = SaveLoad.CreateGameDataSnapshot(SaveLoad.SaveAndReload(), Multiplayer.GameComp.multifaction);
 
         if (!TickPatch.Simulating && !Multiplayer.IsReplay)
         {

--- a/Source/Client/Saving/SaveLoad.cs
+++ b/Source/Client/Saving/SaveLoad.cs
@@ -20,7 +20,7 @@ namespace Multiplayer.Client
 
     public static class SaveLoad
     {
-        public static TempGameData SaveAndReload(bool cache = false)
+        public static TempGameData SaveAndReload()
         {
             Multiplayer.reloading = true;
 

--- a/Source/Client/Saving/SaveLoad.cs
+++ b/Source/Client/Saving/SaveLoad.cs
@@ -24,9 +24,7 @@ namespace Multiplayer.Client
         {
             Multiplayer.reloading = true;
 
-            var worldGridSaved = Find.WorldGrid;
             var tweenedPos = new Dictionary<int, Vector3>();
-            var drawers = new Dictionary<int, MapDrawer>();
             var localFactionId = Multiplayer.RealPlayerFaction.loadID;
             var mapCmds = new Dictionary<int, Queue<ScheduledCommand>>();
             var planetRenderMode = Find.World.renderer.wantedMode;
@@ -37,8 +35,6 @@ namespace Multiplayer.Client
 
             foreach (Map map in Find.Maps)
             {
-                drawers[map.uniqueID] = map.mapDrawer;
-
                 foreach (Pawn p in map.mapPawns.AllPawnsSpawned)
                     tweenedPos[p.thingIDNumber] = p.drawer.tweener.tweenedPos;
 
@@ -58,20 +54,15 @@ namespace Multiplayer.Client
                 gameData = SaveGameData();
             }
 
-            if (cache)
-            {
-                MapDrawerRegenPatch.copyFrom = drawers;
-                WorldGridCachePatch.copyFrom = worldGridSaved;
-                WorldGridExposeDataPatch.copyFrom = worldGridSaved;
-                WorldRendererCachePatch.copyFrom = worldGridSaved;
-            }
-            else
-            {
-                MapDrawerRegenPatch.copyFrom.Clear();
-                WorldGridCachePatch.copyFrom = null;
-                WorldGridExposeDataPatch.copyFrom = null;
-                WorldRendererCachePatch.copyFrom = null;
-            }
+            // Join-point live caches stay disabled here.
+            // Reusing render/world objects across reload proved unstable, while the measured gain
+            // was only about half a second, which is not enough to justify the risk.
+            // We still clear/null the static holders instead of commenting them out so stale state
+            // cannot survive if another path ever arms these cache fields again.
+            MapDrawerRegenPatch.copyFrom.Clear();
+            WorldGridCachePatch.copyFrom = null;
+            WorldGridExposeDataPatch.copyFrom = null;
+            WorldRendererCachePatch.copyFrom = null;
 
             MusicManagerPlay musicManager = null;
             if (Find.MusicManagerPlay.gameObjectCreated)


### PR DESCRIPTION
## Summary
- stop rearming join-point live render/world caches in SaveLoad
- keep explicit Clear() and null resets instead of commenting out the copyFrom holders so stale static state cannot survive
- remove the dead SaveAndReload cache flag and update the remaining join-point callsite to the parameterless method
- document that the live-cache path was unstable and the measured gain of about half a second did not justify keeping it

## Testing
- dotnet build .\Source\Client\Multiplayer.csproj -c Release
- dotnet build .\Source\Server\Server.csproj -c Release