### PR TITLE
Debug actions: Keep the static field dump alive when a type initializer fails

### DIFF
--- a/Source/Client/Debug/DebugActions.cs
+++ b/Source/Client/Debug/DebugActions.cs
@@ -11,6 +11,7 @@ using System.Text;
 using HarmonyLib;
 using LudeonTK;
 using Multiplayer.Client.Desyncs;
+using Multiplayer.Common;
 using Multiplayer.Client.Util;
 using Multiplayer.Client.Windows;
 using RimWorld;
@@ -456,7 +457,9 @@ namespace Multiplayer.Client
 
             object FieldValue(FieldInfo field)
             {
-                var value = field.GetValue(null);
+                if (!StaticFieldDump.TryReadStaticValue(field, out var value, out var failure))
+                    return $"[unreadable: {failure}]";
+
                 if (value is ICollection col)
                     return col.Count;
                 if (field.Name.ToLowerInvariant().Contains("path") && value is string path && (path.Contains("/") || path.Contains("\\")))
@@ -464,7 +467,7 @@ namespace Multiplayer.Client
                 return value;
             }
 
-            foreach (var type in asm.GetTypes())
+            foreach (var type in StaticFieldDump.TypesOf(asm))
                 if (!type.IsGenericTypeDefinition && type.Namespace != null && typeValidator(type) && !type.HasAttribute<DefOf>() && !type.HasAttribute<CompilerGeneratedAttribute>())
                     foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly))
                         if (!field.IsLiteral && !field.IsInitOnly && !field.HasAttribute<CompilerGeneratedAttribute>())

--- a/Source/Common/StaticFieldDump.cs
+++ b/Source/Common/StaticFieldDump.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Multiplayer.Common
+{
+    /// <summary>
+    /// The reflection behind the "Print static fields" debug dump, which lists mutable static state across
+    /// loaded assemblies. Unsynchronized static state is a common source of desyncs, so the dump is one of
+    /// the first things reached for when a session diverges.
+    ///
+    /// Kept here rather than beside the debug action so it can be tested. The test project cannot
+    /// reference the client, which needs the game's own assemblies to load.
+    /// </summary>
+    public static class StaticFieldDump
+    {
+        /// <summary>
+        /// Reads a static field's current value.
+        ///
+        /// Contract: never propagate. Reading a static field runs its declaring type's initializer, which
+        /// is arbitrary code and can fail for reasons that have nothing to do with the dump. A caller
+        /// wants the other few thousand fields even when one is unreadable.
+        ///
+        /// MonoMod is the case that forced this: it ships every platform's interop types in one assembly,
+        /// so the ones belonging to another operating system throw DllNotFoundException the moment they
+        /// are touched. That is true on every platform -- only the type names change.
+        /// </summary>
+        /// <param name="field">The static field to read.</param>
+        /// <param name="value">The value read, or null when it could not be read.</param>
+        /// <param name="failure">A short description of why it could not be read, or null on success.</param>
+        /// <returns>Whether the value was read.</returns>
+        public static bool TryReadStaticValue(FieldInfo field, out object value, out string failure)
+        {
+            try
+            {
+                value = field.GetValue(null);
+                failure = null;
+                return true;
+            }
+            catch (Exception e)
+            {
+                // The base exception, because the interesting part is what the initializer actually hit.
+                // Reporting TypeInitializationException would name the mechanism and hide the cause.
+                value = null;
+                failure = e.GetBaseException().GetType().Name;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The types in <paramref name="assembly"/>.
+        ///
+        /// Contract: report whatever loaded. An assembly referencing something absent cannot enumerate
+        /// all of its types, but it still resolves most of them, and those are worth dumping.
+        /// </summary>
+        public static IEnumerable<Type> TypesOf(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                // Types is padded with nulls for the entries that failed to load.
+                return e.Types.Where(t => t != null);
+            }
+        }
+    }
+}

--- a/Source/Tests/StaticFieldDumpTest.cs
+++ b/Source/Tests/StaticFieldDumpTest.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Reflection;
+using Multiplayer.Common;
+
+namespace Tests;
+
+public class StaticFieldDumpTest
+{
+    /// <summary>
+    /// Stands in for the platform-specific interop types MonoMod ships in a single assembly. Reading any
+    /// static on the ones belonging to a different operating system runs an initializer that P/Invokes a
+    /// library the host does not have. The shape is identical on every platform; only the type names
+    /// differ, so this reproduces it without depending on which OS the tests run under.
+    ///
+    /// The explicit static constructor is deliberate: it suppresses beforefieldinit, so initialization
+    /// happens exactly when the field is read rather than at some earlier point of the runtime's choosing.
+    /// </summary>
+    private static class FailsToInitialize
+    {
+        public static int Value;
+
+        static FailsToInitialize() => throw new DllNotFoundException("libc");
+    }
+
+    private static class Ordinary
+    {
+        public static int Value;
+
+        static Ordinary() => Value = 42;
+    }
+
+    private static FieldInfo StaticFieldOf(Type type, string name)
+        => type.GetField(name, BindingFlags.Public | BindingFlags.Static);
+
+    [Test]
+    public void TryReadStaticValue_ReadsAnOrdinaryField()
+    {
+        var read = StaticFieldDump.TryReadStaticValue(
+            StaticFieldOf(typeof(Ordinary), nameof(Ordinary.Value)),
+            out var value,
+            out var failure);
+
+        Assert.That(read, Is.True);
+        Assert.That(value, Is.EqualTo(42));
+        Assert.That(failure, Is.Null);
+    }
+
+    [Test]
+    public void TryReadStaticValue_ReportsAFailingInitializerInsteadOfPropagating()
+    {
+        var read = StaticFieldDump.TryReadStaticValue(
+            StaticFieldOf(typeof(FailsToInitialize), nameof(FailsToInitialize.Value)),
+            out _,
+            out var failure);
+
+        Assert.That(read, Is.False, "an unreadable field must be reported, not thrown");
+        Assert.That(failure, Does.Contain(nameof(DllNotFoundException)),
+            "the report should name the underlying cause, not the TypeInitializationException wrapping it");
+    }
+}


### PR DESCRIPTION
`Mods -> Print static fields (mods)` produces **no output at all** when any
loaded assembly has a static field whose declaring type's initializer throws.

## Root cause

Reading a static field runs that type's initializer, and that is arbitrary mod
code. `FieldValue` called `field.GetValue(null)` unguarded, so the exception
unwound out of the debug action and `Dialog_Debug` reported a window failure
instead of the listing.

One bad initializer anywhere in the loaded assemblies costs the entire report.

That matters more than it first appears, because of when this action gets used:
it exists to surface unsynchronized mutable static state, which is one of the
first things reached for when a session desyncs. It is invoked precisely when
something is already wrong — which is when odd inputs are most likely.

## What changed

- **`TryReadStaticValue`** catches per field and reports the **base** exception's
  type name in place of the value. The outer exception is always
  `TypeInitializationException`, which names the mechanism and hides the cause;
  the inner one is what tells a reader whether to care.
- **`TypesOf`** falls back to `e.Types.Where(t => t != null)` on
  `ReflectionTypeLoadException`, so an assembly referencing something absent
  still dumps the types it did resolve.

`catch (Exception)` rather than a specific type is deliberate: the thrown type is
whatever a mod's initializer happens to throw, and `GetValue` can also fail
without an initializer being involved. The cost of catching too much is one line
reading `[unreadable: X]`. The cost of catching too little is losing all 1,614 of
them.

## Why the reflection moved to `Common`

`Source/Tests` references only `ChatCommandContracts`, `Common` and `SourceGen` —
not `Client`, which needs the game's assemblies to load and throws
`FileNotFoundException: Could not load file or assembly 'Assembly-CSharp'` in CI.

The two fragile calls therefore live in `Source/Common/StaticFieldDump.cs`, and
the debug action calls them. No behaviour beyond the guards changed.

## Testing

**Unit: 160 pass** (158 before, 2 added).

The added test reproduces the observed chain
`TypeInitializationException ---> DllNotFoundException: libc`. Its stand-in type
uses an explicit static constructor to suppress `beforefieldinit`, so
initialization happens exactly on first read rather than at a moment of the
runtime's choosing. The declaration needs no native library, so the test behaves
identically on every platform.

**Manual**, main menu, dev mode:

- Before: no output, one exception.
- After: **1,614 lines with 16 `[unreadable: …]` entries** and no exception — 15
  `DllNotFoundException` from MonoMod's foreign-platform interop, and 1
  `NullReferenceException` from a content mod whose initializer reads DLC data
  with the DLC inactive. Either alone previously cost the whole report.
- `Print static fields (game)` unchanged: 2,247 lines, zero unreadable.

## Note for review

This is not a Windows-specific fix. MonoMod ships the Windows, Linux and macOS
backends in one assembly and the dump walks all of them, so the same defect
occurs on every platform — only the type names in the stack differ.
