### PR TITLE
Networking: Stop reporting an ordinary disconnect as a send error

### DIFF
--- a/Source/Common/Networking/LiteNetConnection.cs
+++ b/Source/Common/Networking/LiteNetConnection.cs
@@ -7,12 +7,16 @@ namespace Multiplayer.Common
     {
         public readonly NetPeer peer = peer;
 
+        /// <summary>
+        /// Sends without first checking the peer's transport state. That state changes on LiteNetLib's
+        /// own thread, so it can go stale between <see cref="ConnectionBase.Send"/> approving the send
+        /// against the protocol state and the packet arriving here; a check on this side can never be
+        /// race-free. LiteNetLib discards sends to a peer that has gone away, silently and without
+        /// throwing, so there is nothing left for one to do.
+        /// </summary>
         protected override void SendRaw(byte[] raw, bool reliable)
         {
-            if (peer.ConnectionState == ConnectionState.Connected)
-                peer.Send(raw, reliable ? DeliveryMethod.ReliableOrdered : DeliveryMethod.Unreliable);
-            else
-                ServerLog.Error($"SendRaw() called with invalid connection state ({peer}): {peer.ConnectionState}");
+            peer.Send(raw, reliable ? DeliveryMethod.ReliableOrdered : DeliveryMethod.Unreliable);
         }
 
         protected override void OnClose(ServerDisconnectPacket? goodbye)

--- a/Source/Common/Networking/MpConnectionState.cs
+++ b/Source/Common/Networking/MpConnectionState.cs
@@ -43,6 +43,19 @@ namespace Multiplayer.Common
                 ? null
                 : (MpConnectionState)Activator.CreateInstance(StateImpls[(int)state], conn);
 
+        /// <summary>
+        /// Removes the handlers registered for one state, so a different implementation can take its
+        /// place. <see cref="SetImplementation"/> is additive and rejects a second handler for the
+        /// same packet, which suits registering each state once at start-up but leaves no way to
+        /// replace one afterwards.
+        /// </summary>
+        public static void ClearImplementation(ConnectionStateEnum state)
+        {
+            StateImpls[(int)state] = null!;
+            for (var packetId = 0; packetId < packetHandlers.GetLength(1); packetId++)
+                packetHandlers[(int)state, packetId] = null;
+        }
+
         public static void SetImplementation(ConnectionStateEnum state, Type type)
         {
             if (!type.IsSubclassOf(typeof(MpConnectionState))) return;

--- a/Source/Tests/Helper/TestNetListener.cs
+++ b/Source/Tests/Helper/TestNetListener.cs
@@ -15,6 +15,9 @@ public class TestNetListener(Type joiningStateType) : INetEventListener
         conn = new LiteNetConnection(peer);
         conn.username = "test1";
 
+        // The registry is process-wide and additive, so a registration from an earlier test has to
+        // be removed before this one can take its place.
+        MpConnectionState.ClearImplementation(ConnectionStateEnum.ClientJoining);
         MpConnectionState.SetImplementation(ConnectionStateEnum.ClientJoining, joiningStateType);
         conn.ChangeState(ConnectionStateEnum.ClientJoining);
 

--- a/Source/Tests/ServerTest.cs
+++ b/Source/Tests/ServerTest.cs
@@ -31,17 +31,10 @@ public class ServerTest
         var server = MakeServer(out var port);
         ConnectClient(port, typeof(TestJoiningState));
 
-        var timeoutWatch = Stopwatch.StartNew();
-        while (true)
-        {
-            if (server.InitDataState == InitDataState.Complete && server.playerManager.Players.Count == 0)
-                break; // Success
-
-            if (timeoutWatch.ElapsedMilliseconds > 2000)
-                Assert.Fail("Timeout");
-
-            Thread.Sleep(50);
-        }
+        WaitUntil(
+            nameof(Test),
+            () => server.InitDataState == InitDataState.Complete && server.playerManager.Players.Count == 0,
+            () => $"InitDataState={server.InitDataState} Players={server.playerManager.Players.Count}");
     }
 
     [Test]
@@ -83,17 +76,22 @@ public class ServerTest
 
         ConnectClient(port, typeof(TestLoadingKeepAliveState));
 
-        var timeoutWatch = Stopwatch.StartNew();
-        while (true)
-        {
-            if (server.playerManager.Players.Count == 0)
-                break;
+        // Players.Count == 0 already holds before the client connects, so waiting on it alone proves
+        // nothing. Observe the client arrive and then leave: both conditions start out false.
+        WaitUntil(
+            $"{nameof(LoadingStateHandlesKeepAliveWhileWaitingForJoinPoint)}.joined",
+            () => server.playerManager.Players.Count == 1,
+            () => $"Players={server.playerManager.Players.Count} " +
+                  $"CreatingJoinPoint={server.worldData.CreatingJoinPoint}");
 
-            if (timeoutWatch.ElapsedMilliseconds > 2000)
-                Assert.Fail("Timeout");
+        WaitUntil(
+            $"{nameof(LoadingStateHandlesKeepAliveWhileWaitingForJoinPoint)}.left",
+            () => server.playerManager.Players.Count == 0,
+            () => $"Players={server.playerManager.Players.Count} " +
+                  $"CreatingJoinPoint={server.worldData.CreatingJoinPoint}");
 
-            Thread.Sleep(50);
-        }
+        // The loading state was blocked on this join point, so reaching here means it completed.
+        Assert.That(server.worldData.CreatingJoinPoint, Is.False);
     }
 
     [Test]
@@ -110,20 +108,68 @@ public class ServerTest
 
         ConnectClient(port, typeof(TestJoiningState));
 
-        var timeoutWatch = Stopwatch.StartNew();
-        while (true)
-        {
-            if (server.playerManager.Players.Count == 1)
-                break;
+        // The seeded player above already satisfies Players.Count == 1, so waiting on that alone
+        // would pass without the client ever joining. Wait for it to arrive, then to leave.
+        WaitUntil(
+            $"{nameof(StandaloneJoinWithExistingPlayer_DoesNotStartJoinPoint)}.joined",
+            () => server.playerManager.Players.Count == 2,
+            () => $"Players={server.playerManager.Players.Count} " +
+                  $"CreatingJoinPoint={server.worldData.CreatingJoinPoint}");
 
-            if (timeoutWatch.ElapsedMilliseconds > 2000)
-                Assert.Fail("Timeout");
-
-            Thread.Sleep(50);
-        }
+        WaitUntil(
+            $"{nameof(StandaloneJoinWithExistingPlayer_DoesNotStartJoinPoint)}.left",
+            () => server.playerManager.Players.Count == 1,
+            () => $"Players={server.playerManager.Players.Count} " +
+                  $"CreatingJoinPoint={server.worldData.CreatingJoinPoint}");
 
         Assert.That(server.worldData.CreatingJoinPoint, Is.False);
     }
+
+    /// <summary>
+    /// Polls until <paramref name="condition"/> holds, or fails with what was actually observed.
+    ///
+    /// These tests drive a real server on a real socket, so how long the condition takes depends on the
+    /// machine. "Timeout" on its own says only that something did not happen; it does not say which half
+    /// of a compound condition was still false, nor how close to the budget the run came. Both are needed
+    /// to choose a defensible budget rather than a superstitious one.
+    ///
+    /// Every wait emits one measurement line, on success as well as failure, so a repeated run yields the
+    /// distribution instead of a single anecdote. Written through TestContext.Progress because NUnit only
+    /// surfaces captured Console output for tests that fail, and the successful runs are the interesting
+    /// ones here.
+    /// </summary>
+    private static void WaitUntil(string label, Func<bool> condition, Func<string> describeState,
+        int timeoutMs = 5000)
+    {
+        var watch = Stopwatch.StartNew();
+        var polls = 0;
+
+        while (true)
+        {
+            polls++;
+
+            if (condition())
+            {
+                Report(label, "ok", watch.ElapsedMilliseconds, polls, describeState());
+                return;
+            }
+
+            if (watch.ElapsedMilliseconds > timeoutMs)
+            {
+                var state = describeState();
+                Report(label, "timeout", watch.ElapsedMilliseconds, polls, state);
+                Assert.Fail($"{label} timed out after {watch.ElapsedMilliseconds} ms " +
+                            $"({polls} polls, budget {timeoutMs} ms); observed {state}");
+            }
+
+            Thread.Sleep(50);
+        }
+    }
+
+    /// <summary>One greppable line per wait. Prefixed so a harness can pick it out of ordinary test output.</summary>
+    private static void Report(string label, string outcome, long elapsedMs, int polls, string state) =>
+        TestContext.Progress.WriteLine(
+            $"##WAIT## label={label} outcome={outcome} elapsed_ms={elapsedMs} polls={polls} state=[{state}]");
 
     private void ConnectClient(int port, Type joiningStateType)
     {


### PR DESCRIPTION
`ServerTest.Test` fails intermittently — about 1 run in 140 idle, and 1 in 14
when the machine is under CPU load — always with the same message:

    SendRaw() called with invalid connection state (127.0.0.1:PORT): Disconnected

## Why it fails

Two independent state machines guard the same send:

| Layer | Guard | Changed by |
| --- | --- | --- |
| `ConnectionBase.Send` | protocol state is not `Disconnected` | the server thread, via `PlayerManager.SetDisconnected` |
| `LiteNetConnection.SendRaw` | transport state is `Connected` | LiteNetLib's own thread, asynchronously |

The server only learns a peer has gone when `OnPeerDisconnected` is delivered,
and that happens at exactly one point per tick, inside
`netManagers.ForEach(m => m.Tick())`. The transport state changes whenever
LiteNetLib decides. A change landing just after that point leaves the rest of
the tick believing the peer is live — and `TickNet` broadcasts
`ServerTimeControlPacket` to every playing player unconditionally, every tick.

So `Send` approves the send, `SendRaw` finds the transport already gone, and
logs `ServerLog.Error`. `ServerTest` routes that into `Assert.Fail`, which is
what turns an ordinary client disconnect into a red build.

No teardown ordering can close this, because the state changes on a thread the
server does not control.

## Why the guard is removed rather than corrected

`NetPeer.Send` on a peer that has gone away returns normally, throws nothing,
and logs nothing — LiteNetLib already discards it. I verified this directly
against the referenced version rather than assuming it.

So the guard suppressed nothing the library would not have suppressed anyway,
and existed only to report an unavoidable race as though it were a programming
error. `SendRaw` becomes the unconditional send; a seven-line method becomes
two.

## What else is in this change

The flake sits in a test class that had two further problems, and fixing them
turned out to be a prerequisite rather than a nicety.

**Two of the four tests asserted nothing.** One waited for
`Players.Count == 0` before its client had connected; the other for
`Players.Count == 1` when it had already seeded that player itself. Both
conditions were true on the first poll, so the tests passed whether or not the
join they are named for ever happened — a broken loading state would still have
reported green. They now watch the client arrive and then leave, and the
keep-alive test asserts the join point it was blocked on has completed.

**Making those waits real exposed a registry problem.**
`MpConnectionState.SetImplementation` is additive and rejects a duplicate
handler for the same packet, which suits production registering each state once
at start-up. `TestNetListener` registers per connection with a per-test type, so
once two tests genuinely connect with different state classes it threw
`Packet ClientJoining:Server_KeepAlive already has a handler` and took the whole
test host down. This had stayed hidden precisely because those two tests
returned before their client finished connecting.

**The polling waits are now a shared helper** that reports what it observed
rather than bare `Assert.Fail("Timeout")`, and emits one measurement line per
wait on success as well as failure. That is what made the diagnosis possible:
the failures turned out to be confined to a single poll count, which is what
identified this as an ordering race rather than a slow machine.

Its budget also goes from 2000 ms to 5000 ms. The 2000 was never derived; the
longest wait measured over 1000 runs was 757 ms, so the margin is thinner than
it looks on a fast machine. A budget costs nothing when the condition holds,
because the wait returns on the poll that satisfies it.

## Verification

| Campaign | Before | After |
| --- | --- | --- |
| 100 iterations, 8 background load threads | 7 failures | **0 / 100** |
| 1000 iterations, idle | 7 failures | **0 / 1000** |

1100 runs, zero failures, zero timeouts.

Worth more than the failure count: every failure had occurred at one specific
poll count, and that bucket is still reached — 38 of 1000 runs — and now never
fails. A green run would also be produced by a test that stopped reaching the
window, so this distinguishes a fixed race from a test that stopped looking.

## Notes for review

- The production change is a deletion. The only production **addition** is
  `MpConnectionState.ClearImplementation`, which exists so a caller can replace
  a registration rather than only add one. Production still registers each state
  once at start-up and never calls it. I would rather add the seam than have the
  test suite depend on registration order, but it is the one line here that is
  arguably test-driven, and I am happy to take a different approach if you'd
  prefer.
- `ServerLog.error = Assert.Fail` is deliberately kept. Silencing it during
  teardown was considered and rejected: it would suppress every genuine
  server-side error the suite can catch, in order to hide one misclassified
  line.
- A send to a peer that is still connecting is now also unreported. That state
  was not exercised by the runs above, so it is the one behavioural gap I would
  flag.
- The flake reproduces reliably under CPU load, so `dotnet test` on a loaded
  runner is the quickest way to confirm it independently.
