### PR TITLE
Async animals alert

### DIFF
--- a/Source/Client/Patches/Alerts.cs
+++ b/Source/Client/Patches/Alerts.cs
@@ -53,7 +53,7 @@ public static class Alert_AbandonedBaby_AbandonedBabies_Patch
 
 // Vanilla uses (mostly) "needs.food.TicksStarving" to determine
 // if animals are hungry/starving. Which in async results in
-// constant warnings, when viewed from another, higher tick map.
+// constant warnings when viewed from another, higher tick map.
 // We ensure that animals in the list are actually starving.
 [HarmonyPatch(typeof(Alert_StarvationAnimals), nameof(Alert_StarvationAnimals.StarvingAnimals), MethodType.Getter)]
 public static class Alert_StarvationAnimals_StarvingAnimals_Patch

--- a/Source/Client/Patches/Alerts.cs
+++ b/Source/Client/Patches/Alerts.cs
@@ -38,7 +38,7 @@ public static class Patch_Alert_SlavesUnsuppressed_Targets
 // You will not get abandoned warning: (baby from other faction without the same faction adult)
 // for (other) player owned babies at all, unless it's happened directly on YOUR base.
 // Example: someone catapulted their baby on your map. Your own babies get a different set of warning, which works fine.
-[HarmonyPatch(typeof(Alert_AbandonedBaby), "AbandonedBabies")]
+[HarmonyPatch(typeof(Alert_AbandonedBaby), nameof(Alert_AbandonedBaby.AbandonedBabies))]
 public static class Patch_Alert_AbandonedBaby_MultifactionWarning
 {
 	[HarmonyPostfix]

--- a/Source/Client/Patches/Alerts.cs
+++ b/Source/Client/Patches/Alerts.cs
@@ -1,6 +1,5 @@
 using HarmonyLib;
 using Verse;
-using Multiplayer.API;
 using System.Collections.Generic;
 using RimWorld;
 using System.Linq;
@@ -11,9 +10,10 @@ namespace Multiplayer.Client;
 [HarmonyPatch(typeof(SlaveRebellionUtility), nameof(SlaveRebellionUtility.IsUnattendedByColonists))]
 public static class Patch_SlaveRebellionUtility_IsUnattendedByColonists
 {
+	[HarmonyPostfix]
 	public static void Postfix(Map map, ref bool __result)
 	{
-		if (!MP.IsInMultiplayer) return;
+		if (Multiplayer.Client == null) return;
 
 		// If any slave is from player's faction
 		__result = __result && map.mapPawns.SlavesOfColonySpawned
@@ -25,9 +25,10 @@ public static class Patch_SlaveRebellionUtility_IsUnattendedByColonists
 [HarmonyPatch(typeof(Alert_SlavesUnsuppressed), nameof(Alert_SlavesUnsuppressed.Targets), MethodType.Getter)]
 public static class Patch_Alert_SlavesUnsuppressed_Targets
 {
+	[HarmonyPostfix]
 	public static void Postfix(ref List<Pawn> __result)
 	{
-		if (!MP.IsInMultiplayer) return;
+		if (Multiplayer.Client == null) return;
 
 		__result = __result.Where(pawn => pawn.Faction == Faction.OfPlayer).ToList();
 	}
@@ -40,10 +41,65 @@ public static class Patch_Alert_SlavesUnsuppressed_Targets
 [HarmonyPatch(typeof(Alert_AbandonedBaby), "AbandonedBabies")]
 public static class Patch_Alert_AbandonedBaby_MultifactionWarning
 {
+	[HarmonyPostfix]
 	public static void Postfix(ref List<Pawn> __result)
 	{
-		if (!MP.IsInMultiplayer) return;
+		if (Multiplayer.Client == null) return;
 
 		__result = __result.Where(pawn => !pawn.Faction.IsPlayer || pawn.MapHeld.ParentFaction == Faction.OfPlayer).ToList();
 	}
+
+}
+
+// Vanilla uses (mostly) "needs.food.TicksStarving" to determine
+// if animals are hungry/starving. Which in async results in
+// constant warnings, when viewed from another, higher tick map.
+// We ensure that animals in the list are actually starving.
+[HarmonyPatch(typeof(Alert_StarvationAnimals), nameof(Alert_StarvationAnimals.StarvingAnimals), MethodType.Getter)]
+public static class Patch_Alert_StarvationAnimals
+{
+	[HarmonyPostfix]
+	public static void Postfix(Alert_StarvationAnimals __instance, ref List<Pawn> __result)
+	{
+		if (Multiplayer.Client == null || !Multiplayer.GameComp.asyncTime)
+			return;
+
+		for (int i = __instance.starvingAnimalsResult.Count - 1; i >= 0; i--)
+		{
+			Pawn animal = __instance.starvingAnimalsResult[i];
+
+			if (!animal.needs.food.Starving)
+				__instance.starvingAnimalsResult.RemoveAt(i);
+		}
+		
+		__result = __instance.starvingAnimalsResult;
+	}
+
+}
+
+// Exact same idea as in "Patch_Alert_StarvationAnimals",
+// but this class is written slightly differently
+[HarmonyPatch(typeof(Alert_PennedAnimalHungry), nameof(Alert_PennedAnimalHungry.CalculateTargets))]
+public static class Patch_Alert_PennedAnimalHungry
+{
+	[HarmonyPostfix]
+	public static void Postfix(Alert_PennedAnimalHungry __instance)
+	{
+		if (Multiplayer.Client == null || !Multiplayer.GameComp.asyncTime)
+			return;
+
+		for (int i = __instance.targets.Count - 1; i >= 0; i--)
+		{
+			Pawn animal = __instance.targets[i].Pawn;
+
+			if (!animal.needs.food.Starving)
+			{
+				__instance.targets.RemoveAt(i);
+				__instance.pawnNames.RemoveAt(i);
+			}
+
+		}
+
+	}
+
 }

--- a/Source/Client/Patches/Alerts.cs
+++ b/Source/Client/Patches/Alerts.cs
@@ -8,7 +8,7 @@ namespace Multiplayer.Client;
 
 // Add faction check to "slaves unattended" warning
 [HarmonyPatch(typeof(SlaveRebellionUtility), nameof(SlaveRebellionUtility.IsUnattendedByColonists))]
-public static class Patch_SlaveRebellionUtility_IsUnattendedByColonists
+public static class SlaveRebellionUtility_IsUnattendedByColonists_Patch
 {
 	[HarmonyPostfix]
 	public static void Postfix(Map map, ref bool __result)
@@ -23,7 +23,7 @@ public static class Patch_SlaveRebellionUtility_IsUnattendedByColonists
 
 // Add faction check to "slaves unsuppressed" warning
 [HarmonyPatch(typeof(Alert_SlavesUnsuppressed), nameof(Alert_SlavesUnsuppressed.Targets), MethodType.Getter)]
-public static class Patch_Alert_SlavesUnsuppressed_Targets
+public static class Alert_SlavesUnsuppressed_Targets_Patch
 {
 	[HarmonyPostfix]
 	public static void Postfix(ref List<Pawn> __result)
@@ -39,7 +39,7 @@ public static class Patch_Alert_SlavesUnsuppressed_Targets
 // for (other) player owned babies at all, unless it's happened directly on YOUR base.
 // Example: someone catapulted their baby on your map. Your own babies get a different set of warning, which works fine.
 [HarmonyPatch(typeof(Alert_AbandonedBaby), nameof(Alert_AbandonedBaby.AbandonedBabies))]
-public static class Patch_Alert_AbandonedBaby_MultifactionWarning
+public static class Alert_AbandonedBaby_AbandonedBabies_Patch
 {
 	[HarmonyPostfix]
 	public static void Postfix(ref List<Pawn> __result)
@@ -56,7 +56,7 @@ public static class Patch_Alert_AbandonedBaby_MultifactionWarning
 // constant warnings, when viewed from another, higher tick map.
 // We ensure that animals in the list are actually starving.
 [HarmonyPatch(typeof(Alert_StarvationAnimals), nameof(Alert_StarvationAnimals.StarvingAnimals), MethodType.Getter)]
-public static class Patch_Alert_StarvationAnimals
+public static class Alert_StarvationAnimals_StarvingAnimals_Patch
 {
 	[HarmonyPostfix]
 	public static void Postfix(Alert_StarvationAnimals __instance, ref List<Pawn> __result)
@@ -80,7 +80,7 @@ public static class Patch_Alert_StarvationAnimals
 // Exact same idea as in "Patch_Alert_StarvationAnimals",
 // but this class is written slightly differently
 [HarmonyPatch(typeof(Alert_PennedAnimalHungry), nameof(Alert_PennedAnimalHungry.CalculateTargets))]
-public static class Patch_Alert_PennedAnimalHungry
+public static class Alert_PennedAnimalHungry_CalculateTargets_Patch
 {
 	[HarmonyPostfix]
 	public static void Postfix(Alert_PennedAnimalHungry __instance)


### PR DESCRIPTION
Vanilla uses (mostly) `needs.food.TicksStarving` to determine if animals are hungry/starving. Which in async results in constant warnings, when viewed from another, higher tick map.

Meanwhile vanilla humanlike trackers use `needs.food.Starving`, no idea why it wasn't done to the animals in the first place. 
The most non-intrusive way I could come up with, was using postfix to filter the results and ensure animals actually hungry.

There is a separate bug for (async?) alerts, which results in them "jumping" around when hovered with a mouse. Not sure what causes it, but it's not this commit. With this commit if you see the alert, that means 100% there are starving animals, though sometimes (dont know exactly when or why) to get correct, non-jumpy tooltip, you have to find a correct map first. Without this commit alert will always show, sometimes jumpy, sometimes not, but they will be wrong most of the time.