### PR TITLE
Enhance null-checks for various components

### DIFF
--- a/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
+++ b/Source/Client/AsyncTime/AsyncWorldTimeComp.cs
@@ -50,7 +50,7 @@ public class AsyncWorldTimeComp : IExposable, ITickable
         get => !Find.Maps.Any()
             ? timeSpeedInt
             : Find.Maps.Select(m => m.AsyncTime())
-                .Where(a => a.ActualRateMultiplier(a.DesiredTimeSpeed) != 0f)
+                .Where(a => a != null && a.ActualRateMultiplier(a.DesiredTimeSpeed) != 0f)
                 .Max(a => a?.DesiredTimeSpeed) ?? TimeSpeed.Paused;
         set => timeSpeedInt = value;
     }

--- a/Source/Client/Factions/Forbiddables.cs
+++ b/Source/Client/Factions/Forbiddables.cs
@@ -116,7 +116,7 @@ namespace Multiplayer.Client
         static void Prefix(Thing __instance)
         {
             if (Multiplayer.Client == null) return;
-            __instance.Map.MpComp().Notify_ThingDespawned(__instance);
+            __instance.Map?.MpComp()?.Notify_ThingDespawned(__instance);
         }
     }
 }

--- a/Source/Client/Patches/TeachingPatches.cs
+++ b/Source/Client/Patches/TeachingPatches.cs
@@ -15,7 +15,7 @@ static class WorkGiverTeachUnsetTarget
         if (!Multiplayer.InInterface)
             return true;
         // If target is not pawn, no result
-        if (t is not Pawn pawn)
+        if (t is not Pawn pawn || pawn.CurJob == null)
             return false;
 
         // Alternative approach would be to store the current target of the lesson taking pawn in the


### PR DESCRIPTION
Improve null-checks in the TeachingPatches, AsyncWorldTimeComp, and ThingDespawnUnsetForbidden classes to prevent potential null reference exceptions during execution.