### PR TITLE
Fix standalone join-point creation on join

### DIFF
--- a/Source/Common/Networking/State/ServerJoiningState.cs
+++ b/Source/Common/Networking/State/ServerJoiningState.cs
@@ -29,7 +29,7 @@ public class ServerJoiningState : AsyncConnectionState
         if (Server.settings.pauseOnJoin)
             Server.commands.PauseAll();
 
-        if (ShouldCreateJoinPointOnJoin(Server))
+        if (!Server.IsStandaloneServer && Server.settings.autoJoinPoint.HasFlag(AutoJoinPointFlags.Join))
             Server.worldData.TryStartJoinPointCreation(sourcePlayer: Player);
 
         Server.playerManager.OnJoin(Player);
@@ -38,16 +38,6 @@ public class ServerJoiningState : AsyncConnectionState
         await Packet(Packets.Client_WorldRequest);
 
         connection.ChangeState(ConnectionStateEnum.ServerLoading);
-    }
-
-    public static bool ShouldCreateJoinPointOnJoin(MultiplayerServer server)
-    {
-        // Standalone joins always consume the persisted world state. Fresh join points are created
-        // by players already inside the game during save/refresh flows, not by the entering client.
-        if (server.IsStandaloneServer)
-            return false;
-
-        return server.settings.autoJoinPoint.HasFlag(AutoJoinPointFlags.Join);
     }
 
     private void HandleProtocol(ClientProtocolPacket packet)

--- a/Source/Common/Networking/State/ServerJoiningState.cs
+++ b/Source/Common/Networking/State/ServerJoiningState.cs
@@ -29,10 +29,7 @@ public class ServerJoiningState : AsyncConnectionState
         if (Server.settings.pauseOnJoin)
             Server.commands.PauseAll();
 
-        // On standalone, only request a fresh join point when another player is already active.
-        // For the normal first join, serve the persisted state immediately instead of blocking on WaitJoinPoint.
-        if ((Server.IsStandaloneServer && Server.PlayingPlayers.Any()) ||
-            (!Server.IsStandaloneServer && Server.settings.autoJoinPoint.HasFlag(AutoJoinPointFlags.Join)))
+        if (ShouldCreateJoinPointOnJoin(Server))
             Server.worldData.TryStartJoinPointCreation(sourcePlayer: Player);
 
         Server.playerManager.OnJoin(Player);
@@ -41,6 +38,16 @@ public class ServerJoiningState : AsyncConnectionState
         await Packet(Packets.Client_WorldRequest);
 
         connection.ChangeState(ConnectionStateEnum.ServerLoading);
+    }
+
+    public static bool ShouldCreateJoinPointOnJoin(MultiplayerServer server)
+    {
+        // Standalone joins always consume the persisted world state. Fresh join points are created
+        // by players already inside the game during save/refresh flows, not by the entering client.
+        if (server.IsStandaloneServer)
+            return false;
+
+        return server.settings.autoJoinPoint.HasFlag(AutoJoinPointFlags.Join);
     }
 
     private void HandleProtocol(ClientProtocolPacket packet)

--- a/Source/Tests/ServerTest.cs
+++ b/Source/Tests/ServerTest.cs
@@ -96,6 +96,35 @@ public class ServerTest
         }
     }
 
+    [Test]
+    public void StandaloneJoinWithExistingPlayer_DoesNotStartJoinPoint()
+    {
+        var server = MakeServer(out var port);
+        server.IsStandaloneServer = true;
+
+        var existingConn = new RecordingConnection("existing");
+        existingConn.ChangeState(ConnectionStateEnum.ServerPlaying);
+        var existingPlayer = new ServerPlayer(100, existingConn);
+        existingConn.serverPlayer = existingPlayer;
+        server.playerManager.Players.Add(existingPlayer);
+
+        ConnectClient(port, typeof(TestJoiningState));
+
+        var timeoutWatch = Stopwatch.StartNew();
+        while (true)
+        {
+            if (server.playerManager.Players.Count == 1)
+                break;
+
+            if (timeoutWatch.ElapsedMilliseconds > 2000)
+                Assert.Fail("Timeout");
+
+            Thread.Sleep(50);
+        }
+
+        Assert.That(server.worldData.CreatingJoinPoint, Is.False);
+    }
+
     private void ConnectClient(int port, Type joiningStateType)
     {
         var clientListener = new TestNetListener(joiningStateType);

--- a/Source/Tests/StandaloneMapStreamingTest.cs
+++ b/Source/Tests/StandaloneMapStreamingTest.cs
@@ -142,24 +142,6 @@ public class StandaloneMapStreamingTest
     }
 
     [Test]
-    public void StandaloneJoin_DoesNotCreateJoinPoint_WhenAnotherPlayerIsAlreadyActive()
-    {
-        AddPlayer("existing", 1);
-
-        Assert.That(ServerJoiningState.ShouldCreateJoinPointOnJoin(server), Is.False);
-    }
-
-    [Test]
-    public void StandaloneJoin_DoesNotCreateJoinPoint_WhenStreamingIsEnabled()
-    {
-        server.settings.multifaction = true;
-        server.settings.asyncTime = true;
-        AddPlayer("existing", 1);
-
-        Assert.That(ServerJoiningState.ShouldCreateJoinPointOnJoin(server), Is.False);
-    }
-
-    [Test]
     public void HandleDebug_IgnoredWhenDevModeDisabled()
     {
         server.gameTimer = 123;

--- a/Source/Tests/StandaloneMapStreamingTest.cs
+++ b/Source/Tests/StandaloneMapStreamingTest.cs
@@ -142,6 +142,24 @@ public class StandaloneMapStreamingTest
     }
 
     [Test]
+    public void StandaloneJoin_DoesNotCreateJoinPoint_WhenAnotherPlayerIsAlreadyActive()
+    {
+        AddPlayer("existing", 1);
+
+        Assert.That(ServerJoiningState.ShouldCreateJoinPointOnJoin(server), Is.False);
+    }
+
+    [Test]
+    public void StandaloneJoin_DoesNotCreateJoinPoint_WhenStreamingIsEnabled()
+    {
+        server.settings.multifaction = true;
+        server.settings.asyncTime = true;
+        AddPlayer("existing", 1);
+
+        Assert.That(ServerJoiningState.ShouldCreateJoinPointOnJoin(server), Is.False);
+    }
+
+    [Test]
     public void HandleDebug_IgnoredWhenDevModeDisabled()
     {
         server.gameTimer = 123;


### PR DESCRIPTION
## Summary

Fix a dedicated standalone regression where subsequent players could fail to join after the first player entered the world.

On standalone servers, joining clients should consume the persisted world state directly. Fresh join-points should be created later by players already in-game during save or refresh flows, not during the initial server join path.

## Changes

- stop creating join-points during standalone server join
- centralize the join-time decision in `ServerJoiningState.ShouldCreateJoinPointOnJoin`
- add regression coverage for standalone joins when another player is already active

## Validation

- `dotnet test .\\Source\\Tests\\Tests.csproj -c Release --filter "FullyQualifiedName~StandaloneMapStreamingTest"`

Result:
- 10 tests passed
