### PR TITLE
Debug actions: Replay debug actions under the acting player's world view

### DIFF
--- a/Source/Client/Debug/DebugSync.cs
+++ b/Source/Client/Debug/DebugSync.cs
@@ -48,6 +48,12 @@ namespace Multiplayer.Client
 
             int selectedId = data.ReadInt32();
 
+            // Replay under the acting player's view, not the local one. Read before the node graph is
+            // rebuilt below, because node labels are allowed to depend on it -- the incident action's label
+            // embeds its target's name, so a wrong view here produces a path that matches nothing and the
+            // command silently does not run on this client.
+            WorldSelectedPatch.result = data.ReadBool();
+
             if (Multiplayer.MapContext != null)
             {
                 var thing = Multiplayer.ThingsById.GetValueSafe(selectedId);
@@ -115,6 +121,7 @@ namespace Multiplayer.Client
 
                 MouseCellPatch.result = null;
                 MouseTilePatch.result = null;
+                WorldSelectedPatch.result = null;
                 Find.Selector.selected = prevSelected;
                 FieldRefs.worldSelected(Find.WorldSelector) = prevWorldSelected;
 
@@ -155,6 +162,11 @@ namespace Multiplayer.Client
                 writer.WriteInt32(Find.Selector.SingleSelectedThing?.thingIDNumber ?? -1);
             else
                 writer.WriteInt32(Find.WorldSelector.SingleSelectedObject?.ID ?? -1);
+
+            // Which view the acting player had open. Debug actions may legitimately read it -- vanilla's
+            // incident action derives its entire target from it -- so replaying one faithfully means
+            // reproducing it, exactly as the cursor and selection above are reproduced.
+            writer.WriteBool(WorldRendererUtility.WorldSelected);
 
             Multiplayer.WriterLog.AddCurrentNode(writer);
 

--- a/Source/Client/Patches/Patches.cs
+++ b/Source/Client/Patches/Patches.cs
@@ -192,6 +192,29 @@ namespace Multiplayer.Client
         }
     }
 
+    /// <summary>
+    /// Overrides whether the planet view is showing, while a debug command is being replayed.
+    ///
+    /// Companion to the cursor overrides above. Debug actions are allowed to read the interface -- vanilla's
+    /// incident action picks its target with
+    /// <c>WorldRendererUtility.WorldSelected ? Find.WorldSelector.SingleSelectedObject : Find.CurrentMap</c> --
+    /// so replaying one faithfully means reproducing what the acting player could see, not just where their
+    /// cursor was. Without this, the same command targets a caravan on a player looking at the planet and a
+    /// colony on a player looking at a map.
+    /// </summary>
+    [HarmonyPatch(typeof(WorldRendererUtility), nameof(WorldRendererUtility.WorldSelected), MethodType.Getter)]
+    public static class WorldSelectedPatch
+    {
+        /// <summary>Non-null only while a debug command is being replayed.</summary>
+        public static bool? result;
+
+        static void Postfix(ref bool __result)
+        {
+            if (result.HasValue)
+                __result = result.Value;
+        }
+    }
+
     [HarmonyPatch(typeof(KeyBindingDef), nameof(KeyBindingDef.IsDownEvent), MethodType.Getter)]
     public static class KeyIsDownPatch
     {


### PR DESCRIPTION
Firing a debug action desyncs the game whenever two players are looking at
different screens.

## Root cause

`DebugSync` replays a debug action on every client by re-running it from a synced
node path. It reproduces the cursor position and the selected object so that
actions depending on them behave the same everywhere — but not **which view the
acting player had open**.

Vanilla's incident action derives its entire target from exactly that:

```csharp
// Verse.DebugActionsIncidents.GetTarget()
IIncidentTarget target = WorldRendererUtility.WorldSelected
    ? Find.WorldSelector.SingleSelectedObject as IIncidentTarget
    : null;
if (target == null && WorldRendererUtility.WorldSelected) target = Find.World;
if (target == null) target = Find.CurrentMap;
```

`WorldRendererUtility.WorldSelected` is client-local camera state. So a host on
the planet with a caravan selected resolves `Caravan`, while a client looking at
a colony resolves `Find.CurrentMap`.

That breaks the replay twice over:

1. **Wrong target.** The same command aims at different things on each client.
2. **Silent non-execution.** The node's label is built from the target's name
   (`labelGetter = () => name + " (" + GetIncidentTargetLabel() + ")..."`), so
   the two clients disagree about the label. `RecreateGraphAndGetNode` matches
   children by `LabelAndCategory()`, finds nothing, returns `null`, and the
   caller skips execution. The command is accepted, acknowledged, and quietly
   never runs on that client — with no log line where it happens.

A synchronized command that runs on some clients and not others is about the most
direct way to desync a lockstep simulation, and this one leaves no trace at the
point of failure, which is why the desync surfaces later somewhere unrelated.

| | Host — planet view | Client — colony view |
|---|---|---|
| `WorldSelected` | `true` | `false` |
| `GetTarget()` | the selected `Caravan` | `Find.CurrentMap` |
| Node label | `Do incident (Caravan Rim)...` | `Do incident (Map)...` |
| `RecreateGraphAndGetNode` | found | **`null`** |
| Outcome | runs, consumes RNG | **does nothing** |

## Evidence

Firing `GiveQuest_EndGame_ShipEscape` with the host on the planet and the client
on a colony map. Both traces are the **first** entry in their capture, i.e. the
divergence itself rather than its aftermath.

Host — executing the incident inside the synced command:

```
at RimWorld.UniqueIDsManager.GetNextQuestID ()
at RimWorld.Quest.MakeRaw ()
at RimWorld.QuestGen.QuestGen.InitializeQuestGen (RimWorld.QuestScriptDef, Slate)
at RimWorld.QuestUtility.GenerateQuestAndMakeAvailable (RimWorld.QuestScriptDef, single)
at RimWorld.IncidentWorker_GiveQuest.GiveQuest (RimWorld.IncidentParms, RimWorld.QuestScriptDef)
at RimWorld.IncidentWorker_GiveQuest.TryExecuteWorker (RimWorld.IncidentParms)
at RimWorld.IncidentWorker.TryExecute (RimWorld.IncidentWorker, RimWorld.IncidentParms)
at Verse.DebugActionsIncidents/<>c__DisplayClass7_1.<GetIncidentDebugAction>b__3 ()
at Multiplayer.Client.DebugActionNodeEnter/MpDebugAction.Action ()          DebugSync.cs:302
at Multiplayer.Client.DebugSync.HandleCmd (Multiplayer.Common.ByteReader)   DebugSync.cs:124
at Multiplayer.Client.AsyncTime.AsyncWorldTimeComp.ExecuteCmd (ScheduledCommand)
```

Client, same trace index — never entered the command at all, just ticking:

```
at Verse.Rand.MTBEventOccurs (single, single, single)
at Verse.HediffGiver_RandomAgeCurved.OnIntervalPassed (Verse.Pawn, Verse.Hediff)
at Verse.Pawn_HealthTracker.HealthTickInterval (Verse.Pawn_HealthTracker, int)
at Verse.Pawn.TickInterval (Verse.Pawn, int)
at Verse.Thing.DoTick ()
at Verse.TickList.Tick ()
at Multiplayer.Client.AsyncTimeComp.Tick ()                    AsyncTimeComp.cs:158
at Multiplayer.Client.TickPatch.TickTickable (ITickable)       TickPatch.cs:264
at Multiplayer.Client.TickPatch.DoTick (bool&)                 TickPatch.cs:243
```

The same signature appears with `CaravanMeeting`, diverging slightly earlier —
while the debug action is still computing its parameters, before the worker runs:

```
at Verse.FloatRange.get_RandomInRange ()
at RimWorld.StorytellerUtility.DefaultThreatPointsNow (RimWorld.IIncidentTarget)
at RimWorld.StorytellerUtility.DefaultParmsNow (IncidentCategoryDef, IIncidentTarget)
at Verse.DebugActionsIncidents/<>c__DisplayClass7_1.<GetIncidentDebugAction>b__3 ()
at Multiplayer.Client.DebugActionNodeEnter/MpDebugAction.Action ()          DebugSync.cs:302
at Multiplayer.Client.DebugSync.HandleCmd (Multiplayer.Common.ByteReader)   DebugSync.cs:124
```

## The fix

Carry the flag in the debug command and override the getter during replay,
following the `MouseCellPatch` / `MouseTilePatch` pattern already used for the
cursor:

- `WorldSelectedPatch` — getter postfix with a nullable `result`, placed beside
  the existing cursor overrides.
- `SendCmd` writes `WorldRendererUtility.WorldSelected`.
- `HandleCmd` reads it **before** rebuilding the node graph (labels depend on it)
  and clears it in the same `finally` block as the cursor overrides, so it cannot
  leak into normal play.

## Verification

Two connected clients, `asyncTime` off, multifaction off:

- **Host on the planet with a caravan selected, client on a colony** — the
  original repro. Fires at the caravan on both. No desync.
- **Both on the planet, nothing selected** — target resolves to `Find.World` on
  both. No desync.
- **`GiveQuest_EndGame_ShipEscape` from the world view** — the trace above. Quest
  letter arrives on host and client. No desync.

Build clean, 158/158 tests (no test-visible surface; the harness cannot construct
RimWorld UI types).

## Notes

- **The debug command's wire format gains one byte.** Host and clients need
  matching builds, which this mod already requires.
- Fixes every debug action whose label varies with local state, not only
  incidents.
- `[NO]` in the incident list means "would not fire naturally", **not** "cannot be
  forced" — the action checks `TargetAllowed` but never `CanFireNow`. That is
  unchanged here, and is why the `GiveQuest` case above executes at all.
- Two follow-ups are worth doing separately: logging an error when a debug node
  path cannot be resolved (that silent `null` is what made this expensive to
  find), and keeping path resolution out of the simulation's random stream.
