### PR TITLE
Fix delayed world-to-map pawn timestamp conversion

### DIFF
--- a/Source/Client/Patches/TimestampFixer.cs
+++ b/Source/Client/Patches/TimestampFixer.cs
@@ -96,8 +96,12 @@ static class PawnSpawn_FixTimestamp
         if (Multiplayer.Client == null) return;
         if (__instance.Map == null) return;
 
-        if (__instance.GetComp<MultiplayerPawnComp>().worldPawnRemoveTick == Multiplayer.AsyncWorldTime.worldTicks)
+        var comp = __instance.GetComp<MultiplayerPawnComp>();
+        if (comp.worldPawnRemoveTick != -1)
+        {
             TimestampFixer.FixPawn(__instance, null, __instance.Map);
+            comp.worldPawnRemoveTick = -1;
+        }
     }
 }
 
@@ -110,6 +114,9 @@ static class WorldPawnsAddPawn_FixTimestamp
 
         var lastMap = p.GetComp<MultiplayerPawnComp>().lastMap;
         if (lastMap != -1)
+        {
             TimestampFixer.FixPawn(p, Find.Maps.FirstOrDefault(m => m.uniqueID == lastMap), null);
+            p.GetComp<MultiplayerPawnComp>().lastMap = -1;
+        }
     }
 }


### PR DESCRIPTION
Disclaimer: I delegated the fix to codex but I don't know enough of the codebase to understand the fix.  

The bug it fixes is that pawn that come back from a lending pawn quest, never sleep.  
It's an issue with async time and the next sleep tick of the pawn is based on the world time tick.  
I did tested on my own server and my pawn can sleep normally after coming back from a lending pawn quests with this patch