### PR TITLE
Skip autosave requests while simulating

### DIFF
--- a/Source/Client/Patches/VTRSyncPatch.cs
+++ b/Source/Client/Patches/VTRSyncPatch.cs
@@ -2,7 +2,6 @@ using System;
 using HarmonyLib;
 using Multiplayer.Client.Util;
 using Multiplayer.Common;
-using Multiplayer.Common.Networking.Packet;
 using RimWorld.Planet;
 using Verse;
 
@@ -147,7 +146,7 @@ namespace Multiplayer.Client.Patches
                     // On standalone with streaming, trigger a join point when leaving a map
                     // so each player can save independently without disturbing others
                     if (Multiplayer.session?.ConnectedToStandaloneServer == true && Multiplayer.GameComp.multifaction && Multiplayer.GameComp.asyncTime)
-                        Multiplayer.Client.Send(new ClientAutosavingPacket(JoinPointRequestReason.WorldTravel));
+                        Autosaving.SendAutosavingRequest(JoinPointRequestReason.WorldTravel);
                 }
                 // Detect transition back to tile map
                 else if (__result != WorldRenderMode.Planet && lastRenderMode == WorldRenderMode.Planet)

--- a/Source/Client/Session/Autosaving.cs
+++ b/Source/Client/Session/Autosaving.cs
@@ -20,7 +20,7 @@ public static class Autosaving
             if (!SaveGameToFile_Overwrite(GetNextAutosaveFileName(), snapshot))
                 return;
 
-            Multiplayer.Client.Send(new ClientAutosavingPacket(JoinPointRequestReason.Save));
+            SendAutosavingRequest(JoinPointRequestReason.Save);
 
             // When connected to a standalone server, also upload fresh snapshots
             if (Multiplayer.session?.ConnectedToStandaloneServer == true)
@@ -29,6 +29,14 @@ public static class Autosaving
                 SaveLoad.SendStandaloneWorldSnapshot(snapshot);
             }
         }, "MpSaving", false, null);
+    }
+
+    public static void SendAutosavingRequest(JoinPointRequestReason reason)
+    {
+        if (TickPatch.Simulating)
+            return;
+
+        Multiplayer.Client.Send(new ClientAutosavingPacket(reason));
     }
 
     private static string GetNextAutosaveFileName()

--- a/Source/Client/Windows/SaveGameWindow.cs
+++ b/Source/Client/Windows/SaveGameWindow.cs
@@ -3,7 +3,6 @@ using Multiplayer.Common;
 using RimWorld;
 using System.Collections.Generic;
 using System.IO;
-using Multiplayer.Common.Networking.Packet;
 using UnityEngine;
 using Verse;
 
@@ -206,7 +205,7 @@ public class SaveGameWindow : Window
                 if (!Autosaving.SaveGameToFile_Overwrite(curText, currentReplay))
                     return;
 
-                Multiplayer.Client.Send(new ClientAutosavingPacket(JoinPointRequestReason.Save));
+                Autosaving.SendAutosavingRequest(JoinPointRequestReason.Save);
             }, "MpSaving", false, null);
             Close();
         }


### PR DESCRIPTION
Prevents clients from sending autosave/join-point requests while they are still simulating/catching up.  

A standalone client can currently send `ClientAutosavingPacket` during catch-up, for example when world render mode changes to planet mode after joining. The server accepts that as a join-point request, but the client cannot complete the join-point upload while `TickPatch.Simulating` is true. This can leave the standalone server stuck in join-point creation.