### PR TITLE
Isolate RNG in the gravship launch ritual's reachability check

### DIFF
--- a/Source/Client/Patches/Seeds.cs
+++ b/Source/Client/Patches/Seeds.cs
@@ -235,4 +235,34 @@ namespace Multiplayer.Client
         }
     }
 
+    [HarmonyPatch(typeof(RitualBehaviorWorker_GravshipLaunch), nameof(RitualBehaviorWorker_GravshipLaunch.CanReachGravship))]
+    static class SeedGravshipCanReachGravship
+    {
+        static void Prefix(ref bool __state)
+        {
+            if (Multiplayer.Client == null) return;
+
+            // The gravship launch confirmation dialog works out which pawns can board while it is being
+            // built: Dialog_BeginRitual's constructor calls CreateRitualRoleAssignments ->
+            // RitualRoleAssignments.PawnNotAssignableReason -> RitualBehaviorWorker_GravshipLaunch
+            // .PawnCanFillRole -> CanReachGravship -> GravshipUtility.TryFindSpotOnGravship ->
+            // Region.RandomCell, which consumes RNG. Building that dialog is UI work and, because the
+            // dialog is opened only by the issuing peer (see CancelDialogBeginRitual's
+            // currentExecutingCmdIssuedBySelf gate), it runs on just one peer - so this RNG must not
+            // advance the shared stream. Spamming the launch button repeats it and the divergence
+            // accumulates into a desync ("Random state from commands doesn't match").
+            // CanReachGravship returns a bool that does not depend on the RNG (it only searches for any
+            // allowed cell), and the real boarding calls TryFindSpotOnGravship outside this check, so
+            // isolating the RNG here leaves both the check result and determinism intact.
+            Rand.PushState();
+            __state = true;
+        }
+
+        static void Finalizer(bool __state)
+        {
+            if (__state)
+                Rand.PopState();
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #967.

## Problem

Building the gravship launch confirmation dialog decides which pawns can board, in `Dialog_BeginRitual`'s constructor:

```
Dialog_BeginRitual..ctor -> CreateRitualRoleAssignments
  -> RitualRoleAssignments.PawnNotAssignableReason
  -> RitualBehaviorWorker_GravshipLaunch.PawnCanFillRole
  -> CanReachGravship -> GravshipUtility.TryFindSpotOnGravship
  -> Region.RandomCell -> Rand.Range        // consumes RNG
```

Building the dialog is UI work opened only by the issuing peer (the `currentExecutingCmdIssuedBySelf` gate in `CancelDialogBeginRitual`), so this RNG runs on just one peer and advances the shared stream there only. Spamming the launch button repeats it and the divergence accumulates into a desync (`Random state from commands doesn't match`). Measured: with nothing ticking, the gravship map alone was off by +11,617 rand iterations, all on the peer that pressed launch.

## Fix

Wrap `RitualBehaviorWorker_GravshipLaunch.CanReachGravship` in `Rand.PushState` / `PopState`, matching the existing `SeedPreceptComp_UnwillingToDo_Chance` isolation in the same file for RNG that "can be called in interface". `CanReachGravship` returns a bool that does not depend on the RNG (it only searches for any allowed cell), and the real boarding calls `TryFindSpotOnGravship` outside this check, so isolating here leaves both the check result and determinism intact.

## Testing

- Reproduced on vanilla Multiplayer + Odyssey (async time + multifaction, no third-party mods): spamming the launch button desyncs a client with `Random state from commands doesn't match`.
- With this fix, ~100 rapid clicks produce no desync.
- `Source/Client` builds clean (Release).

---

*Investigated and written with the help of Claude (Anthropic).*
