### PR TITLE
Fix spectator home check with null faction

### DIFF
--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -871,7 +871,7 @@ static class Map_IsPlayerHome_Spectator_Patch
             if (!__instance.wasSpawnedViaGravShipLanding)
             {
                 MapInfo mapInfo = __instance.info;
-                if (((mapInfo != null) ? mapInfo.parent : null) == null || __instance.info.parent.Faction.IsPlayer == false || !__instance.info.parent.def.canBePlayerHome)
+                if (((mapInfo != null) ? mapInfo.parent : null) == null || __instance.info.parent.Faction?.IsPlayer != true || !__instance.info.parent.def.canBePlayerHome)
                 {
                     __result = GravshipUtility.PlayerHasGravEngine(__instance);
                     return false;


### PR DESCRIPTION
I've hit the nullref while playing, when you enter abandoned bases.