### PR TITLE
Fix drafted-move desync from unsynced EndCurrentJob in PawnGotoAction

### DIFF
--- a/Source/Client/Patches/Feedback.cs
+++ b/Source/Client/Patches/Feedback.cs
@@ -237,11 +237,15 @@ namespace Multiplayer.Client.Patches
         private static MethodInfo tryTakeOrderedJob =
             AccessTools.Method(typeof(Pawn_JobTracker), nameof(Pawn_JobTracker.TryTakeOrderedJob));
 
+        private static MethodInfo endCurrentJob =
+            AccessTools.Method(typeof(Pawn_JobTracker), nameof(Pawn_JobTracker.EndCurrentJob));
+
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             foreach (var inst in instructions)
             {
                 if (inst.Calls(tryTakeOrderedJob)) inst.operand = ((Delegate)CustomTryTakeOrderedJob).Method;
+                else if (inst.Calls(endCurrentJob)) inst.operand = ((Delegate)CustomEndCurrentJob).Method;
                 yield return inst;
             }
         }
@@ -253,6 +257,17 @@ namespace Multiplayer.Client.Patches
             if (self.TryTakeOrderedJob(job, tag, requestQueueing) && (TickPatch.currentExecutingCmdIssuedBySelf || Multiplayer.Client == null))
                 FleckMaker.Static(job.targetA.Cell, self.pawn.Map, FleckDefOf.FeedbackGoto);
             return false;
+        }
+
+        // PawnGotoAction can also stop a pawn without going through TryTakeOrderedJob: when the pawn is
+        // already standing on gotoLoc and its current job is Goto, it calls EndCurrentJob directly. That
+        // call isn't synced, so the pawn stops only for the player who issued the order while it keeps
+        // walking for everyone else, causing a desync. Sync it the same way as the TryTakeOrderedJob call.
+        [SyncMethod]
+        static void CustomEndCurrentJob(Pawn_JobTracker self, JobCondition condition,
+            bool startNewJob = true, bool canReturnToPool = true)
+        {
+            self.EndCurrentJob(condition, startNewJob, canReturnToPool);
         }
     }
 


### PR DESCRIPTION
Fixes #849.

`PawnGotoAction` runs once per pawn on the client that issues a drafted move order. We already sync its `TryTakeOrderedJob` call, but it has another path: when a pawn is already standing on `gotoLoc` and its current job is `Goto`, it calls `Pawn_JobTracker.EndCurrentJob` directly. That call isn't synced, so the pawn stops only for the player who issued the order while it keeps walking for everyone else, causing a desync.

This redirects that `EndCurrentJob` call to a synced wrapper through the existing `DraftedMove_GotoFeedbackPatch` transpiler, the same way the `TryTakeOrderedJob` call is handled — the first solution proposed in #849.

Repro: draft a group, give a long move order, then while they're still walking re-issue a move onto the cells they're currently standing on. Desynced 3/3 for me; with this change I couldn't reproduce it in 10 attempts. I've also been running it as a small separate mod in our ongoing multiplayer game with no issues so far.
