### PR TITLE
Seed quest name generation so retries cost one synced RNG draw

### DIFF
--- a/Source/Client/Patches/Seeds.cs
+++ b/Source/Client/Patches/Seeds.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using Multiplayer.Client.Util;
+using RimWorld.QuestGen;
 using Verse;
 using Verse.Grammar;
 
@@ -168,6 +169,14 @@ namespace Multiplayer.Client
             yield return AccessTools.Method(typeof(GrammarResolver), nameof(GrammarResolver.Resolve));
             yield return AccessTools.Method(typeof(PawnBioAndNameGenerator), nameof(PawnBioAndNameGenerator.GeneratePawnName));
             yield return AccessTools.Method(typeof(NameGenerator), nameof(NameGenerator.GenerateName), [typeof(RulePackDef), typeof(Predicate<string>), typeof(bool), typeof(string), typeof(string), typeof(List<Rule>)]);
+            // The GrammarRequest overload holds the validator retry loop and is called directly
+            // (bypassing the RulePackDef overload above) by quest naming among others; a validator
+            // rejection count depends on the generated text and therefore on the client's language.
+            yield return AccessTools.Method(typeof(NameGenerator), nameof(NameGenerator.GenerateName), [typeof(GrammarRequest), typeof(Predicate<string>), typeof(bool), typeof(string), typeof(string)]);
+            // Quest naming additionally retries whole NameGenerator calls while the name collides
+            // with an existing quest's name — wrap the outer loop too so quest naming costs exactly
+            // one synced draw regardless of language or collisions.
+            yield return AccessTools.Method(typeof(QuestNode_ResolveQuestName), nameof(QuestNode_ResolveQuestName.Resolve));
         }
 
         [HarmonyPriority(MpPriority.MpFirst)]


### PR DESCRIPTION
## Problem

Quest naming retries while the generated name collides with an existing quest's name, and `NameGenerator`'s `GrammarRequest` overload retries while its validator rejects the text. Both retry counts depend on the *generated strings*, and therefore on the client's language — the Russian rule packs collide constantly where English rarely does.

Every retry consumes synced `Rand` draws, so with mixed-language players in the same game the RNG streams diverge and quest sites land on different tiles.

## Fix

Two methods added to `SeedGrammar`'s `TargetMethods` in `Source/Client/Patches/Seeds.cs`:

- `NameGenerator.GenerateName(GrammarRequest, Predicate<string>, bool, string, string)` — this overload holds the validator retry loop and is called directly by quest naming, bypassing the `RulePackDef` overload that is already seeded.
- `QuestNode_ResolveQuestName.Resolve` — the outer loop that retries whole `NameGenerator` calls while the name collides with an existing quest's.

Seeding both means the entire retry loop costs exactly one synced draw, regardless of language or how many collisions occur.

## Verification

`dotnet build Source/Multiplayer.sln -c Release` succeeds with 0 errors against `dev` alone; the change touches only vanilla RimWorld symbols