### PR TITLE
Fix plant growth quantization drift in save compression

### DIFF
--- a/Source/Client/Saving/SaveCompression.cs
+++ b/Source/Client/Saving/SaveCompression.cs
@@ -83,7 +83,7 @@ namespace Multiplayer.Client
                 writer.Write(thing.thingIDNumber);
                 writer.Write(thing.HitPoints);
 
-                byte growth = (byte)Math.Ceiling(thing.Growth * 255);
+                byte growth = EncodePlantGrowth(thing.Growth);
                 writer.Write(growth);
                 writer.Write(thing.Age);
 
@@ -105,6 +105,18 @@ namespace Multiplayer.Client
             {
                 writer.Write((ushort)0);
             }
+        }
+
+        private static byte EncodePlantGrowth(float growth)
+        {
+            int quantized = (int)(growth * 255f + 0.5f);
+
+            if (quantized < 0)
+                quantized = 0;
+            else if (quantized > 255)
+                quantized = 255;
+
+            return (byte)quantized;
         }
 
         public static void Load(Map map)


### PR DESCRIPTION
## Summary
This fixes a save compression round-trip issue where plant growth could drift upward after a save/load cycle.

## Root cause
I tracked this down while comparing normal hosted saves against the standalone/joinpoint path that goes through SaveAndReload.

With cache re-arming disabled for diagnostics, the payload diff consistently showed plant state changing across a save+reload roundtrip even when session data and queued commands stayed stable. The focused diff showed the same plant entry keeping the same id, HP, age, and flags, but with growthByte increasing by 1 after reload.

This comes from the plant compression format introduced in 2019 in commit e7076df (the save compression change). That commit changed plant growth serialization from a float to a byte using:
- save: ceil(Growth * 255)
- load: growthByte / 255f

That encoding is not round-trip stable, so repeated SaveAndReload cycles can ratchet plant growth upward.

## Change
Replace the ceil-based quantization with a round-to-nearest quantization that preserves byte -> float -> byte roundtrips.

## Validation
- Checked the history of SaveCompression.cs and confirmed the byte-based plant growth encoding was introduced by the 2019 save compression change.
- Reproduced the drift by comparing pre/post SaveAndReload payloads.
- After this change, compressedPlantsDeflate became identical before and after SaveAndReload in the diagnostic runs, removing the growthByte N -> N+1 drift.