### PR TITLE
"NearbyFactionGoodwill" and "TradeRequest" fixes

### DIFF
--- a/Source/Client/Factions/MultifactionPatches.cs
+++ b/Source/Client/Factions/MultifactionPatches.cs
@@ -957,3 +957,43 @@ static class TradeUtility_AllLaunchableThingsForTrade_Patch
         }
     }
 }
+
+// This patch affects ritual outcome "NearbyFactionGoodwill"
+// We should exclude other player factions from it, because it does nothing
+// With this applied these rituals will target correct npc factions instead
+[HarmonyPatch(typeof(Faction), nameof(Faction.CanChangeGoodwillFor))]
+public static class Faction_CanChangeGoodwillFor_Patch
+{
+	[HarmonyPostfix]
+	public static void Postfix(Faction __instance, Faction other, int goodwillChange, ref bool __result)
+	{
+		if (Multiplayer.Client == null || !Multiplayer.GameComp.multifaction || !__result)
+			return;
+
+		if (__instance.IsPlayer && other.IsPlayer)
+			__result = false;
+	}
+
+}
+
+// This affects "TradeRequest" quests. Despite how funny it was to see other
+// player requesting 50 kids pants, AND IT ACTUALLY WORKS, I doubt it is intended,
+// and it consumes a quest "slot" that would be otherwise generated for a correct
+// faction. "Visitable" already checks if the settlement is "OfPlayer" factions,
+// but we also want to check that it is not "IsPlayer", for multifaction. This
+// method is used in quest generation checks and in caravan gizmos. Just in case
+// you wonder, it still allows your pawns to get into other players settlements.
+[HarmonyPatch(typeof(Settlement), nameof(Settlement.Visitable), MethodType.Getter)]
+public static class Settlement_Visitable_Patch
+{
+	[HarmonyPostfix]
+	public static void Postfix(Settlement __instance, ref bool __result)
+	{
+		if (Multiplayer.Client == null || !Multiplayer.GameComp.multifaction || !__result)
+			return;
+
+		if (__instance.Faction.IsPlayer)
+			__result = false;
+	}
+
+}


### PR DESCRIPTION
2 tiny patches to ensure that ritual reward and quest can target correct (meaningful) factions.

While "NearbyFactionGoodwill" is a pure fix of a bug, "TradeRequest" patch is more complicated.
I learned that trade request from another player faction indeed works. But it dilutes rewards pool from real factions, and doesnt make much sense. I commented about 50 kids pants quest in exchange for legendary LMG... neither of which exist/appear on that player settlement).