### PR TITLE
Disable desync log stack trace unwinding for non-X86/X64 arches

### DIFF
--- a/Source/Client/Desyncs/DeferredStackTracing.cs
+++ b/Source/Client/Desyncs/DeferredStackTracing.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using HarmonyLib;
 using Multiplayer.Client.Patches;
 using Multiplayer.Common;
@@ -25,6 +26,9 @@ namespace Multiplayer.Client.Desyncs
 
         public static int acc;
 
+        private static bool SupportsDeferredStackTracing =>
+            RuntimeInformation.ProcessArchitecture is Architecture.X64 or Architecture.X86;
+
         public static void Postfix()
         {
             if (Native.LmfPtr == 0) return;
@@ -43,6 +47,7 @@ namespace Multiplayer.Client.Desyncs
 
         public static bool ShouldAddStackTraceForDesyncLog()
         {
+            if (!SupportsDeferredStackTracing) return false;
             if (Multiplayer.Client == null) return false;
             if (Multiplayer.settings.desyncTracingMode == DesyncTracingMode.None) return false;
             if (Multiplayer.game == null) return false;


### PR DESCRIPTION
This is implemented only for x86 and using it on other arches breaks the game tick.

Related to issue https://github.com/rwmt/Multiplayer/issues/944 and PR https://github.com/rwmt/Multiplayer/pull/827