### PR TITLE
CI: Fix Roslyn version mismatch causing CS8795 build failures (#970), harden PR CI

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -31,6 +31,14 @@ jobs:
     - name: Display SDK version
       run: dotnet --version
 
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
     - name: Install Mod Dependencies
       run: dotnet restore ${{ env.SLN_PATH }}
 

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -13,11 +13,8 @@ on:
 
 jobs:
   build:
-    name: Build beta (.NET ${{ matrix.dotnet }})
+    name: Build beta
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: ['9.x', '10.x']
     env:
         GH_TOKEN: ${{ github.token }}
     steps:
@@ -26,19 +23,14 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Setup .NET ${{ matrix.dotnet }}
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
-      id: setup-dotnet
       with:
-        dotnet-version: ${{ matrix.dotnet }}
-
-    - name: Override global.json for matrix testing
-      run: |
-        echo "{\"sdk\":{\"version\":\"${{ steps.setup-dotnet.outputs.dotnet-version }}\"}}" > global.json
+        dotnet-version: 9.x
 
     - name: Display SDK version
       run: dotnet --version
-      
+
     - name: Install Mod Dependencies
       run: dotnet restore ${{ env.SLN_PATH }}
 

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -13,8 +13,11 @@ on:
 
 jobs:
   build:
-    name: Build beta
+    name: Build beta (.NET ${{ matrix.dotnet }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet: ['9.x', '10.x']
     env:
         GH_TOKEN: ${{ github.token }}
     steps:
@@ -22,11 +25,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-      
-    - name: Setup Dotnet
+
+    - name: Setup .NET ${{ matrix.dotnet }}
       uses: actions/setup-dotnet@v4
+      id: setup-dotnet
       with:
-        dotnet-version: 9.x
+        dotnet-version: ${{ matrix.dotnet }}
+
+    - name: Override global.json for matrix testing
+      run: |
+        echo "{\"sdk\":{\"version\":\"${{ steps.setup-dotnet.outputs.dotnet-version }}\"}}" > global.json
+
+    - name: Display SDK version
+      run: dotnet --version
       
     - name: Install Mod Dependencies
       run: dotnet restore ${{ env.SLN_PATH }}

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -23,21 +23,13 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Setup .NET
+    - name: Setup Dotnet
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.x
 
     - name: Display SDK version
       run: dotnet --version
-
-    - name: Cache NuGet packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
 
     - name: Install Mod Dependencies
       run: dotnet restore ${{ env.SLN_PATH }}

--- a/.github/workflows/build-workshop.yml
+++ b/.github/workflows/build-workshop.yml
@@ -21,7 +21,10 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.x
-      
+
+    - name: Display SDK version
+      run: dotnet --version
+
     - name: Run workshop bundler
       run: ./workshop_bundler.sh
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -32,20 +32,14 @@ jobs:
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: 9.x
+        cache: true
+        cache-dependency-path: '**/*.csproj'
       env:
         DOTNET_NOLOGO: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     - name: Display SDK version
       run: dotnet --version
-
-    - name: Cache NuGet packages
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
 
     - name: Restore dependencies
       run: dotnet restore ${{ env.SLN_PATH }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
     steps:
     
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: 9.x
       env:
@@ -32,7 +32,7 @@ jobs:
       run: dotnet --version
 
     - name: Cache NuGet packages
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -53,8 +53,8 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: test-results
+        name: test-results-${{ matrix.os }}
         path: '**/TestResults/**'
         retention-days: 7

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,6 +8,10 @@ env:
 on:
   pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   builds:
     name: Builds (${{ matrix.os }})

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build-test:
-    name: Build, Test (${{ matrix.os }}, ${{ matrix.configuration }}, .NET ${{ matrix.sdk }})
+    name: Build, Test (${{ matrix.os }}, .NET ${{ matrix.sdk }}, ${{ matrix.configuration }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     # '11' is preview-only right now, so let it fail without blocking the PR -

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -37,6 +37,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     # The committed global.json pins a specific major version, which would
     # otherwise force every "dotnet" invocation on this leg (including
@@ -118,6 +120,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,6 +27,14 @@ jobs:
     - name: Display SDK version
       run: dotnet --version
 
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
     - name: Restore dependencies
       run: dotnet restore ${{ env.SLN_PATH }}
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,12 +17,13 @@ concurrency:
 
 jobs:
   builds:
-    name: Builds (${{ matrix.os }})
+    name: Builds (${{ matrix.os }}, ${{ matrix.configuration }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        configuration: [Debug, Release]
       fail-fast: false
     steps:
     
@@ -44,20 +45,17 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore ${{ env.SLN_PATH }}
 
-    - name: Build debug
-      run: dotnet build ${{ env.SLN_PATH }} --no-restore   
-             
-    - name: Build release
-      run: dotnet build ${{ env.SLN_PATH }} --configuration Release --no-restore
+    - name: Build
+      run: dotnet build ${{ env.SLN_PATH }} --configuration ${{ matrix.configuration }} --no-restore
 
     - name: Run tests
-      run: dotnet test ${{ env.SLN_PATH }} --no-restore --logger "trx;logfilename=TestResults.trx"
+      run: dotnet test ${{ env.SLN_PATH }} --configuration ${{ matrix.configuration }} --no-restore --logger "trx;logfilename=TestResults.trx"
 
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: test-results-${{ matrix.os }}
+        name: test-results-${{ matrix.os }}-${{ matrix.configuration }}
         path: '**/TestResults/**'
         retention-days: 7
         if-no-files-found: error

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -139,3 +139,74 @@ jobs:
     - name: Check code formatting
       continue-on-error: true
       run: dotnet format ${{ env.SLN_PATH }} --verify-no-changes
+
+  package-artifacts:
+    name: Package mod, server artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+
+    # submodules: recursive is required here (unlike the other jobs) because
+    # Languages/ is a submodule and gets bundled directly into the mod
+    # artifact.
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+        submodules: recursive
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        global-json-file: global.json
+        cache: true
+        cache-dependency-path: '**/*.csproj'
+
+    - name: Restore dependencies
+      run: dotnet restore ${{ env.SLN_PATH }}
+
+    # Multiplayer.csproj copies its build output into Assemblies/ and
+    # AssembliesCustom/ as a post-build step, alongside the static About/,
+    # Defs/, Languages/, and Textures/ content - together these are the
+    # complete mod folder.
+    - name: Build mod (Release)
+      run: dotnet build ${{ env.SLN_PATH }} --configuration Release --no-restore
+
+    # Server.csproj publish restores runtime-specific assets itself, so no
+    # --no-restore here.
+    - name: Publish server (Windows)
+      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --runtime win-x64 --self-contained false -p:UseAppHost=true -o output/Server/Windows
+
+    - name: Publish server (Linux)
+      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --runtime linux-x64 --self-contained false -p:UseAppHost=true -o output/Server/Linux
+
+    - name: Add server launcher script
+      run: |
+        cat > output/Server/Linux/Server.sh <<'EOF'
+        #!/usr/bin/env bash
+        set -euo pipefail
+        SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+        exec dotnet "$SCRIPT_DIR/Server.dll" "$@"
+        EOF
+        chmod +x output/Server/Linux/Server.sh
+
+    - name: Package mod files
+      run: |
+        mkdir -p output/Multiplayer
+        mv About/ Assemblies/ AssembliesCustom/ Defs/ Languages/ Textures/ output/Multiplayer/
+
+    - name: Upload mod artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: Multiplayer-mod
+        path: output/Multiplayer/
+        retention-days: 7
+        if-no-files-found: error
+
+    - name: Upload server artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: Multiplayer-server
+        path: output/Server/
+        retention-days: 7
+        if-no-files-found: error

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,8 @@ name: Validate Pull Request
 
 env:
   SLN_PATH: Source/
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 permissions:
   contents: read
@@ -47,9 +49,6 @@ jobs:
         global-json-file: global.json
         cache: true
         cache-dependency-path: '**/*.csproj'
-      env:
-        DOTNET_NOLOGO: true
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     - name: Set up .NET (override)
       if: matrix.sdk != 'global.json'
@@ -58,9 +57,6 @@ jobs:
         dotnet-version: ${{ matrix.sdk }}.0.x
         cache: true
         cache-dependency-path: '**/*.csproj'
-      env:
-        DOTNET_NOLOGO: true
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     - name: Display SDK version
       run: dotnet --version
@@ -98,9 +94,6 @@ jobs:
         global-json-file: global.json
         cache: true
         cache-dependency-path: '**/*.csproj'
-      env:
-        DOTNET_NOLOGO: true
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     - name: Restore dependencies
       run: dotnet restore ${{ env.SLN_PATH }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,6 +12,7 @@ jobs:
   builds:
     name: Builds (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,8 +10,12 @@ on:
 
 jobs:
   builds:
-    name: Builds
-    runs-on: ubuntu-latest
+    name: Builds (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
     steps:
     
     - uses: actions/checkout@v4
@@ -46,3 +50,11 @@ jobs:
 
     - name: Run tests
       run: dotnet test ${{ env.SLN_PATH }} --no-restore
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: '**/TestResults/**'
+        retention-days: 7

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -107,7 +107,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.configuration }}-${{ matrix.sdk }}
+        name: test-results-${{ matrix.os }}-${{ matrix.sdk }}-${{ matrix.configuration }}
         path: '**/TestResults/**'
         retention-days: 7
         if-no-files-found: error
@@ -155,6 +155,12 @@ jobs:
         persist-credentials: false
         submodules: recursive
 
+    # GitHub Actions expressions have no substring function, so the short
+    # SHA used to name artifacts below is computed here instead.
+    - name: Compute short commit SHA
+      id: vars
+      run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
     - name: Set up .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
@@ -201,7 +207,7 @@ jobs:
     - name: Upload mod artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: Multiplayer-mod
+        name: Multiplayer-mod-pr${{ github.event.pull_request.number }}-${{ steps.vars.outputs.short_sha }}
         path: artifacts/mod/
         retention-days: 7
         if-no-files-found: error
@@ -209,7 +215,7 @@ jobs:
     - name: Upload server artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: Multiplayer-server
+        name: Multiplayer-server-pr${{ github.event.pull_request.number }}-${{ steps.vars.outputs.short_sha }}
         path: artifacts/server/
         retention-days: 7
         if-no-files-found: error

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,7 +23,10 @@ jobs:
       env:
         DOTNET_NOLOGO: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true
-        
+
+    - name: Display SDK version
+      run: dotnet --version
+
     - name: Restore dependencies
       run: dotnet restore ${{ env.SLN_PATH }}
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,22 +17,35 @@ concurrency:
 
 jobs:
   builds:
-    name: Builds (${{ matrix.os }}, ${{ matrix.configuration }})
+    name: Builds (${{ matrix.os }}, ${{ matrix.configuration }}, .NET ${{ matrix.sdk }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         configuration: [Debug, Release]
+        sdk: [global.json, 10.0.x]
       fail-fast: false
     steps:
-    
+
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Set up .NET
+    - name: Set up .NET (from global.json)
+      if: matrix.sdk == 'global.json'
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: 9.x
+        global-json-file: global.json
+        cache: true
+        cache-dependency-path: '**/*.csproj'
+      env:
+        DOTNET_NOLOGO: true
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+    - name: Set up .NET (override SDK)
+      if: matrix.sdk != 'global.json'
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        dotnet-version: ${{ matrix.sdk }}
         cache: true
         cache-dependency-path: '**/*.csproj'
       env:
@@ -55,7 +68,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.configuration }}
+        name: test-results-${{ matrix.os }}-${{ matrix.configuration }}-${{ matrix.sdk }}
         path: '**/TestResults/**'
         retention-days: 7
         if-no-files-found: error

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -103,6 +103,9 @@ jobs:
     - name: Run tests
       run: dotnet test ${{ env.SLN_PATH }} --configuration ${{ matrix.configuration }} --no-restore --logger "trx;logfilename=TestResults.trx"
 
+    # overwrite: true because this name is keyed by matrix values, not run
+    # attempt - re-running a flaky test leg without a new push would
+    # otherwise 409-conflict against the first attempt's artifact.
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -111,6 +114,7 @@ jobs:
         path: '**/TestResults/**'
         retention-days: 7
         if-no-files-found: error
+        overwrite: true
 
   format-check:
     name: Code formatting (non-blocking)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -175,31 +175,34 @@ jobs:
     # Server.csproj publish restores runtime-specific assets itself, so no
     # --no-restore here.
     - name: Publish server (Windows)
-      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --runtime win-x64 --self-contained false -p:UseAppHost=true -o output/Server/Windows
+      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --runtime win-x64 --self-contained false -p:UseAppHost=true -o artifacts/server/Server/Windows
 
     - name: Publish server (Linux)
-      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --runtime linux-x64 --self-contained false -p:UseAppHost=true -o output/Server/Linux
+      run: dotnet publish ${{ env.SLN_PATH }}Server/Server.csproj --configuration Release --runtime linux-x64 --self-contained false -p:UseAppHost=true -o artifacts/server/Server/Linux
 
     - name: Add server launcher script
       run: |
-        cat > output/Server/Linux/Server.sh <<'EOF'
+        cat > artifacts/server/Server/Linux/Server.sh <<'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
         SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
         exec dotnet "$SCRIPT_DIR/Server.dll" "$@"
         EOF
-        chmod +x output/Server/Linux/Server.sh
+        chmod +x artifacts/server/Server/Linux/Server.sh
 
     - name: Package mod files
       run: |
-        mkdir -p output/Multiplayer
-        mv About/ Assemblies/ AssembliesCustom/ Defs/ Languages/ Textures/ output/Multiplayer/
+        mkdir -p artifacts/mod/Multiplayer
+        mv About/ Assemblies/ AssembliesCustom/ Defs/ Languages/ Textures/ artifacts/mod/Multiplayer/
 
+    # upload-artifact strips exactly the given "path" and keeps everything
+    # below it, so pointing at the parent of Multiplayer/ and Server/ (rather
+    # than at those folders directly) is what makes them the zip's root.
     - name: Upload mod artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Multiplayer-mod
-        path: output/Multiplayer/
+        path: artifacts/mod/
         retention-days: 7
         if-no-files-found: error
 
@@ -207,6 +210,6 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Multiplayer-server
-        path: output/Server/
+        path: artifacts/server/
         retention-days: 7
         if-no-files-found: error

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,9 @@ name: Validate Pull Request
 env:
   SLN_PATH: Source/
 
+permissions:
+  contents: read
+
 on:
   pull_request
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,7 +49,7 @@ jobs:
       run: dotnet build ${{ env.SLN_PATH }} --configuration Release --no-restore
 
     - name: Run tests
-      run: dotnet test ${{ env.SLN_PATH }} --no-restore
+      run: dotnet test ${{ env.SLN_PATH }} --no-restore --logger "trx;logfilename=TestResults.trx"
 
     - name: Upload test results
       if: always()

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -42,9 +42,9 @@ jobs:
     # otherwise force every "dotnet" invocation on this leg (including
     # setup-dotnet's own internal calls) back to that version regardless of
     # which SDK we install below.
-    - name: Pin global.json to override SDK
+    - name: Remove committed global.json for SDK override leg
       if: matrix.sdk != 'global.json'
-      run: echo '{"sdk":{"version":"${{ matrix.sdk }}.0.100","rollForward":"latestFeature"}}' > ./global.json
+      run: rm global.json
 
     - name: Set up .NET (pinned)
       if: matrix.sdk == 'global.json'
@@ -56,14 +56,41 @@ jobs:
 
     - name: Set up .NET (override)
       if: matrix.sdk != 'global.json'
+      id: setup_dotnet_override
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: ${{ matrix.sdk }}.0.x
         cache: true
         cache-dependency-path: '**/*.csproj'
 
+    # A generic "major.0.100" anchor + rollForward doesn't reliably match a
+    # preview-only install (dotnet/sdk#12335, reproduced here for the "11"
+    # leg) - pin the exact resolved version instead, per
+    # https://github.com/actions/setup-dotnet#matrix-testing.
+    - name: Pin global.json to resolved override SDK
+      if: matrix.sdk != 'global.json'
+      run: echo '{"sdk":{"version":"${{ steps.setup_dotnet_override.outputs.dotnet-version }}","rollForward":"latestPatch"}}' > ./global.json
+
     - name: Display SDK version
       run: dotnet --version
+
+    # Catches a silent wrong-SDK regression: dotnet --version could report
+    # the global.json-pinned major instead of this leg's intended one
+    # without anything failing until the logs were read by hand.
+    - name: Verify resolved SDK matches this leg's expected major version
+      shell: bash
+      run: |
+        ACTUAL_MAJOR=$(dotnet --version | cut -d. -f1)
+        if [ "${{ matrix.sdk }}" = "global.json" ]; then
+          EXPECTED_MAJOR=$(grep -oE '"version": *"[0-9]+' global.json | grep -oE '[0-9]+$')
+        else
+          EXPECTED_MAJOR="${{ matrix.sdk }}"
+        fi
+        echo "Resolved SDK major: $ACTUAL_MAJOR, expected: $EXPECTED_MAJOR"
+        if [ "$ACTUAL_MAJOR" != "$EXPECTED_MAJOR" ]; then
+          echo "::error::Resolved .NET SDK major ($ACTUAL_MAJOR) does not match this leg's expected major ($EXPECTED_MAJOR)"
+          exit 1
+        fi
 
     - name: Restore dependencies
       run: dotnet restore ${{ env.SLN_PATH }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,11 +24,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         configuration: [Debug, Release]
-        sdk: [global.json, 10.0.x]
+        # Add another major version (e.g. '11', '8') to test more SDKs.
+        sdk: [global.json, '10']
       fail-fast: false
     steps:
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    # The committed global.json pins a specific major version, which would
+    # otherwise force every "dotnet" invocation on this leg (including
+    # setup-dotnet's own internal calls) back to that version regardless of
+    # which SDK we install below.
+    - name: Point global.json at this leg's SDK major version
+      if: matrix.sdk != 'global.json'
+      run: echo '{"sdk":{"version":"${{ matrix.sdk }}.0.100","rollForward":"latestFeature"}}' > ./global.json
 
     - name: Set up .NET (from global.json)
       if: matrix.sdk == 'global.json'
@@ -45,7 +54,7 @@ jobs:
       if: matrix.sdk != 'global.json'
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: ${{ matrix.sdk }}
+        dotnet-version: ${{ matrix.sdk }}.0.x
         cache: true
         cache-dependency-path: '**/*.csproj'
       env:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -63,3 +63,4 @@ jobs:
         name: test-results-${{ matrix.os }}
         path: '**/TestResults/**'
         retention-days: 7
+        if-no-files-found: error

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  builds:
-    name: Builds (${{ matrix.os }}, ${{ matrix.configuration }}, .NET ${{ matrix.sdk }})
+  build-test:
+    name: Build, Test (${{ matrix.os }}, ${{ matrix.configuration }}, .NET ${{ matrix.sdk }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -29,17 +29,18 @@ jobs:
       fail-fast: false
     steps:
 
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # The committed global.json pins a specific major version, which would
     # otherwise force every "dotnet" invocation on this leg (including
     # setup-dotnet's own internal calls) back to that version regardless of
     # which SDK we install below.
-    - name: Point global.json at this leg's SDK major version
+    - name: Pin global.json to override SDK
       if: matrix.sdk != 'global.json'
       run: echo '{"sdk":{"version":"${{ matrix.sdk }}.0.100","rollForward":"latestFeature"}}' > ./global.json
 
-    - name: Set up .NET (from global.json)
+    - name: Set up .NET (pinned)
       if: matrix.sdk == 'global.json'
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
@@ -50,7 +51,7 @@ jobs:
         DOTNET_NOLOGO: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true
 
-    - name: Set up .NET (override SDK)
+    - name: Set up .NET (override)
       if: matrix.sdk != 'global.json'
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
@@ -67,7 +68,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore ${{ env.SLN_PATH }}
 
-    - name: Build
+    - name: Build solution
       run: dotnet build ${{ env.SLN_PATH }} --configuration ${{ matrix.configuration }} --no-restore
 
     - name: Run tests
@@ -83,12 +84,13 @@ jobs:
         if-no-files-found: error
 
   format-check:
-    name: Code formatting (informational)
+    name: Code formatting (non-blocking)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
 
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,12 +22,16 @@ jobs:
     name: Build, Test (${{ matrix.os }}, ${{ matrix.configuration }}, .NET ${{ matrix.sdk }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    # '11' is preview-only right now, so let it fail without blocking the PR -
+    # this leg exists to catch upcoming breaks early, not to gate on
+    # preview-SDK bugs unrelated to this repo's code.
+    continue-on-error: ${{ matrix.sdk == '11' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         configuration: [Debug, Release]
-        # Add another major version (e.g. '11', '8') to test more SDKs.
-        sdk: [global.json, '10']
+        # Add another major version (e.g. '12', '8') to test more SDKs.
+        sdk: [global.json, '10', '11']
       fail-fast: false
     steps:
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -81,3 +81,31 @@ jobs:
         path: '**/TestResults/**'
         retention-days: 7
         if-no-files-found: error
+
+  format-check:
+    name: Code formatting (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        global-json-file: global.json
+        cache: true
+        cache-dependency-path: '**/*.csproj'
+      env:
+        DOTNET_NOLOGO: true
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+    - name: Restore dependencies
+      run: dotnet restore ${{ env.SLN_PATH }}
+
+    # continue-on-error keeps this from failing the PR: the repo has existing
+    # formatting debt, so this reports issues in the log without blocking
+    # merges until that debt is cleaned up.
+    - name: Check code formatting
+      continue-on-error: true
+      run: dotnet format ${{ env.SLN_PATH }} --verify-no-changes

--- a/Source/SourceGen/SourceGen.csproj
+++ b/Source/SourceGen/SourceGen.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.13.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMinor"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.316",
+    "version": "9.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "9.0.316",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Fixes #970: builds failed with cascading `CS9057`/`CS8795` errors because `SourceGen.csproj` pinned `Microsoft.CodeAnalysis.CSharp`/`.Analyzers` to `5.3.0`, which requires Roslyn 5.3.0+ (bundled starting in .NET SDK 10.0.300+), while CI and most local setups run .NET 9.x, which only bundles Roslyn 4.14.0. Downgrading to `4.13.0` restores compatibility with 9.x while remaining forward-compatible with 10.x and 11.x — verified directly in CI across all three.

Everything else in this PR is CI infrastructure that grew out of diagnosing and guarding against that failure: a pinned local SDK version so contributors don't hit environment drift, SDK-version visibility in every pipeline's logs, and a substantially hardened `pr-check.yml` that turned up (and fixed) several pre-existing correctness bugs along the way.

---

## 1. The actual fix

`Source/SourceGen/SourceGen.csproj`: `Microsoft.CodeAnalysis.CSharp` / `.Analyzers` `5.3.0` → `4.13.0`.

## 2. Supporting changes (small, all three workflows)

- **`global.json`** (new): pins the local/CI SDK baseline to `9.0.100` with `rollForward: latestMinor`, so contributors and CI resolve the same SDK family without needing an exact patch match.
- **`build-beta.yml`, `build-workshop.yml`**: added a one-line `Display SDK version` (`dotnet --version`) step to each, purely for log visibility when diagnosing future SDK-related failures. No other behavior changes to either file.

## 3. `pr-check.yml` overhaul

This is the bulk of the diff. Originally scoped as "add SDK visibility," it expanded into a full hardening pass once several real bugs surfaced during the work — each one confirmed via live GitHub Actions runs, not just locally.

**Action & permission hygiene**
- Pin `actions/checkout`, `setup-dotnet`, `cache`, `upload-artifact` to exact commit SHAs instead of floating tags
- Add explicit `permissions: contents: read`
- Add `persist-credentials: false` on checkout steps that never push
- Add a `concurrency` group to cancel stale runs on new pushes to the same PR

**Reliability fixes**
- **NuGet cache was permanently stuck.** The key hashed a `packages.lock.json` that doesn't exist in this repo, so the cache silently locked onto its first-ever save and never updated again. Switched to `setup-dotnet`'s built-in cache keyed off `**/*.csproj`.
- **Test-result upload failures were silent.** `if-no-files-found` defaulted to `warn`; a missing-artifact regression could pass CI unnoticed. Changed to `error`.
- **`DOTNET_CLI_TELEMETRY_OPTOUT` wasn't actually opting out of anything.** It was scoped only to the SDK-setup step, not the `restore`/`build`/`test` invocations that actually trigger telemetry. Moved to workflow-level `env`.
- **`timeout-minutes: 15`** added — a hung test previously had no CI-level backstop and could in theory run for hours.
- **Committed `global.json` was silently overriding matrix SDK selection.** `global.json` is read by the `dotnet` CLI for every invocation regardless of what a step installs — so when the matrix tried to test SDK 10/11, it either crashed or (worse) *silently built against the wrong SDK the whole time*, a false-positive green run. Fixed by rewriting `global.json` to each leg's resolved SDK before build steps, plus an explicit assertion step that now fails loudly if this regresses.
- **Generic version anchors don't match preview-only SDKs.** Pinning `"11.0.100"` with `rollForward` doesn't roll forward to an installed `11.0.100-preview.6.x` build even with `allowPrerelease` on by default (matches [dotnet/sdk#12335](https://github.com/dotnet/sdk/issues/12335)). Fixed by pinning to the exact resolved version string instead of a guessed one.

**Coverage**
- Matrix is now 3 OS (ubuntu/windows/macos) × 2 configuration (Debug **and** Release — previously Debug only) × 3 SDK (`global.json`-pinned 9.x, 10, 11-preview) = 18 legs. Release is included because this repo ships Release builds and Release-mode JIT optimizations can hide/reveal bugs Debug never shows.
- `.NET 11` legs are `continue-on-error: true` — previews can carry real, unrelated upstream bugs; this exists to catch forward-compat breaks early, not to block merges on them.
- Added a non-blocking `dotnet format --verify-no-changes` check. Verified locally first: the repo currently has pre-existing formatting debt (236/449 files) despite an existing `.editorconfig`, so this reports violations in the log rather than gating every future PR on unrelated debt.

**New: downloadable PR build artifacts**
- Added a `package-artifacts` job that builds the mod (Release) and publishes the dedicated server for win-x64/linux-x64, uploading both as workflow artifacts (`Multiplayer-mod-pr<N>-<sha>`, `Multiplayer-server-pr<N>-<sha>`) — no GitHub Release, no write permission needed, works for PRs from forks. Lets reviewers grab and test-install the exact build from any PR.

---

## Known pre-existing issue (unrelated to this PR)

The expanded matrix surfaced an intermittent flake in the networking test suite (`SendRaw() called with invalid connection state ... Disconnected`, a disconnect race in server keep-alive ticks). It reproduces on both macOS (as a timeout) and Windows (as this assertion) and predates this PR — nothing here touches test infrastructure or timing. Flagging separately rather than folding a fix in here, since it's a product-code issue, not a CI one.
