### PR TITLE
Fix NRE showing join data window after a def mismatch

### DIFF
--- a/Source/Client/Networking/State/ClientJoiningState.cs
+++ b/Source/Client/Networking/State/ClientJoiningState.cs
@@ -96,6 +96,8 @@ namespace Multiplayer.Client
             }
 
             var remoteInfo = RemoteData.FromNet(packet);
+            // Captured before Complete runs: StopMultiplayerAndClearAllWindows nulls the session
+            var connector = Multiplayer.session.connector;
 
             // Delay showing the window for better UX
             OnMainThread.Schedule(Complete, 0.3f);
@@ -117,7 +119,7 @@ namespace Multiplayer.Client
                     .Take(10)
                     .Join(kv => $"{kv.name}: {kv.status}", "\n");
 
-                Find.WindowStack.Add(new JoinDataWindow(remoteInfo, Multiplayer.session.connector)
+                Find.WindowStack.Add(new JoinDataWindow(remoteInfo, connector)
                 {
                     connectAnywayDisabled = defDiff ? "MpMismatchDefsDiff".Translate() + defDiffStr : null,
                     connectAnywayCallback = StartDownloading


### PR DESCRIPTION
### Problem

A client that joins a server with mismatched defs never sees the "Data mismatch" window. Instead the join fails with an NRE and the session is torn down:

```
Stopping multiplayer session from static System.Void Multiplayer.Client.Multiplayer::StopMultiplayerAndClearAllWindows()
Exception running scheduled action: System.NullReferenceException: Object reference not set to an instance of an object
  at Multiplayer.Client.ClientJoiningState+<>c__DisplayClass10_0.<HandleJoinData>g__Complete|0 () [0x0009e] in Multiplayer/Networking/State/ClientJoiningState.cs:120
  at Multiplayer.Client.OnMainThread.RunScheduled () [0x00034] in Multiplayer/OnMainThread.cs:79
```

The player is left with no indication of *which* defs mismatched and no way to use "Connect anyway" or "Fix and restart".

### Cause

In `HandleJoinData`'s deferred `Complete` callback, a def mismatch calls `Multiplayer.StopMultiplayerAndClearAllWindows()`, which sets `Multiplayer.session = null`. Eight lines later the same callback constructs the window with `Multiplayer.session.connector`, dereferencing the session that was just nulled.

The `Multiplayer.session.connector` argument was introduced in d01bfda ("Typed `ClientInitDataPacket.Mods`"), so this path has been broken since then. Only the `defDiff` branch is affected — a mods/configs-only mismatch leaves the session alive and works fine, which is why it isn't hit more often.

### Fix

Capture the connector into a local at the top of `HandleJoinData`, while the session is still guaranteed alive, and pass that to `JoinDataWindow`. This mirrors the existing null-safety in `BootstrapConfiguratorWindow`, which already reads `Multiplayer.session?.connector`.

### Testing

Reproduced by joining a host with a differing def set; verified the NRE no longer occurs and the Data mismatch window opens. Platform-independent, though it was found on macOS/arm64.