### PR TITLE
Debug actions: Skip methods Log all patch cannot instrument

### DIFF
--- a/Source/Client/Debug/DebugActions.cs
+++ b/Source/Client/Debug/DebugActions.cs
@@ -11,6 +11,7 @@ using System.Text;
 using HarmonyLib;
 using LudeonTK;
 using Multiplayer.Client.Desyncs;
+using Multiplayer.Common;
 using Multiplayer.Client.Util;
 using Multiplayer.Client.Windows;
 using RimWorld;
@@ -335,17 +336,31 @@ namespace Multiplayer.Client
         [DebugAction(MultiplayerCategory, allowedGameStates = AllowedGameStates.Playing)]
         static void LogAllPatch()
         {
+            var logger = new HarmonyMethod(typeof(MpDebugActions), nameof(MultiplayerMethodCallLogger));
+            var refused = 0;
+
             foreach (var method in Assembly.GetExecutingAssembly().DefinedTypes.SelectMany(t => t.DeclaredMethods))
-                if (method.Name != "MultiplayerMethodCallLogger" &&
-                    !method.Name.StartsWith("get_") &&
-                    !method.IsGenericMethod &&
-                    method.DeclaringType?.IsGenericType is false &&
-                    method.DeclaringType?.BaseType != typeof(MulticastDelegate) &&
-                    !method.IsAbstract)
-                    Multiplayer.harmony.Patch(
-                        method,
-                        prefix: new HarmonyMethod(typeof(MpDebugActions), nameof(MultiplayerMethodCallLogger))
-                    );
+            {
+                if (!InstrumentationTargets.ShouldInstrument(method))
+                    continue;
+
+                try
+                {
+                    Multiplayer.harmony.Patch(method, prefix: logger);
+                }
+                catch (Exception e)
+                {
+                    // The filter cannot anticipate every reason Harmony may refuse a method, and a trace
+                    // missing one entry is worth far more than no trace at all. Counted rather than logged
+                    // per method, so a systematic refusal does not bury the trace this action exists for.
+                    refused++;
+                    if (refused == 1)
+                        Log.Warning($"MP: could not instrument {method.FullDescription()}: {e.GetBaseException().Message}");
+                }
+            }
+
+            if (refused > 0)
+                Log.Warning($"MP: {refused} method(s) could not be instrumented; the trace below is incomplete");
         }
 
         [DebugAction(MultiplayerCategory, allowedGameStates = AllowedGameStates.Entry)]

--- a/Source/Common/InstrumentationTargets.cs
+++ b/Source/Common/InstrumentationTargets.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+
+namespace Multiplayer.Common
+{
+    /// <summary>
+    /// Decides which methods the "Log all patch" debug action may attach its call logger to.
+    ///
+    /// Kept here rather than beside the debug action so it can be tested. The test project cannot
+    /// reference the client, which needs the game's own assemblies to load.
+    /// </summary>
+    public static class InstrumentationTargets
+    {
+        /// <summary>The logger's own prefix, which must never instrument itself.</summary>
+        public const string LoggerMethodName = "MultiplayerMethodCallLogger";
+
+        /// <summary>
+        /// Whether a call logger can be attached to <paramref name="method"/>.
+        ///
+        /// Contract: exclude anything Harmony cannot build a wrapper around. Harmony patches by emitting
+        /// a replacement that wraps the original's body, so a method with no body to wrap produces
+        /// malformed IL and the runtime rejects it.
+        /// </summary>
+        public static bool ShouldInstrument(MethodBase method)
+        {
+            if (method == null)
+                return false;
+
+            if (method.Name == LoggerMethodName)
+                return false;
+
+            // Extern, so the body lives in a native library and there is nothing to wrap. This assembly
+            // declares two, in ArbiterWindowFix. Tested via MethodAttributes rather than a dedicated
+            // property, because MethodBase exposes no IsPInvokeImpl on every target framework here.
+            if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
+                return false;
+
+            // Property getters are noise: they run constantly and say nothing about control flow.
+            if (method.Name.StartsWith("get_"))
+                return false;
+
+            if (method.IsAbstract)
+                return false;
+
+            // Open generic parameters, whether the method's own or inherited from its declaring type,
+            // leave nothing concrete to emit against.
+            if (method.IsGenericMethod || method.ContainsGenericParameters)
+                return false;
+
+            var declaring = method.DeclaringType;
+            if (declaring == null || declaring.IsGenericType)
+                return false;
+
+            if (declaring.BaseType == typeof(System.MulticastDelegate))
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/Source/Tests/InstrumentationTargetsTest.cs
+++ b/Source/Tests/InstrumentationTargetsTest.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Multiplayer.Common;
+
+namespace Tests;
+
+public class InstrumentationTargetsTest
+{
+    private static class Candidates
+    {
+        public static void Ordinary()
+        {
+        }
+
+        /// <summary>
+        /// Stands in for ArbiterWindowFix.SetParent, the declaration that aborts the real action.
+        ///
+        /// Declared but never called, so it needs no library at run time and behaves the same on every
+        /// platform. What matters is only that reflection reports it as extern.
+        /// </summary>
+        [DllImport("User32")]
+        public static extern int SetParent(int hwnd, int nCmdShow);
+
+        public static void Generic<T>()
+        {
+        }
+
+        public static int Value => 0;
+    }
+
+    private static MethodBase MethodOf(string name)
+        => typeof(Candidates).GetMethod(name, BindingFlags.Public | BindingFlags.Static);
+
+    [Test]
+    public void ShouldInstrument_AnOrdinaryMethod()
+    {
+        Assert.That(InstrumentationTargets.ShouldInstrument(MethodOf(nameof(Candidates.Ordinary))), Is.True);
+    }
+
+    [Test]
+    public void ShouldNotInstrument_AnExternMethod()
+    {
+        var method = MethodOf(nameof(Candidates.SetParent));
+
+        Assert.That(method.Attributes.HasFlag(MethodAttributes.PinvokeImpl), Is.True,
+            "the stand-in must actually be extern for this test to mean anything");
+        Assert.That(InstrumentationTargets.ShouldInstrument(method), Is.False,
+            "an extern method has no IL body, so Harmony emits a malformed wrapper and the runtime rejects it");
+    }
+
+    [Test]
+    public void ShouldNotInstrument_AGenericMethod()
+    {
+        Assert.That(InstrumentationTargets.ShouldInstrument(MethodOf(nameof(Candidates.Generic))), Is.False);
+    }
+
+    [Test]
+    public void ShouldNotInstrument_APropertyGetter()
+    {
+        var getter = typeof(Candidates).GetProperty(nameof(Candidates.Value), BindingFlags.Public | BindingFlags.Static)!.GetGetMethod();
+
+        Assert.That(InstrumentationTargets.ShouldInstrument(getter), Is.False);
+    }
+
+    [Test]
+    public void ShouldNotInstrument_TheLoggerItself()
+    {
+        var logger = typeof(SelfReference).GetMethod(
+            InstrumentationTargets.LoggerMethodName,
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.That(InstrumentationTargets.ShouldInstrument(logger), Is.False,
+            "instrumenting the logger would make every logged call log itself");
+    }
+
+    private static class SelfReference
+    {
+        // Named to match the real prefix, so the guard is exercised by name as it is in production.
+        public static void MultiplayerMethodCallLogger()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`Multiplayer -> Log all patch`, and its main-menu variant `Log all patch entry`,
attach a call logger to every method the multiplayer assembly declares. The
action throws on the first **extern** method it reaches, the loop aborts, and
every method not yet reached is left uninstrumented — while the action still
emits a large, plausible-looking trace with no sign that coverage is partial.

```
Exception filling window for LudeonTK.Dialog_Debug: System.InvalidProgramException:
Invalid IL code in (wrapper dynamic-method)
MonoMod.Utils.DynamicMethodDefinition:Multiplayer.Client.ArbiterWindowFix.SetParent_Patch1 (int,int): IL_0015: ret

  at HarmonyLib.PatchFunctions.UpdateWrapper (System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo)
  at HarmonyLib.PatchProcessor.Patch ()
  at HarmonyLib.Harmony.Patch (System.Reflection.MethodBase original, ...)
  at Multiplayer.Client.MpDebugActions.LogAllPatch ()
  at Multiplayer.Client.MpDebugActions.LogAllPatchEntry ()
```

A reader reasonably concludes that any method absent from the trace was never
called, when it may simply never have been instrumented. Which methods survive
depends on the order `DefinedTypes` happens to return, so the coverage boundary
is arbitrary and can move between builds.

Measured on the same main menu, before and after:

|                                      | Before | After   |
| ------------------------------------ | ------ | ------- |
| Lines                                | 36,766 | 607,583 |
| Distinct MP types instrumented       | 21     | **55**  |
| `InvalidProgramException`            | 1      | 0       |
| Types instrumented before, not after | —      | 0       |

Types that were previously never reached include `Desyncs.DeferredStackTracing`,
`ModCompatibilityManager`, `Patches.MarkLongEvents` and `Patches.NewLongEvent` —
the desync and long-event machinery this action is most often used to trace.

## Root cause

Harmony patches by emitting a wrapper around the original's body. An extern
method has no body, so the wrapper is malformed and the runtime rejects it.

The filter in `LogAllPatch` excludes generics, property getters, abstracts and
delegate members, but not externs, and the `Patch` call is not guarded:

```csharp
foreach (var method in Assembly.GetExecutingAssembly().DefinedTypes.SelectMany(t => t.DeclaredMethods))
    if (method.Name != "MultiplayerMethodCallLogger" &&
        !method.Name.StartsWith("get_") &&
        !method.IsGenericMethod &&
        method.DeclaringType?.IsGenericType is false &&
        method.DeclaringType?.BaseType != typeof(MulticastDelegate) &&
        !method.IsAbstract)
        Multiplayer.harmony.Patch(method, prefix: ...);   // no try/catch
```

The assembly declares two extern methods — `ArbiterWindowFix`'s
`DllImport("User32")` declarations, used to hide the headless arbiter's window.
This does not depend on the host operating system: the loop reflects over them
rather than calling them, and a P/Invoke declaration is unpatchable everywhere.

## Fix

Exclude extern methods (`MethodAttributes.PinvokeImpl`) and methods still
carrying open generic parameters, alongside the exclusions already present.

Guard the `Patch` call as well. The filter cannot anticipate every reason Harmony
may refuse a method, and this action is wanted precisely when something is
already wrong, so it should lose one entry rather than the whole trace. The count
is reported once at the end, and the first refusal in full, so a systematic
problem stays visible without burying the trace under one line per method.

The decision moves to `Multiplayer.Common.InstrumentationTargets` so it can be
covered by a test — the test project cannot reference the client, which needs the
game's assemblies.

## Testing

- Builds clean in Debug; **163/163 tests pass**.
- New `InstrumentationTargetsTest` uses a stand-in extern declaration that is
  never called, so it needs no library and behaves the same on every platform.
- Manual, at the main menu with dev mode on: `Log all patch entry` completes with
  no exception, and produces the coverage in the table above.

## Notes

- Overlaps the open ["Keep the static field dump alive when a type initializer
  fails"](https://github.com/rwmt/Multiplayer/pull/978/) PR by exactly one line — both add `using Multiplayer.Common;` to
  `DebugActions.cs`, at the same position, so whichever merges first leaves the
  other clean.